### PR TITLE
feat: add codex resume session picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Archive, unarchive, rename, pin, and switch between sessions — organized like 
 |---------|-------------|
 | `/new` | Start a new session with project picker |
 | `/sessions` | List and switch between sessions |
+| `/resume` | Pick a Codex history session for the current project |
 | `/inspect` | Detailed view of current activity |
 | `/interrupt` | Stop a running task |
 | `/review` | Review changes in current session |

--- a/docs/architecture/current-code-organization.md
+++ b/docs/architecture/current-code-organization.md
@@ -79,7 +79,7 @@ These are the narrow owners worth reading before broad shell code:
 
 - `command-router.ts` - registry-driven Telegram command dispatch
 - `callback-router.ts` - parsed callback dispatch
-- `session-project-coordinator.ts` - project picker, manual path flow, session switching, rename, pin, archive and unarchive, `/status`, `/where`, and session plan-mode toggling
+- `session-project-coordinator.ts` - project picker, manual path flow, session switching, Codex history resume, rename, pin, archive and unarchive, `/status`, `/where`, and session plan-mode toggling
 - `project-browser-coordinator.ts` - `/browse`, directory navigation, text preview pagination, image preview handoff, and root-path confinement
 - `codex-command-coordinator.ts` - model, reasoning effort, skills, plugins, apps, MCP, account, review, fork, rollback, compact, and thread metadata commands
 - `rich-input-adapter.ts` - `/skill`, `/local_image`, `/mention`, `/attach`, queued structured inputs, Telegram photo adaptation, attachment extraction, and voice-input orchestration

--- a/docs/product/auth-and-project-flow.md
+++ b/docs/product/auth-and-project-flow.md
@@ -255,6 +255,27 @@ Rules:
 - background running sessions keep their own runtime card and final-answer delivery
 - subsequent free-text user input targets the newly active session
 
+### `/resume`
+
+Shows:
+- title `可恢复的 Codex 会话（第 N 页）`
+- Codex history sessions for the active session's project path
+- one numeric button per visible Codex history session
+- `上一页`, `下一页`, and `关闭` buttons when applicable
+
+Selection behavior:
+- tapping a numeric button restores the matching Codex thread into a bridge session and makes it active
+- if the Codex thread already maps to a visible or archived session in the same chat, the bridge switches to that session and unarchives it when needed
+- `/resume <n>` is a text fallback for selecting the same numbered item
+
+Rules:
+- bare `/resume` is scoped to the current active project's path, matching the default `codex resume` picker behavior
+- `/resume all` shows Codex history sessions across project paths
+- `/resume page <n>` and `/resume all page <n>` are text fallbacks for pagination
+- without an active session, bare `/resume` asks the user to choose a project first or use `/resume all`
+- if a Codex thread is already bound to another chat, the bridge refuses to attach it to the current chat
+- restored sessions preserve the resumed thread id, latest turn metadata, selected model, and selected reasoning effort when Codex provides them
+
 ### `/archive`
 
 Responses:

--- a/docs/product/callback-contract.md
+++ b/docs/product/callback-contract.md
@@ -49,6 +49,6 @@ Rules:
 - duplicate clicks must be idempotent and return `这个操作已处理。`
 - stale callbacks must return a compact expiry notice; generic interaction flows use `这个按钮已过期，请重新操作。`, while surface-specific flows may ask the user to re-send `/browse`, `/runtime`, `/inspect`, or `/rollback`
 - pre-session browse callbacks (`v1:new:browse:*` and `v5:br:n|y|k:*`) are bridge-owned flows and must stay idempotent like other picker callbacks
-- list-based session switching and pinning remain text commands (`/use <n>` and `/pin`); runtime-hub slot selection is a separate bridge-owned callback action
+- list-based bridge session switching and pinning remain text commands (`/use <n>` and `/pin`); Codex history resume selection uses bridge-owned numeric picker callbacks
 - interaction callbacks are bridge-owned UX for persisted pending interactions, not raw protocol passthrough
-- rename, model, runtime, language, inspect, rollback, plan-result, recent-output, and hub-selector callbacks are bridge-owned UI contracts, not raw Codex callback passthrough
+- resume, rename, model, runtime, language, inspect, rollback, plan-result, recent-output, and hub-selector callbacks are bridge-owned UI contracts, not raw Codex callback passthrough

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -1448,6 +1448,7 @@ test("runtime cards keep command activity on the status message and final answer
 
   try {
     const session = authorizeChatWithSession(store, "chat-1");
+    store.updateSessionThreadId(session.sessionId, "thread-current");
 
     (service as any).api = {
       sendMessage: async (chatId: string, text: string, options?: any) => {
@@ -5139,6 +5140,8 @@ test("hub command reports when no sessions are running", async () => {
 
   try {
     authorizeChat(store, "chat-1");
+    const session = createSession(store, "chat-1");
+    store.setActiveSession("chat-1", session.sessionId);
 
     (service as any).api = {
       sendMessage: async (_chatId: string, text: string) => {
@@ -5197,6 +5200,139 @@ test("structured project and session replies use Telegram HTML parse mode", asyn
     assert.equal(sent.at(-1)?.text, "<b>已收藏项目：</b> Project &lt;Two&gt;");
 
     assert.equal(store.getActiveSession("chat-1")?.sessionId, secondSession.sessionId);
+  } finally {
+    await cleanup();
+  }
+});
+
+
+test("resume command renders selectable session buttons", async () => {
+  const { service, store, cleanup } = await createServiceContext();
+  const sent: Array<{ text: string; parseMode?: string; replyMarkup?: any }> = [];
+
+  try {
+    authorizeChat(store, "chat-1");
+    const session = createSession(store, "chat-1");
+    store.setActiveSession("chat-1", session.sessionId);
+
+    (service as any).api = {
+      sendMessage: async (_chatId: string, text: string, options?: any) => {
+        sent.push({ text, parseMode: options?.parseMode, replyMarkup: options?.replyMarkup });
+        return createFakeTelegramMessage(925 + sent.length, text);
+      }
+    };
+
+    (service as any).appServer = {
+      isRunning: true,
+      listThreads: async () => ({
+        data: [
+          {
+            id: "thread-resume-one",
+            name: "Resume One",
+            cwd: "/tmp/project-one",
+            preview: "first preview",
+            updatedAt: Math.floor(Date.parse("2026-03-10T09:15:00.000Z") / 1000),
+            createdAt: Math.floor(Date.parse("2026-03-10T09:00:00.000Z") / 1000),
+            status: "idle"
+          },
+          {
+            id: "thread-resume-two",
+            name: "Resume Two",
+            cwd: "/tmp/project-one",
+            preview: "second preview",
+            updatedAt: Math.floor(Date.parse("2026-03-10T09:10:00.000Z") / 1000),
+            createdAt: Math.floor(Date.parse("2026-03-10T09:00:00.000Z") / 1000),
+            status: "idle"
+          }
+        ],
+        nextCursor: "next-page"
+      })
+    };
+
+    await (service as any).routeCommand("chat-1", "resume", "");
+
+    assert.equal(sent.at(-1)?.parseMode, "HTML");
+    assert.match(sent.at(-1)?.text ?? "", /可恢复的 Codex 会话/u);
+    assert.deepEqual(sent.at(-1)?.replyMarkup?.inline_keyboard?.[0]?.map((button: { text: string }) => button.text), ["1", "2"]);
+    assert.deepEqual(sent.at(-1)?.replyMarkup?.inline_keyboard?.[1]?.map((button: { text: string }) => button.text), ["下一页"]);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("resume command imports a Codex thread as the active bridge session", async () => {
+  const { service, store, cleanup } = await createServiceContext();
+  const sent: Array<{ text: string; parseMode?: string }> = [];
+  const listCalls: unknown[] = [];
+  const resumeCalls: string[] = [];
+
+  try {
+    authorizeChat(store, "chat-1");
+    const session = createSession(store, "chat-1");
+    store.setActiveSession("chat-1", session.sessionId);
+
+    (service as any).api = {
+      sendMessage: async (_chatId: string, text: string, options?: any) => {
+        sent.push({ text, parseMode: options?.parseMode });
+        return createFakeTelegramMessage(930 + sent.length, text);
+      }
+    };
+
+    (service as any).appServer = {
+      isRunning: true,
+      listThreads: async (options: unknown) => {
+        listCalls.push(options);
+        return {
+          data: [
+            {
+              id: "thread-resume-one",
+              name: "Resume <One>",
+              cwd: "/tmp/project-one",
+              preview: "first preview",
+              updatedAt: Date.parse("2026-03-10T09:15:00.000Z"),
+              createdAt: Date.parse("2026-03-10T09:00:00.000Z"),
+              status: "idle"
+            }
+          ],
+          nextCursor: null
+        };
+      },
+      resumeThread: async (threadId: string) => {
+        resumeCalls.push(threadId);
+        return {
+          model: "gpt-5",
+          reasoningEffort: "high",
+          thread: {
+            id: threadId,
+            name: "Resume <One>",
+            turns: [{ id: "turn-resume-one", status: "completed", items: [] }]
+          }
+        };
+      }
+    };
+
+    await (service as any).routeCommand("chat-1", "resume", "1");
+
+    assert.deepEqual(listCalls[0], { archived: false, limit: 10, sortKey: "updated_at", cwd: "/tmp/project-one" });
+    assert.equal(resumeCalls[0], "thread-resume-one");
+    const activeSession = store.getActiveSession("chat-1");
+    assert.equal(activeSession?.threadId, "thread-resume-one");
+    assert.equal(activeSession?.displayName, "Resume <One>");
+    assert.equal(activeSession?.projectPath, "/tmp/project-one");
+    assert.equal(activeSession?.projectName, "project-one");
+    assert.equal(activeSession?.selectedModel, "gpt-5");
+    assert.equal(activeSession?.selectedReasoningEffort, "high");
+    assert.equal(activeSession?.lastTurnId, "turn-resume-one");
+    assert.equal(activeSession?.lastTurnStatus, "completed");
+    assert.equal(sent.at(-1)?.parseMode, "HTML");
+    assert.equal(
+      sent.at(-1)?.text,
+      [
+        "<b>已恢复 Codex 会话</b>",
+        "<b>会话名：</b> Resume &lt;One&gt;",
+        "<b>项目：</b> project-one"
+      ].join("\n")
+    );
   } finally {
     await cleanup();
   }

--- a/src/service.ts
+++ b/src/service.ts
@@ -1205,6 +1205,18 @@ export class BridgeService {
       beginSessionRename: async (sessionId) => this.beginSessionRename(chatId, message.message_id, sessionId),
       beginProjectRename: async (sessionId) => this.beginProjectRename(chatId, message.message_id, sessionId),
       clearProjectAlias: async (sessionId) => this.clearProjectAlias(chatId, message.message_id, sessionId),
+      handleResumePick: async (includeAll, page, itemIndex) => this.sessionProjectCoordinator.handleResumePickCallback(
+        chatId,
+        { includeAll, page, itemIndex }
+      ),
+      handleResumePage: async (includeAll, page) => this.sessionProjectCoordinator.handleResumePageCallback(
+        chatId,
+        message.message_id,
+        { includeAll, page }
+      ),
+      closeResumeList: async () => {
+        await this.safeDeleteMessage(chatId, message.message_id);
+      },
       handleModelDefault: async (sessionId) => this.codexCommandCoordinator.handleModelDefaultCallback(
         callbackQuery.id,
         chatId,
@@ -1829,6 +1841,11 @@ export class BridgeService {
       },
       handleNew: async () => {
         await this.sessionProjectCoordinator.handleNew(chatId);
+      },
+      handleResume: async () => {
+        await this.runGuardedCommand(chatId, "当前无法恢复 Codex 会话，请稍后重试。", async () => {
+          await this.sessionProjectCoordinator.handleResume(chatId, args);
+        });
       },
       handleBrowse: async () => {
         await this.handleBrowse(chatId);

--- a/src/service/callback-router.test.ts
+++ b/src/service/callback-router.test.ts
@@ -88,6 +88,15 @@ function createHandlers(calls: Call[]) {
     clearProjectAlias: async (sessionId: string) => {
       calls.push({ name: "clearProjectAlias", args: [sessionId] });
     },
+    handleResumePick: async (includeAll: boolean, page: number, itemIndex: number) => {
+      calls.push({ name: "handleResumePick", args: [includeAll, page, itemIndex] });
+    },
+    handleResumePage: async (includeAll: boolean, page: number) => {
+      calls.push({ name: "handleResumePage", args: [includeAll, page] });
+    },
+    closeResumeList: async () => {
+      calls.push({ name: "closeResumeList", args: [] });
+    },
     handleModelDefault: async (sessionId: string) => {
       calls.push({ name: "handleModelDefault", args: [sessionId] });
     },

--- a/src/service/callback-router.ts
+++ b/src/service/callback-router.ts
@@ -36,6 +36,9 @@ export interface BridgeCallbackRouterHandlers {
   beginSessionRename(sessionId: string): Promise<void>;
   beginProjectRename(sessionId: string): Promise<void>;
   clearProjectAlias(sessionId: string): Promise<void>;
+  handleResumePick(includeAll: boolean, page: number, itemIndex: number): Promise<void>;
+  handleResumePage(includeAll: boolean, page: number): Promise<void>;
+  closeResumeList(): Promise<void>;
   handleModelDefault(sessionId: string): Promise<void>;
   handleModelClose(sessionId: string): Promise<void>;
   handleModelPage(sessionId: string, page: number): Promise<void>;
@@ -157,6 +160,18 @@ export async function routeBridgeCallback(
     case "rename_project_clear":
       await handlers.answer();
       await handlers.clearProjectAlias(parsed.sessionId);
+      return;
+    case "resume_pick":
+      await handlers.answer();
+      await handlers.handleResumePick(parsed.includeAll, parsed.page, parsed.itemIndex);
+      return;
+    case "resume_page":
+      await handlers.answer();
+      await handlers.handleResumePage(parsed.includeAll, parsed.page);
+      return;
+    case "resume_close":
+      await handlers.answer();
+      await handlers.closeResumeList();
       return;
     case "model_default":
       await handlers.handleModelDefault(parsed.sessionId);

--- a/src/service/command-router.test.ts
+++ b/src/service/command-router.test.ts
@@ -11,6 +11,7 @@ function createHandlers(calls: string[]) {
     sendStatus: async () => { calls.push("sendStatus"); },
     handleHub: async () => { calls.push("handleHub"); },
     handleNew: async () => { calls.push("handleNew"); },
+    handleResume: async () => { calls.push("handleResume"); },
     handleBrowse: async () => { calls.push("handleBrowse"); },
     handleCancel: async () => { calls.push("handleCancel"); },
     handleSessions: async () => { calls.push("handleSessions"); },

--- a/src/service/session-project-coordinator.ts
+++ b/src/service/session-project-coordinator.ts
@@ -26,8 +26,10 @@ import {
   buildProjectPickerMessage,
   buildProjectPinnedText,
   buildRenameTargetPicker,
+  buildResumeThreadListMessage,
   buildSessionCreatedText,
   buildSessionRenamedText,
+  buildSessionResumedText,
   buildSessionsText,
   buildSessionSwitchedText,
   buildStatusText,
@@ -63,6 +65,37 @@ interface PendingRenameState {
 interface SessionProjectArchiveAppServer {
   archiveThread(threadId: string): Promise<void>;
   unarchiveThread(threadId: string): Promise<void>;
+  listThreads(options?: {
+    archived?: boolean;
+    cursor?: string;
+    cwd?: string;
+    limit?: number;
+    sortKey?: "created_at" | "updated_at";
+  }): Promise<{
+    data: Array<{
+      id: string;
+      name?: string | null;
+      cwd: string;
+      preview?: string;
+      updatedAt: number | string;
+      createdAt: number | string;
+      status: unknown;
+    }>;
+    nextCursor?: string | null;
+  }>;
+  resumeThread(threadId: string): Promise<{
+    model?: string | null;
+    reasoningEffort?: ReasoningEffort | null;
+    thread: {
+      id: string;
+      name?: string | null;
+      preview?: string;
+      turns: Array<{
+        id: string;
+        status?: string | null;
+      }>;
+    };
+  }>;
 }
 
 interface SessionProjectCoordinatorDeps {
@@ -133,6 +166,69 @@ interface SessionProjectCoordinatorDeps {
 function isStaleRemoteThreadArchiveError(error: unknown): boolean {
   const normalized = `${error}`.toLowerCase();
   return normalized.includes("thread not loaded") || normalized.includes("stale rollout path");
+}
+
+const RESUME_THREAD_PAGE_SIZE = 10;
+
+type ResumeArgs =
+  | { kind: "list"; includeAll: boolean; page: number }
+  | { kind: "select"; includeAll: boolean; index: number }
+  | { kind: "invalid"; includeAll: boolean };
+
+function parseResumeArgs(args: string): ResumeArgs {
+  const tokens = args.trim().split(/\s+/u).filter(Boolean);
+  const includeAll = tokens[0]?.toLowerCase() === "all";
+  const rest = includeAll ? tokens.slice(1) : tokens;
+  if (rest.length === 0) {
+    return { kind: "list", includeAll, page: 1 };
+  }
+
+  const first = rest[0]?.toLowerCase();
+  if ((first === "page" || first === "p") && rest[1]) {
+    const page = Number.parseInt(rest[1], 10);
+    return Number.isFinite(page) && page >= 1
+      ? { kind: "list", includeAll, page }
+      : { kind: "invalid", includeAll };
+  }
+
+  const index = Number.parseInt(rest[0] ?? "", 10);
+  return Number.isFinite(index) && index >= 1
+    ? { kind: "select", includeAll, index }
+    : { kind: "invalid", includeAll };
+}
+
+async function listResumeThreadPage(
+  appServer: SessionProjectArchiveAppServer,
+  options: {
+    cwd?: string;
+    page: number;
+  }
+): Promise<{
+  threads: Awaited<ReturnType<SessionProjectArchiveAppServer["listThreads"]>>["data"];
+  hasNext: boolean;
+}> {
+  let cursor: string | undefined;
+  for (let currentPage = 1; currentPage <= options.page; currentPage += 1) {
+    const result = await appServer.listThreads({
+      archived: false,
+      limit: RESUME_THREAD_PAGE_SIZE,
+      sortKey: "updated_at",
+      ...(options.cwd ? { cwd: options.cwd } : {}),
+      ...(cursor ? { cursor } : {})
+    });
+    if (currentPage === options.page) {
+      return {
+        threads: result.data,
+        hasNext: Boolean(result.nextCursor)
+      };
+    }
+    if (!result.nextCursor) {
+      return { threads: [], hasNext: false };
+    }
+    cursor = result.nextCursor;
+  }
+
+  return { threads: [], hasNext: false };
 }
 
 export class SessionProjectCoordinator {
@@ -516,6 +612,131 @@ export class SessionProjectCoordinator {
         archived
       })
     );
+  }
+
+  async handleResume(chatId: string, args: string): Promise<void> {
+    const store = this.deps.getStore();
+    if (!store) {
+      return;
+    }
+
+    const appServer = await this.deps.ensureAppServerAvailable();
+    const activeSession = store.getActiveSession(chatId);
+    const parsedArgs = parseResumeArgs(args);
+    const cwd = parsedArgs.includeAll ? undefined : activeSession?.projectPath;
+    if (!cwd && !parsedArgs.includeAll) {
+      await this.deps.safeSendMessage(chatId, "请先用 /new 选择项目，或用 /resume all 查看全部 Codex 会话。");
+      return;
+    }
+
+    if (parsedArgs.kind === "invalid") {
+      await this.deps.safeSendMessage(chatId, "找不到这个 Codex 会话。");
+      return;
+    }
+
+    if (parsedArgs.kind === "list") {
+      const page = await listResumeThreadPage(appServer, {
+        page: parsedArgs.page,
+        ...(cwd ? { cwd } : {})
+      });
+      const message = buildResumeThreadListMessage(page.threads, {
+        page: parsedArgs.page,
+        pageSize: RESUME_THREAD_PAGE_SIZE,
+        hasNext: page.hasNext,
+        includeAll: parsedArgs.includeAll
+      });
+      await this.deps.safeSendHtmlMessage(chatId, message.text, message.replyMarkup);
+      return;
+    }
+
+    const targetPage = await listResumeThreadPage(appServer, {
+      page: Math.floor((parsedArgs.index - 1) / RESUME_THREAD_PAGE_SIZE) + 1,
+      ...(cwd ? { cwd } : {})
+    });
+    const target = targetPage.threads[(parsedArgs.index - 1) % RESUME_THREAD_PAGE_SIZE];
+    if (!target) {
+      await this.deps.safeSendMessage(chatId, "找不到这个 Codex 会话。");
+      return;
+    }
+
+    const existingSession = store.getSessionByThreadId(target.id);
+    if (existingSession) {
+      if (existingSession.chatId !== chatId) {
+        await this.deps.safeSendMessage(chatId, "这个 Codex 会话已绑定到另一个聊天。");
+        return;
+      }
+      if (existingSession.archived) {
+        store.unarchiveSession(existingSession.sessionId);
+      }
+      store.setActiveSession(chatId, existingSession.sessionId);
+      await this.deps.syncCurrentSessionCard(chatId, "session_resumed");
+      await this.deps.safeSendHtmlMessage(
+        chatId,
+        buildSessionResumedText(existingSession.displayName, this.projectDisplayName(existingSession))
+      );
+      return;
+    }
+
+    const resumed = await appServer.resumeThread(target.id);
+    const lastTurn = resumed.thread.turns.at(-1);
+    const projectName = basename(target.cwd);
+    const displayName = resumed.thread.name?.trim() || target.name?.trim() || target.preview?.trim() || projectName;
+    const session = store.createSession({
+      chatId,
+      projectName,
+      projectPath: target.cwd,
+      displayName,
+      selectedModel: resumed.model ?? null,
+      selectedReasoningEffort: resumed.reasoningEffort ?? null,
+      threadId: resumed.thread.id,
+      lastTurnId: lastTurn?.id ?? null,
+      lastTurnStatus: lastTurn?.status ?? null
+    });
+    store.setActiveSession(chatId, session.sessionId);
+    await this.deps.syncCurrentSessionCard(chatId, "session_resumed");
+    await this.deps.safeSendHtmlMessage(
+      chatId,
+      buildSessionResumedText(session.displayName, this.projectDisplayName(session))
+    );
+  }
+
+  async handleResumePageCallback(
+    chatId: string,
+    messageId: number,
+    options: { includeAll: boolean; page: number }
+  ): Promise<void> {
+    const store = this.deps.getStore();
+    if (!store) {
+      return;
+    }
+
+    const appServer = await this.deps.ensureAppServerAvailable();
+    const activeSession = store.getActiveSession(chatId);
+    const cwd = options.includeAll ? undefined : activeSession?.projectPath;
+    if (!cwd && !options.includeAll) {
+      await this.deps.safeSendMessage(chatId, "请先用 /new 选择项目，或用 /resume all 查看全部 Codex 会话。");
+      return;
+    }
+
+    const page = await listResumeThreadPage(appServer, {
+      page: options.page,
+      ...(cwd ? { cwd } : {})
+    });
+    const message = buildResumeThreadListMessage(page.threads, {
+      page: options.page,
+      pageSize: RESUME_THREAD_PAGE_SIZE,
+      hasNext: page.hasNext,
+      includeAll: options.includeAll
+    });
+    await this.deps.safeEditHtmlMessageText(chatId, messageId, message.text, message.replyMarkup);
+  }
+
+  async handleResumePickCallback(
+    chatId: string,
+    options: { includeAll: boolean; page: number; itemIndex: number }
+  ): Promise<void> {
+    const globalIndex = (options.page - 1) * RESUME_THREAD_PAGE_SIZE + options.itemIndex + 1;
+    await this.handleResume(chatId, `${options.includeAll ? "all " : ""}${globalIndex}`);
   }
 
   async handleUse(chatId: string, args: string): Promise<void> {

--- a/src/telegram/commands.ts
+++ b/src/telegram/commands.ts
@@ -7,6 +7,7 @@ export type TelegramCommandHandlerKey =
   | "sendStatus"
   | "handleHub"
   | "handleNew"
+  | "handleResume"
   | "handleBrowse"
   | "handleCancel"
   | "handleSessions"
@@ -83,6 +84,7 @@ const TELEGRAM_COMMAND_ENTRIES: LocalizedTelegramCommandEntry[] = [
   { command: "status", handler: "sendStatus", description: { zh: "查看服务状态", en: "Show bridge status" }, helpLines: [{ zh: "/status 查看服务状态", en: "/status Show bridge status" }], panel: { group: "help_status", selectable: true, shortLabel: { zh: "状态", en: "Status" } } },
   { command: "hub", handler: "handleHub", description: { zh: "重新查看运行卡片", en: "Bring back the runtime hub" }, helpLines: [{ zh: "/hub 重新查看运行卡片", en: "/hub Bring back the runtime hub" }], panel: { group: "help_status", selectable: true, shortLabel: { zh: "运行卡", en: "Hub" } } },
   { command: "new", handler: "handleNew", description: { zh: "选择项目并新建会话", en: "Choose a project and create a session" }, helpLines: [{ zh: "/new 选择项目并新建会话", en: "/new Choose a project and create a session" }], panel: { group: "session_project", selectable: true, shortLabel: { zh: "新建", en: "New" } } },
+  { command: "resume", handler: "handleResume", description: { zh: "恢复 Codex 历史会话", en: "Resume a Codex history thread" }, helpLines: [{ zh: "/resume 查看可恢复的 Codex 会话；/resume <序号> 恢复", en: "/resume Show resumable Codex threads; /resume <index> resumes one" }], panel: { group: "session_project", selectable: true, shortLabel: { zh: "恢复", en: "Resume" } } },
   { command: "browse", handler: "handleBrowse", description: { zh: "浏览当前项目文件", en: "Browse the current project files" }, helpLines: [{ zh: "/browse 浏览当前项目文件", en: "/browse Browse the current project files" }], panel: { group: "session_project", selectable: true, shortLabel: { zh: "浏览", en: "Browse" } } },
   { command: "sessions", handler: "handleSessions", description: { zh: "查看最近会话", en: "Show recent sessions" }, helpLines: [{ zh: "/sessions 查看最近会话", en: "/sessions Show recent sessions" }, { zh: "/sessions archived 查看已归档会话", en: "/sessions archived Show archived sessions" }], panel: { group: "session_project", selectable: true, shortLabel: { zh: "会话", en: "Sessions" } } },
   { command: "archive", handler: "handleArchive", description: { zh: "归档当前会话", en: "Archive the current session" }, helpLines: [{ zh: "/archive 归档当前会话", en: "/archive Archive the current session" }, { zh: "/archive all 归档所有非运行中会话", en: "/archive all Archive every non-running session" }], panel: { group: "session_project", selectable: true, shortLabel: { zh: "归档", en: "Archive" } } },

--- a/src/telegram/ui-callbacks.ts
+++ b/src/telegram/ui-callbacks.ts
@@ -31,6 +31,9 @@ export type ParsedCallbackData =
   | { kind: "rename_session"; sessionId: string }
   | { kind: "rename_project"; sessionId: string }
   | { kind: "rename_project_clear"; sessionId: string }
+  | { kind: "resume_pick"; includeAll: boolean; page: number; itemIndex: number }
+  | { kind: "resume_page"; includeAll: boolean; page: number }
+  | { kind: "resume_close" }
   | { kind: "model_default"; sessionId: string }
   | { kind: "model_close"; sessionId: string }
   | { kind: "model_page"; sessionId: string; page: number }
@@ -261,6 +264,20 @@ export function encodeRenameProjectCallback(sessionId: string): string {
 
 export function encodeRenameProjectClearCallback(sessionId: string): string {
   return ensureTelegramCallbackDataLimit(`v1:rename:project:clear:${sessionId}`);
+}
+
+export function encodeResumePickCallback(includeAll: boolean, page: number, itemIndex: number): string {
+  return ensureTelegramCallbackDataLimit(
+    `v4:rs:k:${includeAll ? "a" : "c"}:${encodeInteractionIndex(page)}:${encodeInteractionIndex(itemIndex)}`
+  );
+}
+
+export function encodeResumePageCallback(includeAll: boolean, page: number): string {
+  return ensureTelegramCallbackDataLimit(`v4:rs:p:${includeAll ? "a" : "c"}:${encodeInteractionIndex(page)}`);
+}
+
+export function encodeResumeCloseCallback(): string {
+  return "v4:rs:x";
 }
 
 export function encodeModelDefaultCallback(sessionId: string): string {
@@ -781,6 +798,26 @@ export function parseCallbackData(data: string): ParsedCallbackData | null {
 
     if (parts[0] === "v4" && parts[1] === "pr" && parts[2] === "i" && parts[3]) {
       return { kind: "plan_implement", answerId: parts[3] };
+    }
+
+    if (parts[0] === "v4" && parts[1] === "rs") {
+      if (parts[2] === "x") {
+        return { kind: "resume_close" };
+      }
+      const includeAll = parts[3] === "a";
+      if (parts[2] === "p" && (parts[3] === "a" || parts[3] === "c") && parts[4]) {
+        const page = decodeInteractionIndex(parts[4]);
+        if (page !== null && page >= 1) {
+          return { kind: "resume_page", includeAll, page };
+        }
+      }
+      if (parts[2] === "k" && (parts[3] === "a" || parts[3] === "c") && parts[4] && parts[5]) {
+        const page = decodeInteractionIndex(parts[4]);
+        const itemIndex = decodeInteractionIndex(parts[5]);
+        if (page !== null && itemIndex !== null && page >= 1 && itemIndex >= 0) {
+          return { kind: "resume_pick", includeAll, page, itemIndex };
+        }
+      }
     }
 
     if (parts[0] === "v3" && parts[1] === "ix") {

--- a/src/telegram/ui-messages.ts
+++ b/src/telegram/ui-messages.ts
@@ -1,3 +1,5 @@
+import { basename } from "node:path";
+
 import type {
   ProjectCandidate,
   ProjectPickerResult,
@@ -23,7 +25,10 @@ import {
   encodePickCallback,
   encodeRenameProjectCallback,
   encodeRenameProjectClearCallback,
-  encodeRenameSessionCallback
+  encodeRenameSessionCallback,
+  encodeResumeCloseCallback,
+  encodeResumePageCallback,
+  encodeResumePickCallback
 } from "./ui-callbacks.js";
 import {
   chunkButtons,
@@ -412,6 +417,109 @@ export function buildSessionCreatedText(sessionName: string, projectPath: string
 
 export function buildSessionSwitchedText(sessionName: string, projectName: string): string {
   return buildSessionProjectContextBlock("已切换会话", sessionName, projectName);
+}
+
+export function buildSessionResumedText(sessionName: string, projectName: string): string {
+  return buildSessionProjectContextBlock("已恢复 Codex 会话", sessionName, projectName);
+}
+
+export function buildResumeThreadListText(threads: Array<{
+  name?: string | null;
+  cwd: string;
+  preview?: string;
+  updatedAt: number | string;
+}>, options: {
+  page?: number;
+  pageSize?: number;
+  hasNext?: boolean;
+  includeAll?: boolean;
+} = {}): string {
+  const page = Math.max(1, Math.trunc(options.page ?? 1));
+  const pageSize = Math.max(1, Math.trunc(options.pageSize ?? 10));
+  const includeAll = options.includeAll ?? false;
+  if (threads.length === 0) {
+    return escapeHtml(`可恢复的 Codex 会话（第 ${page} 页）\n暂无会话。${page > 1 ? `\n上一页：/resume ${includeAll ? "all " : ""}page ${page - 1}` : ""}`);
+  }
+
+  const lines = [`可恢复的 Codex 会话（第 ${page} 页）`, `发送 /resume ${includeAll ? "all " : ""}<序号> 恢复。`];
+  threads.forEach((thread, index) => {
+    const ordinal = (page - 1) * pageSize + index + 1;
+    const projectName = basename(thread.cwd);
+    const title = thread.name?.trim() || thread.preview?.trim() || projectName;
+    const preview = thread.preview?.trim() && thread.preview.trim() !== title ? ` | ${thread.preview.trim()}` : "";
+    const updatedAt = formatResumeThreadRelativeTime(thread.updatedAt);
+    lines.push(`${ordinal}. ${title} | ${projectName}${preview}${updatedAt ? ` | ${updatedAt}` : ""}`);
+  });
+  if (page > 1) {
+    lines.push(`上一页：/resume ${includeAll ? "all " : ""}page ${page - 1}`);
+  }
+  if (options.hasNext) {
+    lines.push(`下一页：/resume ${includeAll ? "all " : ""}page ${page + 1}`);
+  }
+
+  return escapeHtml(lines.join("\n"));
+}
+
+export function buildResumeThreadListMessage(threads: Array<{
+  name?: string | null;
+  cwd: string;
+  preview?: string;
+  updatedAt: number | string;
+}>, options: {
+  page?: number;
+  pageSize?: number;
+  hasNext?: boolean;
+  includeAll?: boolean;
+} = {}): {
+  text: string;
+  replyMarkup: TelegramInlineKeyboardMarkup;
+} {
+  const page = Math.max(1, Math.trunc(options.page ?? 1));
+  const pageSize = Math.max(1, Math.trunc(options.pageSize ?? 10));
+  const includeAll = options.includeAll ?? false;
+  const selectionButtons = threads.map((thread, index) => ({
+    text: String((page - 1) * pageSize + index + 1),
+    callback_data: encodeResumePickCallback(includeAll, page, index)
+  }));
+  const rows: TelegramInlineKeyboardMarkup["inline_keyboard"] = [];
+  rows.push(...chunkButtons(selectionButtons, 5));
+
+  const navigation: Array<{ text: string; callback_data: string }> = [];
+  if (page > 1) {
+    navigation.push({ text: "上一页", callback_data: encodeResumePageCallback(includeAll, page - 1) });
+  }
+  if (options.hasNext) {
+    navigation.push({ text: "下一页", callback_data: encodeResumePageCallback(includeAll, page + 1) });
+  }
+  if (navigation.length > 0) {
+    rows.push(navigation);
+  }
+  rows.push([{ text: "关闭", callback_data: encodeResumeCloseCallback() }]);
+
+  return {
+    text: buildResumeThreadListText(threads, options),
+    replyMarkup: {
+      inline_keyboard: rows
+    }
+  };
+}
+
+function formatResumeThreadRelativeTime(value: number | string): string | null {
+  if (typeof value === "string") {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+      return formatResumeThreadRelativeTime(numeric);
+    }
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? formatRelativeTime(new Date(parsed).toISOString()) : null;
+  }
+
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  const milliseconds = value < 100_000_000_000 ? value * 1000 : value;
+  return formatRelativeTime(new Date(milliseconds).toISOString());
 }
 
 export function buildArchiveSuccessText(

--- a/src/telegram/ui.test.ts
+++ b/src/telegram/ui.test.ts
@@ -25,6 +25,8 @@ import {
   buildRuntimePreferencesAppliedMessage,
   buildRuntimePreferencesMessage,
   buildSessionCreatedText,
+  buildResumeThreadListMessage,
+  buildResumeThreadListText,
   buildSessionSwitchedText,
   buildUnarchiveSuccessText,
   buildWhereText,
@@ -289,6 +291,56 @@ test("buildSessionsText renders archived view with a dedicated title", async () 
   });
 });
 
+test("buildResumeThreadListText renders page metadata and seconds timestamps", async () => {
+  await withMockedNow("2026-03-10T10:10:00.000Z", () => {
+    const text = buildResumeThreadListText(
+      [
+        {
+          name: "Resume <One>",
+          cwd: "/tmp/project-one",
+          preview: "first preview",
+          updatedAt: Math.floor(Date.parse("2026-03-10T10:05:00.000Z") / 1000)
+        }
+      ],
+      { page: 2, pageSize: 10, hasNext: true, includeAll: false }
+    );
+
+    assert.match(text, /^可恢复的 Codex 会话（第 2 页）/u);
+    assert.match(text, /11\. Resume &lt;One&gt; \| project-one \| first preview \| 5分钟前/u);
+    assert.match(text, /下一页：\/resume page 3/u);
+    assert.doesNotMatch(text, /20548 天前/u);
+  });
+});
+
+test("buildResumeThreadListMessage renders numbered selection and pagination buttons", async () => {
+  await withMockedNow("2026-03-10T10:10:00.000Z", () => {
+    const message = buildResumeThreadListMessage(
+      [
+        {
+          name: "Resume <One>",
+          cwd: "/tmp/project-one",
+          preview: "first preview",
+          updatedAt: Math.floor(Date.parse("2026-03-10T10:05:00.000Z") / 1000)
+        },
+        {
+          name: "Resume Two",
+          cwd: "/tmp/project-one",
+          preview: "second preview",
+          updatedAt: "2026-03-10T10:00:00.000Z"
+        }
+      ],
+      { page: 1, pageSize: 10, hasNext: true, includeAll: false }
+    );
+
+    assert.match(message.text, /1\. Resume &lt;One&gt;/u);
+    assert.match(message.text, /2\. Resume Two/u);
+    assert.deepEqual(message.replyMarkup.inline_keyboard[0]?.map((button) => button.text), ["1", "2"]);
+    assert.deepEqual(message.replyMarkup.inline_keyboard[1]?.map((button) => button.text), ["下一页"]);
+    assert.equal(parseCallbackData(message.replyMarkup.inline_keyboard[0]?.[0]?.callback_data ?? "")?.kind, "resume_pick");
+    assert.equal(parseCallbackData(message.replyMarkup.inline_keyboard[1]?.[0]?.callback_data ?? "")?.kind, "resume_page");
+  });
+});
+
 test("buildWhereText includes stable bridge and Codex identifiers when available", () => {
   const text = buildWhereText(
     createSession({
@@ -548,6 +600,10 @@ test("project browser directory message renders entries and browse callbacks", (
     kind: "browse_open",
     token: "tok123",
     entryIndex: 6
+  });
+  assert.deepEqual(parseCallbackData(rendered.replyMarkup.inline_keyboard.at(-2)?.[0]?.callback_data ?? ""), {
+    kind: "browse_resume",
+    token: "tok123"
   });
   assert.deepEqual(parseCallbackData(rendered.replyMarkup.inline_keyboard.at(-1)?.[1]?.callback_data ?? ""), {
     kind: "browse_close",
@@ -1575,6 +1631,10 @@ test("parseCallbackData understands compact and legacy v3 interaction callbacks"
   });
   assert.deepEqual(parseCallbackData("v5:br:k:tok123"), {
     kind: "browse_use_current_dir_cancel",
+    token: "tok123"
+  });
+  assert.deepEqual(parseCallbackData("v5:br:z:tok123"), {
+    kind: "browse_resume",
     token: "tok123"
   });
   assert.deepEqual(parseCallbackData("v7:rr:o:answer-1"), {

--- a/src/telegram/ui.test.ts
+++ b/src/telegram/ui.test.ts
@@ -602,7 +602,7 @@ test("project browser directory message renders entries and browse callbacks", (
     entryIndex: 6
   });
   assert.deepEqual(parseCallbackData(rendered.replyMarkup.inline_keyboard.at(-2)?.[0]?.callback_data ?? ""), {
-    kind: "browse_resume",
+    kind: "browse_up",
     token: "tok123"
   });
   assert.deepEqual(parseCallbackData(rendered.replyMarkup.inline_keyboard.at(-1)?.[1]?.callback_data ?? ""), {
@@ -1633,10 +1633,7 @@ test("parseCallbackData understands compact and legacy v3 interaction callbacks"
     kind: "browse_use_current_dir_cancel",
     token: "tok123"
   });
-  assert.deepEqual(parseCallbackData("v5:br:z:tok123"), {
-    kind: "browse_resume",
-    token: "tok123"
-  });
+  assert.equal(parseCallbackData("v5:br:z:tok123"), null);
   assert.deepEqual(parseCallbackData("v7:rr:o:answer-1"), {
     kind: "recent_output_open",
     answerId: "answer-1"


### PR DESCRIPTION
## Summary

The repository currently supports `/session` for viewing and managing conversations created from Telegram, but it does not provide a way to enter sessions that were previously created from the Codex CLI or the Codex app.

This PR adds a new `/resume` command, allowing users to pick and resume existing Codex sessions that are not yet managed by ctb.

## Testing

- [x] `npm run check`
- [x] `npm run test`
- [x] `npm run build`

## Docs

- [ ] no doc update needed
- [x] README updated
- [x] product/architecture/operations docs updated

## Notes For Reviewers

I noticed that the repository does not appear to have a complete i18n setup yet, and some existing UI text is already hardcoded in Chinese.

For consistency with the current codebase, this implementation also uses hardcoded Chinese text instead of introducing a new i18n layer.

If this is not preferred, I would be happy to update the implementation to support i18n.

If you think this overlaps too much with the existing `/session` command, I can also submit a follow-up PR to merge the `/resume` and `/session` flows more closely.

Also, I would be happy to communicate in Chinese if that works for you.