### PR TITLE
Codex Console phase 2: install paths, Feishu audit, Web/App sketch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ Do not treat protocol capability as proof that Telegram UX already exposes it.
 | current Telegram/Feishu capability matrix or future Web/App target capability rows | `docs/AGENTS.md` | `docs/architecture/platform-capability-matrix.md` |
 | where ownership lives in `src/` today | `docs/AGENTS.md` or `src/AGENTS.md` | `docs/architecture/current-code-organization.md` |
 | current internal Core seam, semantic view contracts, or workflow adapters | `src/AGENTS.md` | one narrow file under `src/core/` |
+| new Codex Console continuation task or context-budget decision | `docs/AGENTS.md` | `docs/roadmap/codex-console-continuation-brief.md` |
 | future multi-platform Core direction, platform packs, Web/App control surface goals | `docs/AGENTS.md` | `docs/future/multi-platform-core-prd.md` |
 | install, config, service, update, diagnostics | `docs/AGENTS.md` | `docs/operations/install-and-admin.md` |
 | volatile versions, counts, current size snapshot | `docs/AGENTS.md` | `docs/generated/current-snapshot.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Do not treat protocol capability as proof that Telegram UX already exposes it.
 | runtime lifecycle, SQLite state, recovery, degraded behavior | `docs/AGENTS.md` | `docs/architecture/runtime-and-state.md` |
 | current Codex app-server adoption, supported request families, approvals, notification reduction, or rejected server requests | `docs/AGENTS.md` | `docs/architecture/codex-app-server-adoption.md` |
 | current pack boundary, active pack selection, platform capabilities, or Telegram/Feishu pack ownership | `docs/AGENTS.md` | `docs/architecture/platform-pack-boundary.md` |
+| current Telegram/Feishu capability matrix or future Web/App target capability rows | `docs/AGENTS.md` | `docs/architecture/platform-capability-matrix.md` |
 | where ownership lives in `src/` today | `docs/AGENTS.md` or `src/AGENTS.md` | `docs/architecture/current-code-organization.md` |
 | current internal Core seam, semantic view contracts, or workflow adapters | `src/AGENTS.md` | one narrow file under `src/core/` |
 | future multi-platform Core direction, platform packs, Web/App control surface goals | `docs/AGENTS.md` | `docs/future/multi-platform-core-prd.md` |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ source_of_truth:
   <a href="https://github.com/InDreamer/telegram-codex-bridge/actions/workflows/ci.yml"><img src="https://github.com/InDreamer/telegram-codex-bridge/actions/workflows/ci.yml/badge.svg?branch=master" alt="CI"></a>
   <a href="https://github.com/InDreamer/telegram-codex-bridge/stargazers"><img src="https://img.shields.io/github/stars/InDreamer/telegram-codex-bridge?style=flat" alt="GitHub stars"></a>
   <a href="https://github.com/InDreamer/telegram-codex-bridge/releases"><img src="https://img.shields.io/github/v/release/InDreamer/telegram-codex-bridge?include_prereleases&label=version" alt="Version"></a>
-  <img src="https://img.shields.io/badge/node-%E2%89%A525-brightgreen" alt="Node >= 25">
+  <img src="https://img.shields.io/badge/node-%E2%89%A524-brightgreen" alt="Node >= 24">
   <img src="https://img.shields.io/badge/platform-linux%20%7C%20macos-blue" alt="Platform">
 </p>
 
@@ -51,7 +51,7 @@ flowchart LR
 
 ## Quick Install
 
-### Recommended: Let Codex set it up
+### Default: Telegram skill path
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/InDreamer/telegram-codex-bridge/master/scripts/install-skill-from-github.sh | bash
@@ -63,13 +63,40 @@ Then tell Codex:
 Use $telegram-codex-linker to set up my Telegram bridge.
 ```
 
-The skill handles everything — bridge install, token collection, authorization, and verification. This quick path keeps the Telegram default; pack-aware install/admin docs cover Feishu setup.
+The skill handles bridge install, token collection, authorization, and verification. This is the default quick path because Telegram is the stable first pack.
+
+### Feishu pack path
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/InDreamer/telegram-codex-bridge/master/scripts/install-skill-from-github.sh | bash -s -- --pack feishu
+```
+
+Then tell Codex:
+
+```
+Use $feishu-codex-linker to set up my Feishu bridge.
+```
+
+Feishu setup requires a Feishu self-built app, `FEISHU_APP_ID` / `FEISHU_APP_SECRET`, long connection, message receive events, and card callbacks. Use the pack-aware admin docs for the exact checklist and verification flow; do not assume every Telegram UX is equally native in Feishu.
 
 ### Alternative: Direct install
 
+Telegram default:
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/InDreamer/telegram-codex-bridge/master/scripts/install-from-github.sh | bash -s -- \
+  --pack telegram \
   --telegram-token "<YOUR_BOT_TOKEN>" \
+  --project-scan-roots "$HOME/projects:$HOME/work"
+```
+
+Feishu:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/InDreamer/telegram-codex-bridge/master/scripts/install-from-github.sh | bash -s -- \
+  --pack feishu \
+  --pack-option app-id="<FEISHU_APP_ID>" \
+  --pack-option app-secret="<FEISHU_APP_SECRET>" \
   --project-scan-roots "$HOME/projects:$HOME/work"
 ```
 
@@ -78,7 +105,7 @@ curl -fsSL https://raw.githubusercontent.com/InDreamer/telegram-codex-bridge/mas
 - An always-on Linux or macOS machine
 - An existing [Codex](https://codex.new) installation
 - A Telegram bot token for the default pack (from [@BotFather](https://t.me/BotFather)), or the matching credentials for another supported pack
-- Node >= 25 (if building from source)
+- Node >= 24 (if building from source)
 
 ## Who This Is For
 
@@ -155,7 +182,7 @@ The `ctb` CLI manages your bridge:
 ```bash
 ctb service run         # Start the bridge
 ctb status              # Health check
-ctb authorize pending   # Bind your Telegram account (one-time)
+ctb authorize pending   # Bind your active-pack account (one-time)
 ctb doctor              # Run diagnostics
 ctb update              # Self-update
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ role: entry
 layer: 1
 parent: null
 children: []
-summary: public repository entry point for the Telegram-first bridge and its documentation trees
+summary: public repository entry point for Codex Console and its documentation trees
 read_when:
   - first entry into the repository
   - need to choose between human docs and coding-agent routing
@@ -15,10 +15,10 @@ source_of_truth:
   - AGENTS.md
 -->
 
-<h1 align="center">telegram-codex-bridge</h1>
+<h1 align="center">Codex Console</h1>
 
 <p align="center">
-  <strong>Control Codex from Telegram. No terminal. No laptop. Just your phone.</strong>
+  <strong>Control Codex from chat. No terminal. No laptop. Just your phone.</strong>
 </p>
 
 <p align="center">
@@ -37,11 +37,14 @@ Codex on a VPS is powerful. But reaching it from your phone through a raw SSH se
 
 ## The Solution
 
-`telegram-codex-bridge` turns Telegram into a **native control surface** for your existing Codex installation. It's not a second Codex, not a chatbot wrapper — it's a proper remote control.
+Codex Console turns supported chat platforms into **native control surfaces** for your existing Codex installation. It's not a second Codex, not a chatbot wrapper — it's a proper remote control.
+
+This repository/package is still named `telegram-codex-bridge` for compatibility. The product name is **Codex Console**. The internal shared architecture is **Codex Bridge Core**. Telegram is the stable first platform pack and default install path; Feishu is a serious current platform pack. That does not mean every surface is fully platform-neutral yet.
 
 ```mermaid
 flowchart LR
-  TG["📱 Telegram"] --> BR["🔗 telegram-codex-bridge"]
+  TG["📱 Telegram"] --> BR["🔗 Codex Console"]
+  FS["💬 Feishu"] --> BR
   BR --> CX["⚙️ Codex on your server"]
   CX --> PRJ["📁 Your project files"]
 ```
@@ -60,7 +63,7 @@ Then tell Codex:
 Use $telegram-codex-linker to set up my Telegram bridge.
 ```
 
-The skill handles everything — bridge install, token collection, authorization, and verification.
+The skill handles everything — bridge install, token collection, authorization, and verification. This quick path keeps the Telegram default; pack-aware install/admin docs cover Feishu setup.
 
 ### Alternative: Direct install
 
@@ -74,7 +77,7 @@ curl -fsSL https://raw.githubusercontent.com/InDreamer/telegram-codex-bridge/mas
 
 - An always-on Linux or macOS machine
 - An existing [Codex](https://codex.new) installation
-- A Telegram bot token (from [@BotFather](https://t.me/BotFather))
+- A Telegram bot token for the default pack (from [@BotFather](https://t.me/BotFather)), or the matching credentials for another supported pack
 - Node >= 25 (if building from source)
 
 ## Who This Is For
@@ -82,7 +85,7 @@ curl -fsSL https://raw.githubusercontent.com/InDreamer/telegram-codex-bridge/mas
 - You already run Codex on a server, desktop, or always-on machine
 - You want a cleaner phone workflow than SSH plus tmux
 - You prefer self-hosted tools and explicit operator control
-- You are okay with Telegram being the control plane into a high-trust runtime
+- You are okay with a chat control surface being the control plane into a high-trust runtime
 
 ## What You Get
 
@@ -94,21 +97,23 @@ Run `/new` and **choose your project** before starting. No blind execution, no g
 
 Watch task progress through clean **runtime cards** instead of terminal noise. Use `/inspect` for details, `/where` for current location.
 
-### Approval Flows in Telegram
+### Approval Flows in Chat
 
-When Codex needs your input — approval, questionnaire, or a decision — the bridge renders it as native Telegram UI. No raw protocol messages.
+When Codex needs your input — approval, questionnaire, or a decision — the bridge renders it as native control-surface UI. No raw protocol messages.
 
 ### Rich Input
 
-- Send a **photo** and it maps directly to Codex image input
-- Send a **voice message** and it gets transcribed into text
-- Full support for skills, mentions, and local images
+- Send a **photo/image** through supported media paths and map it to Codex image input
+- Telegram can turn **voice messages** into transcribed text when voice input is enabled; Feishu voice input is not a current capability
+- Skills, mentions, and local-image inputs are part of the stable Telegram/default-pack UX; other packs expose them according to their capability tier
 
 ### Session Management
 
-Archive, unarchive, rename, pin, and switch between sessions — organized like Telegram chats but linked to your server projects.
+Archive, unarchive, rename, and switch between sessions — organized for the active chat surface but linked to your server projects. Platform-specific affordances such as pinning depend on the active pack.
 
 ### Full Command Surface
+
+Telegram exposes the reference command surface. Feishu can route the shared command flows through text commands and adapted card surfaces, while its native bot menu intentionally starts smaller.
 
 | Command | What it does |
 |---------|-------------|
@@ -127,11 +132,12 @@ Archive, unarchive, rename, pin, and switch between sessions — organized like 
 ## How It Works
 
 ```
-You (Telegram) → bridge (on your server) → Codex app-server → your project files
+You (Telegram or Feishu) → Codex Console (on your server) → Codex app-server → your project files
 ```
 
-- **Telegram** is the control surface (your phone)
-- **The bridge** translates between Telegram UX and Codex protocol
+- **Telegram** is the stable first control surface and default pack
+- **Feishu** is a current pack for operators who choose it
+- **Codex Console** translates between chat UX and Codex protocol
 - **Codex** remains the execution engine
 - Everything runs on **your machine** — self-hosted, single-user, high-trust
 
@@ -139,7 +145,7 @@ You (Telegram) → bridge (on your server) → Codex app-server → your project
 
 - Not a second Codex — it controls your existing one
 - Not a multi-user team bot — it's a personal remote control
-- Not a fake terminal in Telegram — it's a proper native UI
+- Not a fake terminal in chat — it's a proper native UI
 - Not a provider layer — your Codex config handles that
 
 ## After Install
@@ -173,6 +179,7 @@ For detailed docs, start here:
 - [`docs/INDEX.md`](docs/INDEX.md) — canonical documentation router
 - [`docs/README.md`](docs/README.md) — documentation map
 - [`docs/product/v1-scope.md`](docs/product/v1-scope.md) — product boundary and trust model
+- [`docs/architecture/platform-capability-matrix.md`](docs/architecture/platform-capability-matrix.md) — Telegram/Feishu capability matrix and future Web/App target rows
 - [`docs/operations/install-and-admin.md`](docs/operations/install-and-admin.md) — admin reference
 - [`docs/architecture/current-code-organization.md`](docs/architecture/current-code-organization.md) — code organization
 
@@ -184,7 +191,7 @@ Read [`CONTRIBUTING.md`](CONTRIBUTING.md), keep the scope tight, and update the 
 
 ## If This Is Useful
 
-Star the repo, try it on a real Codex host, and [open an issue](https://github.com/InDreamer/telegram-codex-bridge/issues) if the install flow or Telegram UX still feels rough.
+Star the repo, try it on a real Codex host, and [open an issue](https://github.com/InDreamer/telegram-codex-bridge/issues) if the install flow or chat UX still feels rough.
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -54,7 +54,7 @@ Protocol evidence is **not** the same thing as shipped Telegram UX.
 
 Use this tier only for future direction, implementation sequencing, or conflict reconstruction.
 
-- `docs/roadmap/`
+- `docs/roadmap/` (start with `docs/roadmap/codex-console-continuation-brief.md` for new continuation tasks)
 - `docs/future/`
 - `docs/plans/`
 - `docs/archive/`
@@ -84,6 +84,7 @@ Read the smallest matching leaf doc.
 | authoritative Codex app-server protocol reference | `docs/research/codex-app-server-authoritative-reference.md` |
 | method-by-method protocol lookup | `docs/research/codex-app-server-api-quick-reference.md` |
 | earlier protocol verification details | `docs/research/app-server-phase-0-verification.md` |
+| new Codex Console continuation task, archive/noise decision, or context-budget decision | `docs/roadmap/codex-console-continuation-brief.md` |
 | future multi-platform Core direction, platform packs, Web/App control surface goals | `docs/future/multi-platform-core-prd.md` |
 | roadmap or future-phase intent | the smallest relevant file under `docs/roadmap/` or `docs/future/` |
 | active implementation planning or handoff context | the smallest relevant file under `docs/plans/` |
@@ -151,4 +152,4 @@ Stop after one leaf doc unless the task shows a real need for:
 - one protocol doc in Tier 2
 - one planning/history doc in Tier 3
 
-Do not read the entire docs tree.
+Do not read the entire docs tree. Do not read `docs/archive/` unless current sources conflict or the task explicitly asks for history.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -78,6 +78,7 @@ Read the smallest matching leaf doc.
 | code-derived ownership map for `src/` | `docs/architecture/current-code-organization.md` |
 | current Codex app-server adoption, supported request families, notification reduction, approvals, and rejected server requests | `docs/architecture/codex-app-server-adoption.md` |
 | current pack boundary, active pack selection, Telegram vs Feishu pack ownership, or platform capability routing | `docs/architecture/platform-pack-boundary.md` |
+| current Telegram/Feishu capability table, common capability vs platform-specific features, or future Web/App target capability rows | `docs/architecture/platform-capability-matrix.md` |
 | install flow, config keys, paths, services, update, diagnostics | `docs/operations/install-and-admin.md` |
 | exact current versions, module counts, size snapshot, other high-drift facts | `docs/generated/current-snapshot.md` |
 | authoritative Codex app-server protocol reference | `docs/research/codex-app-server-authoritative-reference.md` |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,8 +31,8 @@ Open one domain, then one leaf, then stop.
 
 ## Current Truth
 
-- `docs/product/README.md` - current Telegram-first product behavior, scope, commands, and callback UX.
-- `docs/architecture/README.md` - current runtime shape, bridge-versus-platform decoupling status, state model, and code ownership.
+- `docs/product/README.md` - current Codex Console product behavior, including Telegram-first scope, commands, and callback UX.
+- `docs/architecture/README.md` - current runtime shape, bridge-versus-platform decoupling status, state model, pack boundary, capability matrix, and code ownership.
 - `docs/operations/README.md` - install, config, service, update, and diagnostics.
 - `docs/generated/current-snapshot.md` - exact version baselines and other high-drift facts.
 
@@ -42,7 +42,7 @@ Open one domain, then one leaf, then stop.
 
 ## Future, Planning, And History
 
-- `docs/future/README.md` - future repository direction, including the broader Core path.
+- `docs/future/README.md` - future product and architecture direction, including the broader Codex Bridge Core path.
 - `docs/plans/README.md` - active trackers, implementation sequencing, and closeout notes.
 - `docs/roadmap/README.md` - delivery ordering and acceptance intent.
 - `docs/archive/README.md` - historical material only when current sources conflict.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -3,6 +3,7 @@ role: entry
 layer: 1
 parent: null
 children:
+  - docs/roadmap/codex-console-continuation-brief.md
   - docs/product/README.md
   - docs/architecture/README.md
   - docs/operations/README.md
@@ -12,22 +13,26 @@ children:
   - docs/plans/README.md
   - docs/roadmap/README.md
   - docs/archive/README.md
-summary: canonical documentation router that separates current truth, protocol evidence, and future or historical context
+summary: canonical documentation router that separates active task handoff, current truth, protocol evidence, and future or historical context
 read_when:
   - need the canonical docs router
-  - need to choose one documentation domain before opening a leaf
+  - starting a new Codex Console continuation task without a known leaf
 skip_when:
-  - the exact domain or leaf is already known
+  - the exact active brief, domain, or leaf is already known
 source_of_truth:
   - docs/INDEX.md
-  - docs/README.md
+  - docs/roadmap/codex-console-continuation-brief.md
   - docs/catalog.yaml
 -->
 
 # Docs Index
 
-The docs tree is organized by decision value, not by folder trivia.
-Open one domain, then one leaf, then stop.
+The docs tree is organized by decision value and context cost.
+Open one entrypoint, then one leaf, then stop.
+
+## Active Continuation Entrypoint
+
+- `docs/roadmap/codex-console-continuation-brief.md` - start here for new Codex Console / multi-platform bridge continuation work. It names the active source set, archive policy, and next sustainable task queue.
 
 ## Current Truth
 
@@ -44,12 +49,14 @@ Open one domain, then one leaf, then stop.
 
 - `docs/future/README.md` - future product and architecture direction, including the broader Codex Bridge Core path and Web/App control surface sketch.
 - `docs/plans/README.md` - active trackers, implementation sequencing, and closeout notes.
-- `docs/roadmap/README.md` - delivery ordering and acceptance intent.
+- `docs/roadmap/README.md` - delivery ordering, continuation handoff, and acceptance intent.
 - `docs/archive/README.md` - historical material only when current sources conflict.
 
 ## Guardrails
 
+- Start with the continuation brief for new platform-abstraction work; do not start with old dated plans.
 - Current docs and current code beat plan docs.
 - Research docs prove protocol capability, not shipped Telegram support.
 - Future docs describe direction, not the product you have today.
+- Archived docs are for archaeology, not default agent context.
 - If you already know the leaf, skip this file.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,7 +33,7 @@ Open one domain, then one leaf, then stop.
 
 - `docs/product/README.md` - current Codex Console product behavior, including Telegram-first scope, commands, and callback UX.
 - `docs/architecture/README.md` - current runtime shape, bridge-versus-platform decoupling status, state model, pack boundary, capability matrix, and code ownership.
-- `docs/operations/README.md` - install, config, service, update, and diagnostics.
+- `docs/operations/README.md` - install, active-pack selection, config, service, update, and diagnostics.
 - `docs/generated/current-snapshot.md` - exact version baselines and other high-drift facts.
 
 ## Protocol Evidence

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -42,7 +42,7 @@ Open one domain, then one leaf, then stop.
 
 ## Future, Planning, And History
 
-- `docs/future/README.md` - future product and architecture direction, including the broader Codex Bridge Core path.
+- `docs/future/README.md` - future product and architecture direction, including the broader Codex Bridge Core path and Web/App control surface sketch.
 - `docs/plans/README.md` - active trackers, implementation sequencing, and closeout notes.
 - `docs/roadmap/README.md` - delivery ordering and acceptance intent.
 - `docs/archive/README.md` - historical material only when current sources conflict.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ If you want the canonical router, open `docs/INDEX.md`.
 - Current runtime shape or ownership map: `docs/architecture/README.md`
 - Current pack boundary, active-pack behavior, or platform capability split: `docs/architecture/platform-pack-boundary.md`
 - Current Telegram/Feishu capability matrix and future Web/App target rows: `docs/architecture/platform-capability-matrix.md`
-- Install, config, service, update, diagnostics: `docs/operations/install-and-admin.md`
+- Install, active-pack selection, config, service, update, diagnostics: `docs/operations/install-and-admin.md`
 - Exact Codex app-server capability or payload shape: `docs/research/README.md`
 - Future Codex Bridge Core direction: `docs/future/multi-platform-core-prd.md`
 - What landed in the 2026-03-23 abstraction wave and what is still deferred: `docs/plans/README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,39 +12,45 @@ skip_when:
 source_of_truth:
   - docs/README.md
   - docs/INDEX.md
+  - docs/roadmap/codex-console-continuation-brief.md
   - docs/catalog.yaml
 -->
 
 # Documentation Map
 
 Use this file when you want the human-readable version of the doc tree.
-If you want the canonical router, open `docs/INDEX.md`.
+If you are starting a new Codex Console continuation task, open `docs/roadmap/codex-console-continuation-brief.md` first.
 
 ## Start With Truth Status
 
+- Active continuation handoff: `docs/roadmap/codex-console-continuation-brief.md`
 - Current behavior: `docs/product/`, `docs/architecture/`, `docs/operations/`, and `docs/generated/current-snapshot.md`
 - Protocol capability only: `docs/research/`
-- Future direction, sequencing, and history: `docs/future/`, `docs/plans/`, `docs/roadmap/`, and `docs/archive/`
+- Future direction: `docs/future/`
+- Active plans and closeout notes: `docs/plans/`
+- Historical reconstruction only: `docs/archive/`
 
 ## Fast Paths
 
+- New Codex Console / multi-platform bridge continuation work: `docs/roadmap/codex-console-continuation-brief.md`
 - Current Codex Console product boundary: `docs/product/v1-scope.md`
 - Current bridge-versus-platform decoupling progress: `docs/architecture/platform-decoupling-status.md`
-- Current runtime shape or ownership map: `docs/architecture/README.md`
 - Current pack boundary, active-pack behavior, or platform capability split: `docs/architecture/platform-pack-boundary.md`
 - Current Telegram/Feishu capability matrix and future Web/App target rows: `docs/architecture/platform-capability-matrix.md`
 - Install, active-pack selection, config, service, update, diagnostics: `docs/operations/install-and-admin.md`
 - Exact Codex app-server capability or payload shape: `docs/research/README.md`
 - Future Codex Bridge Core direction: `docs/future/multi-platform-core-prd.md`
 - Future Web/App control surface sketch: `docs/future/web-app-control-surface-sketch.md`
-- What landed in the 2026-03-23 abstraction wave and what is still deferred: `docs/plans/README.md`
+- Phase 2 summary / PR note: `docs/plans/2026-04-26-codex-console-phase2-release-note.md`
 
 ## Rules That Matter
 
+- Use the continuation brief to decide what not to read.
 - Current docs and current code beat plans.
 - Protocol evidence proves capability, not shipped Telegram UX.
 - Future and plan docs are intent and sequence, not current behavior.
-- Read one domain, then one leaf, then stop.
+- Archived docs should not enter model context unless the task asks for history or current sources conflict.
+- Read one entrypoint, then one leaf, then stop.
 
 ## Agent Path
 
@@ -53,3 +59,5 @@ Coding agents should usually take the smaller route:
 1. `AGENTS.md`
 2. one domain router such as `docs/AGENTS.md` or `src/AGENTS.md`
 3. one leaf doc or one narrow source file
+
+For continuation work, the leaf is usually `docs/roadmap/codex-console-continuation-brief.md` plus one current-truth doc.

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ If you want the canonical router, open `docs/INDEX.md`.
 - Install, active-pack selection, config, service, update, diagnostics: `docs/operations/install-and-admin.md`
 - Exact Codex app-server capability or payload shape: `docs/research/README.md`
 - Future Codex Bridge Core direction: `docs/future/multi-platform-core-prd.md`
+- Future Web/App control surface sketch: `docs/future/web-app-control-surface-sketch.md`
 - What landed in the 2026-03-23 abstraction wave and what is still deferred: `docs/plans/README.md`
 
 ## Rules That Matter

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,13 +28,14 @@ If you want the canonical router, open `docs/INDEX.md`.
 
 ## Fast Paths
 
-- Current Telegram product boundary: `docs/product/v1-scope.md`
+- Current Codex Console product boundary: `docs/product/v1-scope.md`
 - Current bridge-versus-platform decoupling progress: `docs/architecture/platform-decoupling-status.md`
 - Current runtime shape or ownership map: `docs/architecture/README.md`
 - Current pack boundary, active-pack behavior, or platform capability split: `docs/architecture/platform-pack-boundary.md`
+- Current Telegram/Feishu capability matrix and future Web/App target rows: `docs/architecture/platform-capability-matrix.md`
 - Install, config, service, update, diagnostics: `docs/operations/install-and-admin.md`
 - Exact Codex app-server capability or payload shape: `docs/research/README.md`
-- Future multi-platform Core direction: `docs/future/multi-platform-core-prd.md`
+- Future Codex Bridge Core direction: `docs/future/multi-platform-core-prd.md`
 - What landed in the 2026-03-23 abstraction wave and what is still deferred: `docs/plans/README.md`
 
 ## Rules That Matter

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -8,7 +8,8 @@ children:
   - docs/architecture/current-code-organization.md
   - docs/architecture/codex-app-server-adoption.md
   - docs/architecture/platform-pack-boundary.md
-summary: router for the current runtime shape, decoupling status, state model, verified code ownership map, pack boundary, and app-server adoption boundary
+  - docs/architecture/platform-capability-matrix.md
+summary: router for the current runtime shape, decoupling status, state model, verified code ownership map, pack boundary, capability matrix, and app-server adoption boundary
 read_when:
   - the request is about current runtime lifecycle, state, recovery, or code ownership
   - the request needs the current implementation map before opening source files
@@ -21,6 +22,7 @@ source_of_truth:
   - docs/architecture/current-code-organization.md
   - docs/architecture/codex-app-server-adoption.md
   - docs/architecture/platform-pack-boundary.md
+  - docs/architecture/platform-capability-matrix.md
   - src
 -->
 
@@ -36,6 +38,7 @@ This is still Telegram-first runtime truth, not future-Core intent.
 - `current-code-organization.md` - verified owner map after the Core seam and pack boundary landed.
 - `codex-app-server-adoption.md` - current bridge-owned app-server lifecycle, request families, server-request handling, and notification reduction.
 - `platform-pack-boundary.md` - current active-pack contract, runtime factory, health checks, and Telegram vs Feishu ownership split.
+- `platform-capability-matrix.md` - current Telegram/Feishu capability matrix, common product expectations, platform-specific features, and future Web/App target rows.
 
 ## Skip This Directory When
 

--- a/docs/architecture/platform-capability-matrix.md
+++ b/docs/architecture/platform-capability-matrix.md
@@ -141,7 +141,7 @@ These rows decide how good the experience can be on a platform. They should not 
 | Skill bundle | `telegram-codex-linker` | `feishu-codex-linker` |
 | Primary credentials | `TELEGRAM_BOT_TOKEN` | `FEISHU_APP_ID`, `FEISHU_APP_SECRET` |
 | API family | Telegram Bot API | Feishu OpenAPI / long-connection via compatibility adapters |
-| Ingress | Polling | Feishu event/long-connection compatibility poller, despite pack metadata currently saying polling |
+| Ingress | Polling | Feishu event/long-connection via compatibility poller |
 | Presentation preference | Telegram-native command/buttons | Bridge command buttons and Feishu cards |
 | Dynamic tools | `send_telegram_document`, `send_telegram_image` | `send_feishu_file`, `send_feishu_image` |
 | Voice input | Supported when transcription is configured | Not supported today |
@@ -209,7 +209,6 @@ Use these rules before adding a new platform:
 
 ## Current Caveats
 
-- Feishu pack metadata currently contains compatibility-shaped labels (`polling`, `bot_api`) while actual behavior uses Feishu long-connection/OpenAPI adapters.
 - Feishu `ownsRichInput` and `ownsMediaIngress` are false even though Feishu can adapt image/file message resources through shared compatibility paths.
 - Feishu pin/unpin is not a native capability today.
 - Current product docs still describe many current flows through Telegram UX because Telegram remains the reference/default path.

--- a/docs/architecture/platform-capability-matrix.md
+++ b/docs/architecture/platform-capability-matrix.md
@@ -1,0 +1,216 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/architecture/README.md
+children: []
+summary: current Codex Console capability matrix for Telegram and Feishu, plus future Web/App target rows
+read_when:
+  - the request is about what Telegram or Feishu currently supports
+  - the request is about which capabilities belong in Core, Presentation, Pack, or Skill
+  - the request is about future Web/App platform planning without making the matrix Telegram-shaped
+skip_when:
+  - the request is only about exact Telegram callback payload encoding
+  - the request is only about install command syntax or operator paths
+source_of_truth:
+  - docs/architecture/platform-capability-matrix.md
+  - docs/architecture/platform-pack-boundary.md
+  - docs/architecture/platform-decoupling-status.md
+  - docs/future/multi-platform-core-prd.md
+  - src/core/interaction-model/surface.ts
+  - src/packs/contract.ts
+  - src/packs/telegram/index.ts
+  - src/packs/feishu/index.ts
+  - src/telegram/surface-adapter.ts
+  - pack-manifest.json
+-->
+
+# Platform Capability Matrix
+
+Verified against the current docs and implementation on 2026-04-25.
+
+Use this file to answer:
+
+- what Telegram and Feishu currently support in Codex Console
+- which capabilities are shared product expectations versus platform-specific features
+- how future Web/App surfaces should be evaluated without copying Telegram or Feishu
+
+## Naming And Current Truth
+
+- External product name: **Codex Console**.
+- Internal shared architecture name: **Codex Bridge Core**.
+- Repository/package compatibility name: `telegram-codex-bridge`.
+- Current supported packs: **Telegram** and **Feishu**.
+- Default pack: **Telegram**.
+- Feishu is a serious current pack, not merely a theoretical experiment.
+- Codex Console is not yet a fully platform-neutral product core; the shared service shell still has Telegram-shaped history.
+
+## Symbols
+
+| Symbol | Label | Meaning |
+|---|---|---|
+| ✅ | Native | First-class current support on this platform. |
+| ◐ | Adapted | Supported through an acceptable platform-specific adaptation or reduced UX. |
+| △ | Fallback | Product meaning can work, but through text/manual refresh/files/split messages/etc. |
+| — | Not supported | This platform does not provide this capability today. |
+| ⚠ | Blocker / unverified | Required or claimed area that depends on missing setup, missing runtime path, or unverified behavior. |
+
+Rules:
+
+- Do not read ✅ as "Telegram-like". A future Web/App ✅ may mean a dashboard, panel, modal, or form.
+- Do not collapse setup readiness and static platform capability into one idea. Feishu upload/callback support depends on permissions and observed setup checks.
+- If a universal expectation is not at least △, the platform should not be called a supported Codex Console pack.
+
+## Layer Ownership
+
+| Layer | Owns | Must not own |
+|---|---|---|
+| **Core** | project/session meaning, turn lifecycle, interactions, runtime state, final-answer meaning, delivery outcomes | Telegram buttons, Feishu card JSON, Web layout, platform credentials |
+| **Capability** | whether a platform can support buttons/actions, edits/live updates, rich previews, pagination, media, files, degraded delivery | product workflow decisions |
+| **Presentation** | how a state/interaction/result is rendered for one surface | pack credential flow or runtime state machine |
+| **Pack** | platform identity, ingress, egress, auth binding, install validation, health checks, platform dynamic tools | shared Codex workflow semantics |
+| **Skill / Setup** | guided external setup, credential collection, operator checklist, smoke test | long-lived runtime architecture |
+
+## Universal Product Expectations
+
+These are Codex Console baseline expectations. A supported platform can satisfy them natively or through fallback, but it should not be considered ready if it cannot satisfy the product meaning at all.
+
+| Capability area | Core expectation | Telegram | Feishu | Future Web/App target | Owner layer | Notes |
+|---|---|---:|---:|---:|---|---|
+| Operator identity & auth | Bind the allowed operator/control surface and report ready/awaiting/unhealthy | ✅ | ✅ | ✅ | Pack + Skill | Platform credentials stay pack-specific. |
+| Project/session lifecycle | Make active project/session explicit; support start/resume/switch | ✅ | ◐ | ✅ | Core + Presentation | Feishu currently rides the shared Telegram-shaped service path. |
+| Turn input & continuation | Send new text tasks and continue blocked turns | ✅ | ✅ | ✅ | Core + Pack | Text is the baseline input capability. |
+| Approvals & questions | Present request, collect answer, show resolved/expired/failed state | ✅ | ✅ | ✅ | Core + Presentation | Telegram uses callbacks; Feishu uses card callbacks/adapters; Web/App should use forms/modals. |
+| Runtime visibility | Show running/blocked/done/failed state, progress, inspect/status detail | ✅ | ◐ | ✅ | Core + Presentation | Feishu has adapted cards; Web/App should eventually be richer than chat. |
+| Interrupt / stop | Stop active turn safely from the control surface | ✅ | ✅ | ✅ | Core + Pack | The exact UI should vary by platform. |
+| Final answer delivery | Deliver final answer separately from transient progress and avoid silent truncation | ✅ | ◐ | ✅ | Core + Presentation | Long-form UX is platform-tiered below. |
+| Recovery / degraded delivery | Represent sent, edited/updated, deferred, failed/rate-limited outcomes | ✅ | ◐ | ✅ | Core + Presentation | Existing Core surface outcomes support this direction. |
+| Install/config/health | Validate pack credentials, setup state, and readiness | ✅ | ◐ | ✅ | Pack + Skill | Feishu has more external setup and observed-readiness checks. |
+
+## UX Richness Matrix
+
+These rows decide how good the experience can be on a platform. They should not redefine the shared Core workflow.
+
+| Capability | Telegram | Feishu | Future Web/App target | Notes |
+|---|---:|---:|---:|---|
+| Native interactive controls | ✅ | ✅ | ✅ | Telegram inline buttons; Feishu interactive cards; Web/App forms/buttons. |
+| Editable / live surfaces | ✅ | ✅ | ✅ | Telegram message edits; Feishu card/message updates; Web/App live panels. |
+| Rich text / preview rendering | ✅ | ✅ | ✅ | Both current packs declare rich preview support. |
+| Long-form pagination / collapse | ✅ | ✅ | ✅ | Current packs declare long-form pagination; Web/App should use richer navigation. |
+| Runtime hub / status surfaces | ✅ | ◐ | ✅ | Telegram is reference UX; Feishu is adapted through cards/compat layer. |
+| Inspect / recent output detail | ✅ | ◐ | ✅ | Web/App should eventually be the best surface for dense detail. |
+| Project picker | ✅ | ◐ | ✅ | Feishu support depends on adapted buttons/cards. |
+| Read-only project browsing | ✅ | ◐ | ✅ | Web/App should eventually provide stronger browse/history UX. |
+| Native command/menu discovery | ✅ | ◐ | ✅ | Telegram syncs command menu; Feishu bot menu exposes a smaller native entry set. |
+| Background/progress notifications | ✅ | ◐ | ✅ | Feishu depends on long-connection/event setup. |
+| Long final answers | ✅ | ◐ | ✅ | Chat platforms need collapse/pagination/file fallback; Web/App can use history/pages. |
+
+## Ingress Matrix
+
+| Input / event | Telegram | Feishu | Future Web/App target | Notes |
+|---|---:|---:|---:|---|
+| Text messages / task input | ✅ | ✅ | ✅ | Baseline for supported packs. |
+| Slash/text commands | ✅ | ◐ | ✅ | Feishu can route text commands, but native bot menu is limited. |
+| Native command menu | ✅ | ◐ | ✅ | Feishu currently exposes `new`, `status`, `sessions`, `help` in bot-menu style surfaces. |
+| Callback/action events | ✅ | ✅ | ✅ | Feishu requires interactive card callback setup and observation. |
+| Rich structured input ownership | ✅ | ◐ | ✅ | Telegram owns rich input; Feishu supports adapted message resources but pack metadata does not own rich input. |
+| Receive images | ✅ | ✅ | ✅ | Feishu receives images via message-resource descriptors/download. |
+| Receive files | ✅ | ✅ | ✅ | Feishu receives files via message-resource descriptors/download. |
+| Receive voice/audio | ✅ | — | ✅/△ | Telegram voice requires transcription readiness; Feishu pack declares voice false. |
+| Remote image URL input | — | — | ✅/△ | Current packs declare remote image URL support false. |
+| Group/team multi-user input | — | — | △ | Current product is high-trust/single-operator; Web/App would need a separate product decision. |
+
+## Egress And Media Matrix
+
+| Output / delivery | Telegram | Feishu | Future Web/App target | Notes |
+|---|---:|---:|---:|---|
+| Plain text messages | ✅ | ✅ | ✅ | Baseline. |
+| Rich cards / rich messages | ✅ | ✅ | ✅ | Telegram HTML/inline UI; Feishu interactive cards; Web/App panels. |
+| Edit/update existing surface | ✅ | ✅ | ✅ | Feishu updates cards/messages through adapter behavior. |
+| Delete/retire old surface | ✅ | ◐ | ✅ | Feishu adapter has send/delete/edit fallbacks; exact semantics differ. |
+| Pin/unpin | ✅ | △ | △ | Feishu compatibility currently returns success without real platform pinning; do not treat as native. |
+| Send image to control surface | ✅ | ✅ | ✅ | Pack-specific dynamic tools exist for Telegram and Feishu. |
+| Send file to control surface | ✅ | ✅ | ✅ | Feishu upload support depends on app scopes and probes. |
+| Use remote image URL for output | — | — | ✅/△ | Current packs declare false. |
+| File/image upload readiness checks | ◐ | ✅ | ✅ | Feishu explicitly probes file/image upload scopes; Telegram validates bot credentials. |
+
+## Current Pack Summary
+
+| Area | Telegram | Feishu |
+|---|---|---|
+| Pack status | Stable first/default pack | Serious current pack |
+| Skill bundle | `telegram-codex-linker` | `feishu-codex-linker` |
+| Primary credentials | `TELEGRAM_BOT_TOKEN` | `FEISHU_APP_ID`, `FEISHU_APP_SECRET` |
+| API family | Telegram Bot API | Feishu OpenAPI / long-connection via compatibility adapters |
+| Ingress | Polling | Feishu event/long-connection compatibility poller, despite pack metadata currently saying polling |
+| Presentation preference | Telegram-native command/buttons | Bridge command buttons and Feishu cards |
+| Dynamic tools | `send_telegram_document`, `send_telegram_image` | `send_feishu_file`, `send_feishu_image` |
+| Voice input | Supported when transcription is configured | Not supported today |
+| Setup complexity | Lower: bot token + authorization | Higher: app credentials, bot ability, scopes, events, card callbacks, publishing/long-connection |
+| Main caveat | Product docs still mostly use Telegram as reference UX | Runtime works through Telegram-compatible service adapters, so the boundary is not yet clean |
+
+## Capability Readiness Levels
+
+For future pack planning, track four readiness levels separately:
+
+1. **Static declared capability** — the pack says the platform can do it.
+2. **Configured capability** — credentials, scopes, app settings, and local dependencies are present.
+3. **Observed capability** — the bridge has seen text ingress, callback/action events, uploads, or other required platform signals.
+4. **UX-exposed capability** — users can reach it through menus, cards, commands, buttons, or docs.
+
+This matters because a row can be technically true but not ready for users. Examples:
+
+- Feishu declares callbacks and uploads, but callbacks require card-action setup and uploads require app scopes.
+- Telegram declares voice receive, but useful voice input also depends on transcription configuration.
+- A future Web/App surface may have excellent UI affordances but should not count as supported until it reuses Core workflow semantics.
+
+## What Stays Platform-Specific
+
+Do not move these into Codex Bridge Core:
+
+- Telegram callback payload encoding, inline keyboard layout, Bot API quirks, message ids, command registration, BotFather token flow.
+- Feishu card schema, tenant token flow, app credentials, scope probing, event subscription, OpenAPI upload/download details.
+- Web/App routes, component library, CSS/layout, browser storage, websocket/SSE plumbing, desktop/mobile notification APIs.
+- Platform-specific media resource ids, upload handles, download URLs, conversation ids, and message ids.
+- Platform-specific dynamic tool names; Core should know shared actions like "send image/file to the active control surface".
+
+## Web/App Planning Implications
+
+A future Web/App surface should not be a fake chat pack.
+
+It should reuse Codex Bridge Core semantics:
+
+- project/session state
+- turn lifecycle
+- approvals/questions
+- runtime status and progress
+- final answers and artifacts
+- delivery outcomes and degraded states
+
+But it should use native Web/App presentation:
+
+- dashboards, sidebars, tabs, panels
+- forms/modals for approvals
+- durable final-answer history
+- richer project browsing and file previews
+- live updates through Web/App transport
+- explicit admin/setup pages
+
+Separate product decisions are still required before Web/App expands scope into multi-user collaboration, provider setup, raw terminal views, project write operations, or team permissions.
+
+## Owner Decision Rules
+
+Use these rules before adding a new platform:
+
+1. **No platform support claim without a complete baseline journey.** The user must be able to authorize, choose a project/session, send a task, answer an interaction, inspect progress, interrupt if needed, and receive the final answer.
+2. **No forced UX parity.** A platform can be supported even if it does not look like Telegram or Feishu.
+3. **No hidden Core fork.** A richer Web/App surface must reuse Core workflow semantics rather than becoming a parallel product.
+4. **No boolean-only capability claims.** Track static/configured/observed/UX-exposed readiness separately.
+5. **No third platform before the second-platform lessons are captured.** Feishu should continue to expose which assumptions are still Telegram-shaped.
+
+## Current Caveats
+
+- Feishu pack metadata currently contains compatibility-shaped labels (`polling`, `bot_api`) while actual behavior uses Feishu long-connection/OpenAPI adapters.
+- Feishu `ownsRichInput` and `ownsMediaIngress` are false even though Feishu can adapt image/file message resources through shared compatibility paths.
+- Feishu pin/unpin is not a native capability today.
+- Current product docs still describe many current flows through Telegram UX because Telegram remains the reference/default path.
+- Broad Slack/Discord/Web/App support remains future scope.

--- a/docs/architecture/platform-decoupling-status.md
+++ b/docs/architecture/platform-decoupling-status.md
@@ -25,6 +25,7 @@ source_of_truth:
 # Platform Decoupling Status
 
 Verified against the current implementation on 2026-04-10.
+Naming reviewed on 2026-04-25.
 
 Use this file when the question is:
 
@@ -36,19 +37,28 @@ Use this file when the question is:
 This file is current implementation truth.
 It is not the future multi-platform Core PRD and it is not a historical plan snapshot.
 
+Naming baseline:
+
+- external product name is **Codex Console**
+- internal shared architecture name is **Codex Bridge Core**
+- repository/package compatibility name remains `telegram-codex-bridge`
+- Telegram is the stable first pack and default path
+- Feishu is a serious current pack, not a proof that broad multi-platform maturity is complete
+
 ## Current Truth In One Screen
 
 - the repo now has a real internal Core seam under `src/core/`
 - the repo now has a real pack boundary under `src/packs/`
 - active-pack selection, runtime startup, readiness, install, and skill installation are pack-aware
+- Telegram and Feishu are current packs
 - a first capability and surface-delivery vocabulary has landed and is already used in selected delivery paths
 - shared bridge services still contain substantial Telegram-shaped shell logic
-- Telegram remains the default shipped product truth even though the implementation is no longer purely Telegram-hardcoded
+- Telegram remains the default shipped path even though the implementation is no longer purely Telegram-hardcoded
 
 So two statements are true at the same time:
 
 - the bridge has materially moved beyond a Telegram-only internal architecture
-- the bridge is not yet a fully platform-neutral product core
+- Codex Bridge Core is not yet a fully platform-neutral product core
 
 ## What Has Already Been Decoupled
 
@@ -164,12 +174,12 @@ Safe:
 
 - the repo has a real internal bridge-versus-platform seam
 - the repo has a real pack boundary
-- a second platform has landed through the current pack model
+- Telegram is the stable first pack and Feishu has landed through the current pack model
 - current abstraction work is materially beyond Phase 1-only groundwork
 
 Not safe:
 
-- claiming the bridge is already fully platform-neutral
+- claiming Codex Console is already fully platform-neutral
 - claiming Telegram is now only a thin renderer
 - claiming future platforms will require no more shared abstraction work
 - using Feishu support as proof that all Telegram-first assumptions are gone
@@ -191,4 +201,3 @@ The most important remaining gaps are:
 - For current runtime and persistence rules: `runtime-and-state.md`
 - For operator-visible pack behavior: `../operations/install-and-admin.md`
 - For the future target beyond the current state: `../future/multi-platform-core-prd.md`
-

--- a/docs/architecture/platform-pack-boundary.md
+++ b/docs/architecture/platform-pack-boundary.md
@@ -124,7 +124,7 @@ Feishu pack owners:
 - `src/packs/feishu/index.ts` - Feishu pack definition, health checks, setup-health wiring, and dynamic tools
 - `src/packs/feishu/config.ts` - Feishu pack env/config codec
 - `src/packs/feishu/setup.ts` - Feishu setup-cycle observation and readiness interpretation
-- `src/feishu/` - current Feishu API and polling compatibility adapters
+- `src/feishu/` - current Feishu OpenAPI and long-connection compatibility adapters
 
 Shared shell owners that are still not fully pack-neutral:
 

--- a/docs/architecture/platform-pack-boundary.md
+++ b/docs/architecture/platform-pack-boundary.md
@@ -28,6 +28,7 @@ source_of_truth:
 # Platform Pack Boundary
 
 Verified against the current implementation on 2026-04-09.
+Naming reviewed on 2026-04-25.
 
 Use this file for the answer to:
 
@@ -38,6 +39,14 @@ Use this file for the answer to:
 
 This file is about the current implementation boundary.
 It is not the future multi-platform product PRD.
+For the owner-facing Telegram/Feishu capability table and future Web/App target rows, use `platform-capability-matrix.md`.
+
+Product/architecture naming:
+
+- external product name: **Codex Console**
+- internal architecture name: **Codex Bridge Core**
+- current repository/package compatibility name: `telegram-codex-bridge`
+- current supported packs: Telegram and Feishu
 
 ## Current Truth In One Screen
 
@@ -45,12 +54,12 @@ It is not the future multi-platform product PRD.
 - `BRIDGE_PACK` selects the active pack at config load time; default is still `telegram`
 - runtime startup, readiness checks, install-time skill selection, and dynamic tool declarations are pack-aware
 - the shared service shell is still largely Telegram-shaped
-- Feishu support exists as a current runtime and setup boundary, but that does not override the repo's Telegram-first shipped-product docs
+- Feishu support exists as a current runtime and setup boundary, but that does not erase Telegram-first history or the default Telegram install path
 
 That means two statements are true at the same time:
 
 - current implementation is no longer purely Telegram-hardcoded
-- current default product truth should still be read as Telegram-first unless the task is explicitly about pack internals or Feishu setup
+- Codex Console is currently Telegram-first by default path while also having a serious Feishu pack
 
 ## What The Pack Contract Owns
 
@@ -90,6 +99,7 @@ Current install-facing implications:
 - `ctb install` accepts `--pack <name>` and repeated `--pack-option key=value`
 - `ctb install-skill` also accepts `--pack <name>`
 - GitHub install shortcuts resolve the pack through `pack-manifest.json` and forward it into the CLI
+- Telegram remains the default when no pack is selected
 
 ## Current Owner Split
 
@@ -151,6 +161,6 @@ Needs extra caution:
 
 - changing `BridgePackDefinition` in ways that ripple into `src/service.ts`, readiness, and install
 - claiming a pack capability in docs before the corresponding runtime and UI path exist
-- treating Feishu setup coverage as proof that Telegram-first product docs no longer apply
+- treating Feishu setup coverage as proof that all Telegram-shaped service assumptions are gone
 
 Escalate to the future-direction docs when the change is about a fully platform-neutral product core rather than today's pack-aware runtime boundary.

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -2,7 +2,9 @@
 role: domain
 layer: 2
 parent: docs/INDEX.md
-children: []
+children:
+  - docs/archive/plans/README.md
+  - docs/archive/future/README.md
 summary: router for archived historical material kept for reconstruction only
 read_when:
   - the request needs historical reconstruction because current sources conflict
@@ -22,10 +24,18 @@ Archive material is fallback context, not current truth.
 ## Typical Contents
 
 - superseded drafts
-- legacy plans
+- legacy PRDs and engineering evaluations
+- closed implementation plans
 - older notes kept for reconstruction
+
+## Current Archive Groups
+
+- `future/` - superseded V2/V3 future PRDs and evaluation material.
+- `plans/` - older March implementation plans that should not be model context for current Codex Console continuation work.
+- top-level archive files - older one-off historical notes that predate the current docs information architecture.
 
 ## Skip This Directory When
 
 - current docs and code already answer the question
-- you only need active product, architecture, or operations guidance
+- you only need active product, architecture, operations, roadmap, or future-Core guidance
+- you are preparing a new task prompt and have not yet read `../roadmap/codex-console-continuation-brief.md`

--- a/docs/archive/future/README.md
+++ b/docs/archive/future/README.md
@@ -1,0 +1,5 @@
+# Archived Future Material
+
+Historical V2/V3 PRDs and engineering-evaluation files live here.
+
+Do not use these files as current product direction. For current continuation work, start with `../../roadmap/codex-console-continuation-brief.md`; for active future direction, use `../../future/multi-platform-core-prd.md` or `../../future/web-app-control-surface-sketch.md`.

--- a/docs/archive/future/v2-engineering-evaluation-template.md
+++ b/docs/archive/future/v2-engineering-evaluation-template.md
@@ -1,5 +1,7 @@
 # Telegram Codex Bridge V2 Engineering Evaluation Template
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: future direction, PM intent, or dated evaluation
@@ -8,7 +10,7 @@
 
 Status: Template
 For: Engineering evaluation response
-Related PRD: `docs/future/v2-prd.md`
+Related PRD: `docs/archive/future/v2-prd.md`
 Related v1 docs: `AGENTS.md`, `docs/product/v1-scope.md`, `docs/roadmap/phase-1-delivery.md`
 
 ---

--- a/docs/archive/future/v2-engineering-evaluation.md
+++ b/docs/archive/future/v2-engineering-evaluation.md
@@ -1,9 +1,11 @@
 # Telegram Codex Bridge V2 Engineering Evaluation
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 Status: Evaluated
 For: V2 engineering evaluation response
-Related PRD: `docs/future/v2-prd.md`
-Related template: `docs/future/v2-engineering-evaluation-template.md`
+Related PRD: `docs/archive/future/v2-prd.md`
+Related template: `docs/archive/future/v2-engineering-evaluation-template.md`
 Related v1 docs: `docs/product/v1-scope.md`, `docs/product/chat-and-project-flow.md`, `docs/architecture/runtime-and-state.md`, `docs/operations/install-and-admin.md`, `docs/research/app-server-phase-0-verification.md`
 
 > Truth status:
@@ -73,14 +75,14 @@ Engineering reviewed the requested sources plus current implementation evidence.
   - official pages fetched successfully on 2026-03-10 via `markdown.new` mirror because the direct browser capture was incomplete
 - Path note:
   - the user message referenced `docs/telegram-codex-bridge-v2-prd.md` and `docs/telegram-codex-bridge-v2-engineering-eval-template.md`
-  - in the current repo information architecture, the live future-scope sources are `docs/future/v2-prd.md`, `docs/future/v2-engineering-evaluation-template.md`, and this document at `docs/future/v2-engineering-evaluation.md`
+  - in the current repo information architecture, the live future-scope sources are `docs/archive/future/v2-prd.md`, `docs/archive/future/v2-engineering-evaluation-template.md`, and this document at `docs/archive/future/v2-engineering-evaluation.md`
 
 ### Evidence register
 
 | Evidence type | Link / path / command | Key finding |
 |---|---|---|
 | v1 planning baseline | `docs/archive/legacy-v1-engineering-plan-draft.md` | The earlier monolithic draft was retired; the split v1 docs preserve the same frozen trust boundary |
-| PRD | `docs/future/v2-prd.md` | Priority order is fixed: activity visibility > session management > platform/stability |
+| PRD | `docs/archive/future/v2-prd.md` | Priority order is fixed: activity visibility > session management > platform/stability |
 | current code | `src/service.ts`, `src/state/store.ts`, `src/install.ts`, `src/readiness.ts`, `src/telegram/ui.ts` | Current implementation is solid v1 infrastructure but still final-answer-centric |
 | tests | `npm test` on 2026-03-10 | 12/12 tests passed; current baseline is stable for evaluation |
 | protocol/schema | `docs/research/app-server-phase-0-verification.md`; `/tmp/codex-app-schema/json/codex_app_server_protocol.v2.schemas.json`; `/tmp/codex-app-ts/v2/` | Local runtime confirms legacy event mix and generated v2 schema exposes the richer event surface needed for V2 |

--- a/docs/archive/future/v2-prd.md
+++ b/docs/archive/future/v2-prd.md
@@ -1,5 +1,7 @@
 # Telegram Codex Bridge V2 PRD
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 Status: Draft for engineering evaluation
 Owner: Product
 Last updated: 2026-03-10
@@ -630,7 +632,7 @@ The following topics are explicitly deferred to V3 or later unless product re-op
 
 Current V3 follow-up document:
 
-- `docs/future/v3-prd.md`
+- `docs/archive/future/v3-prd.md`
 
 ---
 

--- a/docs/archive/future/v3-prd.md
+++ b/docs/archive/future/v3-prd.md
@@ -1,13 +1,15 @@
 # Telegram Codex Bridge V3 PRD
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 Status: Active direction; Phase 1 and Phase 2 baseline partially implemented
 Owner: Product
 Last updated: 2026-03-15
 Related docs:
-- `docs/future/v2-prd.md`
+- `docs/archive/future/v2-prd.md`
 - `docs/future/multi-platform-core-prd.md`
-- `docs/plans/2026-03-14-codex-cli-capability-alignment-design.md`
-- `docs/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md`
+- `docs/archive/plans/2026-03-14-codex-cli-capability-alignment-design.md`
+- `docs/archive/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md`
 
 > Truth status:
 > - Current truth? No
@@ -303,11 +305,11 @@ Engineering should return:
 
 The current engineering input document for this is:
 
-- `docs/plans/2026-03-14-codex-cli-capability-alignment-design.md`
+- `docs/archive/plans/2026-03-14-codex-cli-capability-alignment-design.md`
 
 The current implementation handoff for the first V3 build slice is:
 
-- `docs/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md`
+- `docs/archive/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md`
 
 ---
 

--- a/docs/archive/plans/2026-03-10-v2-2a-detailed-design.md
+++ b/docs/archive/plans/2026-03-10-v2-2a-detailed-design.md
@@ -1,5 +1,7 @@
 # Telegram Codex Bridge V2 Phase 2A Detailed Design
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history
@@ -19,9 +21,9 @@ Related documents:
   - `docs/operations/install-and-admin.md`
   - `docs/research/app-server-phase-0-verification.md`
 - Future-scope product/evaluation docs:
-  - `docs/future/v2-prd.md`
-  - `docs/future/v2-engineering-evaluation-template.md`
-  - `docs/future/v2-engineering-evaluation.md`
+  - `docs/archive/future/v2-prd.md`
+  - `docs/archive/future/v2-engineering-evaluation-template.md`
+  - `docs/archive/future/v2-engineering-evaluation.md`
 
 ---
 
@@ -60,8 +62,8 @@ Use the following path convention going forward:
 ### 2.2 Practical rule for references in this design
 
 To avoid more path drift in the current round:
-- treat `docs/future/v2-prd.md` as the only product source for V2 intent
-- treat `docs/future/v2-engineering-evaluation.md` as the current evaluated engineering output
+- treat `docs/archive/future/v2-prd.md` as the only product source for V2 intent
+- treat `docs/archive/future/v2-engineering-evaluation.md` as the current evaluated engineering output
 - place this 2A design under `docs/plans/`
 
 ### 2.3 Maintenance rule after this cleanup

--- a/docs/archive/plans/2026-03-10-v2-implementation-plan.md
+++ b/docs/archive/plans/2026-03-10-v2-implementation-plan.md
@@ -1,5 +1,7 @@
 # Telegram Codex Bridge V2 实施计划
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history
@@ -13,9 +15,9 @@
 
 相关文档：
 - 当前 v1 基线：`docs/product/v1-scope.md`、`docs/product/chat-and-project-flow.md`、`docs/architecture/runtime-and-state.md`、`docs/operations/install-and-admin.md`、`docs/research/app-server-phase-0-verification.md`
-- V2 PRD：`docs/future/v2-prd.md`
-- V2 工程评估：`docs/future/v2-engineering-evaluation.md`
-- 2A 详细设计：`docs/plans/2026-03-10-v2-2a-detailed-design.md`
+- V2 PRD：`docs/archive/future/v2-prd.md`
+- V2 工程评估：`docs/archive/future/v2-engineering-evaluation.md`
+- 2A 详细设计：`docs/archive/plans/2026-03-10-v2-2a-detailed-design.md`
 
 ---
 

--- a/docs/archive/plans/2026-03-13-final-answer-telegram-format-plan.md
+++ b/docs/archive/plans/2026-03-13-final-answer-telegram-format-plan.md
@@ -1,5 +1,7 @@
 # Final Answer Telegram Format Implementation Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history

--- a/docs/archive/plans/2026-03-13-thread-archive-reconciliation-plan.md
+++ b/docs/archive/plans/2026-03-13-thread-archive-reconciliation-plan.md
@@ -1,5 +1,7 @@
 # Thread Archive Reconciliation Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history

--- a/docs/archive/plans/2026-03-14-codex-cli-capability-alignment-design.md
+++ b/docs/archive/plans/2026-03-14-codex-cli-capability-alignment-design.md
@@ -1,5 +1,7 @@
 # V3 Codex CLI Capability Alignment Design
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history
@@ -14,9 +16,9 @@ Planning document with Phase 1 and Phase 2 baseline partially implemented as of 
 
 **Related docs**
 
-- `docs/future/v2-prd.md`
-- `docs/future/v3-prd.md`
-- `docs/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md`
+- `docs/archive/future/v2-prd.md`
+- `docs/archive/future/v3-prd.md`
+- `docs/archive/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md`
 
 **Goal**
 
@@ -33,7 +35,7 @@ This document is the engineering design input for V3, not V2.
 
 Reason:
 
-- `docs/future/v2-prd.md` explicitly keeps Telegram approval flow and similar major protocol-surface expansion out of V2 scope
+- `docs/archive/future/v2-prd.md` explicitly keeps Telegram approval flow and similar major protocol-surface expansion out of V2 scope
 - the capability gaps analyzed here are therefore a V3 planning concern
 
 **Target Boundary**
@@ -552,7 +554,7 @@ After this design document, the next implementation documents should be:
 
 Current first implementation plan:
 
-- `docs/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md`
+- `docs/archive/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md`
 
 Current main pending follow-up after the first implementation slice:
 

--- a/docs/archive/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md
+++ b/docs/archive/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md
@@ -1,5 +1,7 @@
 # V3 Interaction Broker And Blocked Turn Recovery Implementation Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history
@@ -878,16 +880,16 @@ git commit -m "feat: recover and inspect pending interactions"
 ## Task 10: Final Verification And V3 Doc Sync
 
 **Files:**
-- Modify: `docs/future/v3-prd.md`
-- Modify: `docs/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md`
-- Modify: `docs/plans/2026-03-14-codex-cli-capability-alignment-design.md`
+- Modify: `docs/archive/future/v3-prd.md`
+- Modify: `docs/archive/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md`
+- Modify: `docs/archive/plans/2026-03-14-codex-cli-capability-alignment-design.md`
 
 **Step 1: Update the docs**
 
 Add a short implementation-progress reference from:
 
-- `docs/future/v3-prd.md`
-- `docs/plans/2026-03-14-codex-cli-capability-alignment-design.md`
+- `docs/archive/future/v3-prd.md`
+- `docs/archive/plans/2026-03-14-codex-cli-capability-alignment-design.md`
 
 to this plan file.
 
@@ -935,7 +937,7 @@ Expected:
 **Step 5: Commit**
 
 ```bash
-git add src/codex/app-server.ts src/codex/app-server.test.ts src/interactions/normalize.ts src/interactions/normalize.test.ts src/state/store.ts src/state/store.test.ts src/types.ts src/telegram/ui.ts src/telegram/ui.test.ts src/service.ts src/service.test.ts docs/future/v3-prd.md docs/plans/2026-03-14-codex-cli-capability-alignment-design.md docs/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md
+git add src/codex/app-server.ts src/codex/app-server.test.ts src/interactions/normalize.ts src/interactions/normalize.test.ts src/state/store.ts src/state/store.test.ts src/types.ts src/telegram/ui.ts src/telegram/ui.test.ts src/service.ts src/service.test.ts docs/archive/future/v3-prd.md docs/archive/plans/2026-03-14-codex-cli-capability-alignment-design.md docs/archive/plans/2026-03-14-v3-interaction-broker-phase-1-2-implementation-plan.md
 git commit -m "feat: implement v3 interaction broker and blocked turn recovery"
 ```
 

--- a/docs/archive/plans/2026-03-16-telegram-runtime-card-rollback-voice-decisions.md
+++ b/docs/archive/plans/2026-03-16-telegram-runtime-card-rollback-voice-decisions.md
@@ -1,5 +1,7 @@
 # Telegram Runtime Card, Rollback, And Voice Decisions
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history

--- a/docs/archive/plans/2026-03-17-plan-mode-runtime-design.md
+++ b/docs/archive/plans/2026-03-17-plan-mode-runtime-design.md
@@ -1,5 +1,7 @@
 # Plan Mode Toggle And Runtime Card Design
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history

--- a/docs/archive/plans/2026-03-17-plan-mode-runtime-implementation.md
+++ b/docs/archive/plans/2026-03-17-plan-mode-runtime-implementation.md
@@ -1,5 +1,7 @@
 # Plan Mode Toggle And Runtime Card Implementation Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history

--- a/docs/archive/plans/2026-03-17-telegram-runtime-v4.5-design.md
+++ b/docs/archive/plans/2026-03-17-telegram-runtime-v4.5-design.md
@@ -1,5 +1,7 @@
 # Telegram Runtime V4.5 Design
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history
@@ -16,8 +18,8 @@ Approved design capturing the current discussion decisions. This is a planning d
 
 - `docs/architecture/runtime-and-state.md`
 - `docs/product/chat-and-project-flow.md`
-- `docs/plans/2026-03-16-telegram-runtime-card-rollback-voice-decisions.md`
-- `docs/plans/2026-03-17-plan-mode-runtime-design.md`
+- `docs/archive/plans/2026-03-16-telegram-runtime-card-rollback-voice-decisions.md`
+- `docs/archive/plans/2026-03-17-plan-mode-runtime-design.md`
 
 ## 1. Purpose
 

--- a/docs/archive/plans/2026-03-18-v5-5-post-v5-slimming-plan.md
+++ b/docs/archive/plans/2026-03-18-v5-5-post-v5-slimming-plan.md
@@ -1,5 +1,7 @@
 # V5.5 Post-V5 Slimming Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history

--- a/docs/archive/plans/2026-03-18-v5-project-slimming-plan.md
+++ b/docs/archive/plans/2026-03-18-v5-project-slimming-plan.md
@@ -1,5 +1,7 @@
 # V5 Project Slimming Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history
@@ -9,7 +11,7 @@
 > Planning document with verified implementation status as of 2026-03-18.
 > This file is not a current-behavior spec.
 > It is the verified V5 execution tracker and closeout guide.
-> V5 is now closed; deferred follow-up work moved to `docs/plans/2026-03-18-v5-5-post-v5-slimming-plan.md`.
+> V5 is now closed; deferred follow-up work moved to `docs/archive/plans/2026-03-18-v5-5-post-v5-slimming-plan.md`.
 
 ## Verification Basis
 

--- a/docs/archive/plans/2026-03-20-project-picker-single-instance-design.md
+++ b/docs/archive/plans/2026-03-20-project-picker-single-instance-design.md
@@ -1,5 +1,7 @@
 # Project Picker Single-Instance Design
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history

--- a/docs/archive/plans/2026-03-20-project-picker-single-instance-implementation.md
+++ b/docs/archive/plans/2026-03-20-project-picker-single-instance-implementation.md
@@ -1,5 +1,7 @@
 # Project Picker Single-Instance Implementation Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history
@@ -20,7 +22,7 @@
 
 **Files:**
 - Modify: `docs/product/chat-and-project-flow.md`
-- Reference: `docs/plans/2026-03-20-project-picker-single-instance-design.md`
+- Reference: `docs/archive/plans/2026-03-20-project-picker-single-instance-design.md`
 
 **Step 1: Write the failing doc expectation**
 
@@ -48,7 +50,7 @@ Expected: the updated sections mention recreating a fresh picker and keeping one
 **Step 5: Commit**
 
 ```bash
-git add docs/product/chat-and-project-flow.md docs/plans/2026-03-20-project-picker-single-instance-design.md
+git add docs/product/chat-and-project-flow.md docs/archive/plans/2026-03-20-project-picker-single-instance-design.md
 git commit -m "docs: define single-instance project picker lifecycle"
 ```
 

--- a/docs/archive/plans/2026-03-21-review-final-answer-recovery-plan.md
+++ b/docs/archive/plans/2026-03-21-review-final-answer-recovery-plan.md
@@ -1,5 +1,7 @@
 # Review Final Answer Recovery Implementation Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Ensure `/review` always delivers the actual review result to Telegram instead of the fallback "no final answer" message.

--- a/docs/archive/plans/2026-03-21-runtime-hub-refresh-command-plan.md
+++ b/docs/archive/plans/2026-03-21-runtime-hub-refresh-command-plan.md
@@ -1,5 +1,7 @@
 # Runtime Hub Refresh Command Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation scope, product rules, and handoff for the `/hub` runtime-surface refresh flow
@@ -10,7 +12,7 @@
 Planned. This document captures the agreed direction for making runtime-hub access simpler and less disruptive in Telegram chats.
 
 Follow-up changes for immediate accepted-user-work reanchor and `/hub` handoff hints on interaction surfaces are tracked in:
-- `docs/plans/2026-03-21-runtime-hub-reuse-refresh-cap-archive-plan.md`
+- `docs/archive/plans/2026-03-21-runtime-hub-reuse-refresh-cap-archive-plan.md`
 
 ## Problem
 

--- a/docs/archive/plans/2026-03-21-runtime-hub-reuse-refresh-cap-archive-plan.md
+++ b/docs/archive/plans/2026-03-21-runtime-hub-reuse-refresh-cap-archive-plan.md
@@ -1,5 +1,7 @@
 # Runtime Hub Reuse, Immediate Refresh, And Archive Lifecycle Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation scope, source-change handoff, and doc follow-up for the next hub UX adjustment
@@ -16,8 +18,8 @@ Current product docs and current code now outrank this plan for shipped behavior
 
 This follow-up intentionally changes parts of two older task plans:
 
-- `docs/plans/2026-03-21-runtime-hub-slot-model-implementation-plan.md`
-- `docs/plans/2026-03-21-runtime-hub-refresh-command-plan.md`
+- `docs/archive/plans/2026-03-21-runtime-hub-slot-model-implementation-plan.md`
+- `docs/archive/plans/2026-03-21-runtime-hub-refresh-command-plan.md`
 
 What changes from those older plans:
 

--- a/docs/archive/plans/2026-03-21-runtime-hub-slot-model-implementation-plan.md
+++ b/docs/archive/plans/2026-03-21-runtime-hub-slot-model-implementation-plan.md
@@ -1,5 +1,7 @@
 # Runtime Hub Slot-Model Implementation Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > Truth status:
 > - Current truth? No
 > - Use for: implementation rationale, sequencing, and handoff history for the runtime-hub slot model
@@ -11,7 +13,7 @@
 Implemented later and retained as historical planning context. This document captures the runtime-hub redesign agreed for the hub-card optimization discussion on 2026-03-21.
 
 Follow-up changes to latest-hub reuse, middle-hole admission after archive removal, live-hub cap/eviction, and archive/unarchive hub lifecycle are tracked in:
-- `docs/plans/2026-03-21-runtime-hub-reuse-refresh-cap-archive-plan.md`
+- `docs/archive/plans/2026-03-21-runtime-hub-reuse-refresh-cap-archive-plan.md`
 
 ## Problem
 

--- a/docs/archive/plans/2026-03-22-systemd-service-audit-implementation.md
+++ b/docs/archive/plans/2026-03-22-systemd-service-audit-implementation.md
@@ -1,5 +1,7 @@
 # Systemd Service Audit Implementation Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Capture actionable Linux/systemd stop diagnostics so the next bridge outage clearly shows whether the service was stopped intentionally, failed, received a signal, or was terminated by resource pressure.

--- a/docs/archive/plans/2026-03-23-performance-monitoring-plan.md
+++ b/docs/archive/plans/2026-03-23-performance-monitoring-plan.md
@@ -1,5 +1,7 @@
 # Performance Monitoring Tool Implementation Plan
 
+> Archived material: historical reconstruction only. Do not treat this file as current truth or an executable task prompt. Start from current docs or `docs/roadmap/codex-console-continuation-brief.md` instead.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Add a Linux-first, low-overhead, always-on performance monitoring tool to `telegram-codex-bridge` that records bridge and `codex app-server` performance data and exposes recent summaries through the CLI.

--- a/docs/archive/plans/README.md
+++ b/docs/archive/plans/README.md
@@ -1,0 +1,5 @@
+# Archived Plan Material
+
+Closed March implementation plans live here for historical reconstruction only.
+
+Do not use these files as active task prompts. For current continuation work, start with `../../roadmap/codex-console-continuation-brief.md`; for active/recent plans, use `../../plans/README.md`.

--- a/docs/catalog.yaml
+++ b/docs/catalog.yaml
@@ -170,6 +170,11 @@ documents:
     layer: 3
     parent: docs/future/README.md
     summary: future product direction for Codex Console and Codex Bridge Core with Telegram as the stable first pack
+  - path: docs/future/web-app-control-surface-sketch.md
+    role: leaf
+    layer: 3
+    parent: docs/future/README.md
+    summary: future design sketch for a richer Web/App Codex Console control surface powered by Codex Bridge Core
   - path: docs/plans/2026-03-23-multi-platform-core-phase-1-implementation-plan.md
     role: leaf
     layer: 3

--- a/docs/catalog.yaml
+++ b/docs/catalog.yaml
@@ -59,7 +59,7 @@ documents:
     role: domain
     layer: 2
     parent: docs/INDEX.md
-    summary: router for install, configuration, service management, update, and diagnostics docs
+    summary: router for install, active-pack selection, configuration, service management, update, and diagnostics docs
   - path: docs/research/README.md
     role: domain
     layer: 2
@@ -144,7 +144,7 @@ documents:
     role: leaf
     layer: 3
     parent: docs/operations/README.md
-    summary: current install, config, service-management, pack selection, update, and diagnostics contract for operators
+    summary: current install, config, service-management, active-pack selection, update, and diagnostics contract for operators
   - path: docs/generated/current-snapshot.md
     role: leaf
     layer: 2

--- a/docs/catalog.yaml
+++ b/docs/catalog.yaml
@@ -4,7 +4,7 @@ documents:
     role: entry
     layer: 1
     parent: null
-    summary: public repository entry point for the Telegram-first bridge and its documentation trees
+    summary: public repository entry point for Codex Console and its documentation trees
   - path: AGENTS.md
     role: agent
     layer: 1
@@ -44,12 +44,12 @@ documents:
     role: domain
     layer: 2
     parent: docs/INDEX.md
-    summary: router for current Telegram-first product behavior and user-facing command surfaces
+    summary: router for current Codex Console product behavior, Telegram-first baseline, and user-facing command surfaces
   - path: docs/architecture/README.md
     role: domain
     layer: 2
     parent: docs/INDEX.md
-    summary: router for the current runtime shape, decoupling status, state model, verified code ownership map, pack boundary, and app-server adoption boundary
+    summary: router for the current runtime shape, decoupling status, state model, capability matrix, pack boundary, and app-server adoption boundary
   - path: docs/architecture/platform-decoupling-status.md
     role: leaf
     layer: 3
@@ -105,11 +105,16 @@ documents:
     layer: 3
     parent: docs/architecture/README.md
     summary: current pack boundary for active-pack selection, runtime factory ownership, platform capabilities, and Telegram vs Feishu split
+  - path: docs/architecture/platform-capability-matrix.md
+    role: leaf
+    layer: 3
+    parent: docs/architecture/README.md
+    summary: current Telegram and Feishu capability matrix, common product expectations, platform-specific features, and future Web/App target rows
   - path: docs/product/v1-scope.md
     role: leaf
     layer: 3
     parent: docs/product/README.md
-    summary: current shipped v1 scope, trust model, and out-of-scope boundary for the Telegram-first bridge
+    summary: current shipped v1 scope, trust model, and out-of-scope boundary for Codex Console's Telegram-first baseline
   - path: docs/product/chat-and-project-flow.md
     role: leaf
     layer: 3
@@ -164,7 +169,7 @@ documents:
     role: leaf
     layer: 3
     parent: docs/future/README.md
-    summary: future repository direction for a broader platform-neutral Core with Telegram as the first official pack
+    summary: future product direction for Codex Console and Codex Bridge Core with Telegram as the stable first pack
   - path: docs/plans/2026-03-23-multi-platform-core-phase-1-implementation-plan.md
     role: leaf
     layer: 3

--- a/docs/catalog.yaml
+++ b/docs/catalog.yaml
@@ -14,7 +14,7 @@ documents:
     role: entry
     layer: 1
     parent: null
-    summary: canonical documentation router that separates current truth, protocol evidence, and future or historical context
+    summary: canonical docs router with active continuation, current truth, protocol evidence, future/planning, and archive tiers
   - path: docs/README.md
     role: entry
     layer: 1
@@ -40,6 +40,11 @@ documents:
     layer: 2
     parent: AGENTS.md
     summary: local router for bundled Codex skills
+  - path: docs/roadmap/codex-console-continuation-brief.md
+    role: leaf
+    layer: 3
+    parent: docs/roadmap/README.md
+    summary: active low-context handoff for future Codex Console / multi-platform bridge continuation tasks and archive/noise decisions
   - path: docs/product/README.md
     role: domain
     layer: 2
@@ -49,12 +54,7 @@ documents:
     role: domain
     layer: 2
     parent: docs/INDEX.md
-    summary: router for the current runtime shape, decoupling status, state model, capability matrix, pack boundary, and app-server adoption boundary
-  - path: docs/architecture/platform-decoupling-status.md
-    role: leaf
-    layer: 3
-    parent: docs/architecture/README.md
-    summary: current bridge-versus-platform decoupling status, including what has landed, what remains Telegram-shaped, and which gaps are still real
+    summary: router for current runtime shape, decoupling status, state model, pack boundary, capability matrix, and app-server adoption boundary
   - path: docs/operations/README.md
     role: domain
     layer: 2
@@ -79,12 +79,17 @@ documents:
     role: domain
     layer: 2
     parent: docs/INDEX.md
-    summary: router for delivery ordering and acceptance-intent docs
+    summary: router for delivery ordering, continuation handoff, and acceptance intent
   - path: docs/archive/README.md
     role: domain
     layer: 2
     parent: docs/INDEX.md
     summary: router for archived historical material kept for reconstruction only
+  - path: docs/architecture/platform-decoupling-status.md
+    role: leaf
+    layer: 3
+    parent: docs/architecture/README.md
+    summary: current bridge-versus-platform decoupling status, including what has landed and what remains Telegram-shaped
   - path: docs/architecture/runtime-and-state.md
     role: leaf
     layer: 3
@@ -99,7 +104,7 @@ documents:
     role: leaf
     layer: 3
     parent: docs/architecture/README.md
-    summary: current bridge-owned Codex app-server adoption boundary, including lifecycle, request families, server requests, and notification reduction
+    summary: current bridge-owned Codex app-server adoption boundary, request families, server requests, and notification reduction
   - path: docs/architecture/platform-pack-boundary.md
     role: leaf
     layer: 3
@@ -109,7 +114,7 @@ documents:
     role: leaf
     layer: 3
     parent: docs/architecture/README.md
-    summary: current Telegram and Feishu capability matrix, common product expectations, platform-specific features, and future Web/App target rows
+    summary: current Telegram and Feishu capability matrix, common expectations, platform-specific features, and future Web/App target rows
   - path: docs/product/v1-scope.md
     role: leaf
     layer: 3
@@ -159,12 +164,12 @@ documents:
     role: leaf
     layer: 3
     parent: docs/research/README.md
-    summary: per-method quick reference for Codex app-server requests, notifications, and server-request gotchas on the current host baseline
+    summary: per-method quick reference for Codex app-server requests, notifications, and server-request gotchas
   - path: docs/research/app-server-phase-0-verification.md
     role: leaf
     layer: 3
     parent: docs/research/README.md
-    summary: dated phase-0 runtime verification sample for codex-cli 0.112.0, kept as historical protocol evidence only
+    summary: dated phase-0 runtime verification sample kept as historical protocol evidence only
   - path: docs/future/multi-platform-core-prd.md
     role: leaf
     layer: 3
@@ -175,6 +180,46 @@ documents:
     layer: 3
     parent: docs/future/README.md
     summary: future design sketch for a richer Web/App Codex Console control surface powered by Codex Bridge Core
+  - path: docs/plans/2026-04-26-codex-console-phase2-release-note.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: PR-ready Phase 2 closeout note with commits, user-visible impact, known gaps, and verification commands
+  - path: docs/plans/2026-04-26-codex-console-phase2-plan.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: five-phase plan for install-path docs, Feishu audit, metadata cleanup, Web/App sketch, and release note
+  - path: docs/plans/2026-04-26-feishu-official-capability-audit.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: official Feishu API backed capability audit and live-smoke checklist
+  - path: docs/plans/2026-04-09-feishu-pack-setup-capability-and-hardening-plan.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: Feishu setup and hardening backlog for validation, binding, callbacks, and readiness
+  - path: docs/plans/2026-04-08-multi-platform-core-and-feishu-implementation-plan.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: four-phase implementation plan that completed platform abstraction and landed Feishu as the second platform
+  - path: docs/plans/2026-03-30-binding-model-neutralization-note.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: design note for neutralizing Telegram-first auth and session binding fields without overclaiming support
+  - path: docs/plans/2026-03-30-platform-binding-boundary-design.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: design note for platform principal, surface target, and bridge session ownership boundaries
+  - path: docs/plans/2026-03-30-platform-surface-adapter-and-capability-prep.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: predesign note for platform surface adapter boundaries and capability vocabulary
   - path: docs/plans/2026-03-23-multi-platform-core-phase-1-implementation-plan.md
     role: leaf
     layer: 3
@@ -184,29 +229,14 @@ documents:
     role: leaf
     layer: 3
     parent: docs/plans/README.md
-    summary: historical Phase-1 deferred-work baseline for multi-platform Core sequencing, kept as planning context rather than current status truth
-  - path: docs/plans/2026-04-08-multi-platform-core-and-feishu-implementation-plan.md
-    role: leaf
+    summary: Phase-1 deferred-work baseline kept as sequencing context rather than current status truth
+  - path: docs/archive/future/README.md
+    role: archive
     layer: 3
-    parent: docs/plans/README.md
-    summary: executable four-phase implementation plan that completes platform abstraction by Phase 3 and lands Feishu as the second platform in Phase 4
-  - path: docs/plans/2026-04-09-feishu-pack-setup-capability-and-hardening-plan.md
-    role: leaf
+    parent: docs/archive/README.md
+    summary: local index for superseded V2/V3 future PRDs and engineering evaluations; historical reconstruction only
+  - path: docs/archive/plans/README.md
+    role: archive
     layer: 3
-    parent: docs/plans/README.md
-    summary: capability definition and hardening backlog for making Feishu pack setup, validation, binding, and callback readiness work as one operator-safe flow
-  - path: docs/plans/2026-03-30-binding-model-neutralization-note.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: narrow design note for neutralizing the Telegram-first auth and session binding model without claiming multi-platform support
-  - path: docs/plans/2026-03-30-platform-binding-boundary-design.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: design note for stabilizing the platform binding boundary after auth and persistence neutralization work landed
-  - path: docs/plans/2026-03-30-platform-surface-adapter-and-capability-prep.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: narrow predesign note for the next layer after binding neutralization, defining a platform surface adapter boundary and capability vocabulary
+    parent: docs/archive/README.md
+    summary: local index for closed March implementation plans removed from active agent routing; historical reconstruction only

--- a/docs/future/README.md
+++ b/docs/future/README.md
@@ -4,6 +4,7 @@ layer: 2
 parent: docs/INDEX.md
 children:
   - docs/future/multi-platform-core-prd.md
+  - docs/future/web-app-control-surface-sketch.md
 summary: router for future Codex Console product direction and Codex Bridge Core architecture intent
 read_when:
   - the request is about future product direction rather than current shipped behavior
@@ -24,6 +25,7 @@ It does not override current truth: Codex Console is Telegram-first by default p
 ## Open One Leaf
 
 - `multi-platform-core-prd.md` - product and architecture direction for Codex Console powered by Codex Bridge Core, with Telegram as the stable first pack and Feishu as a serious current pack.
+- `web-app-control-surface-sketch.md` - future design sketch for a richer Web/App control surface that reuses Codex Bridge Core without claiming current Web/App support.
 
 ## Related Future Docs
 

--- a/docs/future/README.md
+++ b/docs/future/README.md
@@ -4,10 +4,10 @@ layer: 2
 parent: docs/INDEX.md
 children:
   - docs/future/multi-platform-core-prd.md
-summary: router for future repository direction and forward-looking product or architecture intent
+summary: router for future Codex Console product direction and Codex Bridge Core architecture intent
 read_when:
   - the request is about future product direction rather than current shipped behavior
-  - the request is about the broader multi-platform Core direction
+  - the request is about the broader Codex Bridge Core direction
 skip_when:
   - the request is about current Telegram-first behavior or current code ownership
 source_of_truth:
@@ -19,11 +19,11 @@ source_of_truth:
 # Future Index
 
 Use this directory for future direction only.
-It does not override current Telegram-first truth.
+It does not override current truth: Codex Console is Telegram-first by default path, Feishu is a serious current pack, and broad multi-platform maturity is not yet claimed.
 
 ## Open One Leaf
 
-- `multi-platform-core-prd.md` - repository-level direction for a broader platform-neutral Core with Telegram as the first pack.
+- `multi-platform-core-prd.md` - product and architecture direction for Codex Console powered by Codex Bridge Core, with Telegram as the stable first pack and Feishu as a serious current pack.
 
 ## Related Future Docs
 

--- a/docs/future/README.md
+++ b/docs/future/README.md
@@ -14,7 +14,7 @@ skip_when:
 source_of_truth:
   - docs/future/README.md
   - docs/future/multi-platform-core-prd.md
-  - docs/future
+  - docs/future/web-app-control-surface-sketch.md
 -->
 
 # Future Index
@@ -27,10 +27,9 @@ It does not override current truth: Codex Console is Telegram-first by default p
 - `multi-platform-core-prd.md` - product and architecture direction for Codex Console powered by Codex Bridge Core, with Telegram as the stable first pack and Feishu as a serious current pack.
 - `web-app-control-surface-sketch.md` - future design sketch for a richer Web/App control surface that reuses Codex Bridge Core without claiming current Web/App support.
 
-## Related Future Docs
+## Archived Future Material
 
-- `v3-prd.md` - Telegram-facing future track inside the broader Core direction.
-- `v2-prd.md`, `v2-engineering-evaluation.md`, and `v2-engineering-evaluation-template.md` - older future tracks and evaluation material.
+Older V2/V3 PRDs and engineering-evaluation files moved to `docs/archive/future/`. Do not read them for current continuation work unless reconstructing history.
 
 ## Skip This Directory When
 

--- a/docs/future/multi-platform-core-prd.md
+++ b/docs/future/multi-platform-core-prd.md
@@ -3,7 +3,7 @@ role: leaf
 layer: 3
 parent: docs/future/README.md
 children: []
-summary: future repository direction for a broader platform-neutral Core with Telegram as the first official pack
+summary: future product direction for Codex Console and Codex Bridge Core with Telegram as the stable first pack
 read_when:
   - the request is about the future multi-platform direction of the repository
   - the request needs the target split between Core, presentation, capability, and packs
@@ -13,53 +13,65 @@ source_of_truth:
   - docs/future/multi-platform-core-prd.md
   - docs/product/v1-scope.md
   - docs/architecture/runtime-and-state.md
+  - docs/architecture/platform-capability-matrix.md
   - src/core
 -->
 
-# Multi-Platform Codex Bridge Core PRD
+# Codex Console And Codex Bridge Core PRD
 
 Status: Active future direction
 Owner: Product / Architecture
-Last updated: 2026-03-23
+Last updated: 2026-04-25
 
-Current truth remains Telegram-first.
-This file describes where the repository should go next, not what it ships today.
+Naming policy:
+
+- external product name: **Codex Console**
+- internal architecture name: **Codex Bridge Core**
+- repository/package compatibility name: `telegram-codex-bridge`
+- stable first platform pack: Telegram
+- serious current platform pack: Feishu
+
+Current truth remains Telegram-first by history and default install path, with current pack-aware Telegram and Feishu support.
+This file describes product and architecture direction, not proof that every surface is fully platform-neutral today.
 
 ## What This Covers
 
 This document answers three questions:
 
-- what the repository should become beyond the current Telegram bridge
+- what Codex Console should become beyond the current Telegram-first bridge history
 - which responsibilities belong in a shared Core versus platform-specific packs
-- how to grow beyond Telegram without pretending the current product is already multi-platform
+- how to grow beyond Telegram and Feishu without pretending broad multi-platform maturity is already solved
 
-## Current Baseline On 2026-03-23
+## Current Baseline On 2026-04-25
 
-Today the shipped product is still:
+Today the implementation is still:
 
-- a single-user Telegram control surface
+- single-user and high-trust by default
+- Telegram-first in its top-level service history and default setup path
+- pack-aware for Telegram and Feishu
 - one local long-lived `codex app-server` child over `stdio`
 - one SQLite state store
-- a runtime, interaction, and final-answer UX shaped around Telegram concepts
+- runtime, interaction, and final-answer flows that still contain Telegram-shaped concepts
 
 Important nuance:
 
 - the protocol wrapper already exposes a broader surface than Telegram currently uses
 - the first internal `Domain + Workflow + Interaction Model` seam has landed under `src/core/`
-- that seam is useful groundwork, but it is not yet a platform-neutral product core
+- a current pack boundary exists for Telegram and Feishu
+- those seams are useful and real, but not yet a fully platform-neutral product core
 
 ## Product Goal
 
-The repository should evolve from:
+The product should read externally as:
 
-- a Telegram bridge for Codex
+- **Codex Console**: a self-hosted chat control surface for the Codex installation already running on the operator's machine
 
-to:
+The architecture should evolve internally as:
 
 - a **Codex Bridge Core** that can power multiple control surfaces, with Telegram as the first official platform pack
 
 The point is shared semantics, not forced UX parity.
-Slack, Discord, Telegram, and a future Web or App console can look different while still sharing the same session, turn, interaction, runtime, and final-answer meaning.
+Telegram, Feishu, future chat packs, and a future Web or App console can look different while still sharing the same session, turn, interaction, runtime, and final-answer meaning.
 
 ## Selected Future Model
 
@@ -68,7 +80,7 @@ Slack, Discord, Telegram, and a future Web or App console can look different whi
 | Domain | bridge session, turn, pending interaction, runtime notice, final-answer view, project-selection context | Telegram message ids or transport formatting |
 | Workflow | start or resume session, start turn, continue blocked turn, approvals, questionnaires, runtime reduction, finalization, recovery | concrete platform rendering |
 | Interaction Model | picker, approval, questionnaire, paginated view, runtime panel, final-answer preview, recovery notice | Telegram button layouts or callback payloads |
-| Capability | whether a platform supports buttons, edits, uploads, previews, or long-form pagination | business workflow decisions |
+| Capability | whether a platform can support buttons, edits, uploads, previews, or long-form pagination | business workflow decisions |
 | Presentation | Telegram, Slack, Discord, Web, or App rendering | Core workflow ownership |
 | Pack And Skill | transport glue, auth, ingress, egress, install, repair, upgrade, verification | shared product semantics that multiple platforms need |
 
@@ -76,7 +88,8 @@ Slack, Discord, Telegram, and a future Web or App console can look different whi
 
 Telegram remains:
 
-- the current shipped product surface
+- the stable first product surface
+- the default install path
 - the first official platform pack
 - the reference surface for rich remote-control UX
 
@@ -85,6 +98,26 @@ Telegram should not remain:
 - the long-term repository boundary
 - the hidden default architecture for every future surface
 - the place where shared bridge semantics are invented first
+
+## Relationship To Feishu
+
+Feishu is:
+
+- a serious current platform pack
+- evidence that pack-aware runtime and setup boundaries are real
+- a second surface with its own constraints, not a clone of Telegram UX
+
+Feishu is not:
+
+- proof that broad multi-platform production maturity is complete
+- a reason to erase the remaining Telegram-shaped service shell from current-truth docs
+- a reason to force all future packs into Telegram or Feishu interaction patterns
+
+## Capability Matrix
+
+Use `../architecture/platform-capability-matrix.md` as the current planning table for Telegram, Feishu, and future Web/App target rows.
+It translates implementation-level capability fields into owner-facing product expectations, UX richness tiers, ingress/egress rows, readiness levels, and new-platform decision rules.
+Do not use the matrix to claim broad multi-platform maturity; use it to keep Core semantics and platform-specific affordances separated.
 
 ## Relationship To Skills
 
@@ -107,25 +140,29 @@ Skills should not become:
 In scope for this direction:
 
 - a platform-neutral bridge architecture
-- Telegram as the first explicit pack
+- Codex Console as the external product name
+- Codex Bridge Core as the internal shared architecture name
+- Telegram as the stable first explicit pack
+- Feishu as a serious current pack
 - future chat-platform packs
 - a future Web or App console
 - skill-driven distribution for packs
 
 Out of scope for this direction:
 
-- claiming current multi-platform support
+- claiming broad multi-platform production maturity
 - changing shipped Telegram behavior by documentation alone
 - forcing identical UX across every platform
 - renaming the repository, package, or CLI in this docs phase
 - turning skills into the runtime architecture
 
-## Milestone Read As Of 2026-03-23
+## Milestone Read As Of 2026-04-25
 
 1. Document the future Core direction without rewriting current truth: complete.
 2. Separate platform-neutral workflow and interaction concepts from Telegram-owned delivery concepts: started and materially landed.
-3. Make Telegram the first explicit platform pack: future work.
-4. Add a second pack or a Web/App console after the Core boundary holds: future work.
+3. Make Telegram the first explicit platform pack: materially landed in the current pack boundary.
+4. Add Feishu as a serious current platform pack: materially landed, while hardening remains tracked separately.
+5. Add more packs or a Web/App console only after the Core boundary holds.
 
 ## Success Checks
 

--- a/docs/future/multi-platform-core-prd.md
+++ b/docs/future/multi-platform-core-prd.md
@@ -119,6 +119,8 @@ Use `../architecture/platform-capability-matrix.md` as the current planning tabl
 It translates implementation-level capability fields into owner-facing product expectations, UX richness tiers, ingress/egress rows, readiness levels, and new-platform decision rules.
 Do not use the matrix to claim broad multi-platform maturity; use it to keep Core semantics and platform-specific affordances separated.
 
+For a narrower future Web/App integration sketch, use `web-app-control-surface-sketch.md`. It describes how a richer native surface could reuse Core semantics through dashboards, panels, forms, live transport, media flows, readiness gates, and setup/admin pages without becoming a fake chat pack or claiming current support.
+
 ## Relationship To Skills
 
 Skills should handle:

--- a/docs/future/web-app-control-surface-sketch.md
+++ b/docs/future/web-app-control-surface-sketch.md
@@ -1,0 +1,207 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/future/README.md
+children: []
+summary: future design sketch for a richer Web/App Codex Console control surface powered by Codex Bridge Core
+read_when:
+  - the request is about a future Web or App control surface for Codex Console
+  - the request needs Web/App-specific Core, Presentation, Pack, readiness, or sequencing implications
+skip_when:
+  - the request is about current Telegram or Feishu shipped behavior
+  - the request is asking for Web/App implementation details or source code
+source_of_truth:
+  - docs/future/web-app-control-surface-sketch.md
+  - docs/future/multi-platform-core-prd.md
+  - docs/architecture/platform-capability-matrix.md
+-->
+
+# Web/App Control Surface Sketch
+
+Status: Future design sketch, not implementation commitment
+Owner: Product / Architecture
+Last updated: 2026-04-26
+
+This sketch describes how a future Web or App surface for **Codex Console** could use
+**Codex Bridge Core** without becoming a fake chat pack. It is forward-looking only:
+Telegram remains the stable/default pack, Feishu is a serious current pack, and Web/App
+support is not claimed by this document.
+
+## Goal
+
+Define a Web/App control surface direction that:
+
+- reuses shared Core semantics for projects, sessions, turns, interactions, runtime state,
+  final answers, artifacts, and delivery outcomes
+- presents those semantics through native Web/App affordances such as dashboards, panels,
+  forms, modals, durable history, file pickers, uploads, and live updates
+- keeps platform-specific transport, credentials, layout, browser/app storage, and notification
+  behavior out of Core
+- makes readiness measurable before any user-facing claim that Web/App is supported
+
+## Non-Goals
+
+This sketch does not:
+
+- implement Web/App source code, routes, components, API handlers, or transport
+- claim current Web/App product support
+- replace Telegram or Feishu as current packs
+- copy Telegram chat UX into a browser or app shell
+- expand scope into multi-user collaboration, provider setup, raw terminal access, project write
+  operations, or team permissions unless those are chosen as explicit future decisions
+- make browser, desktop, and mobile app packaging decisions
+
+## Core Reuse Target
+
+A Web/App surface should call into the same product meaning used by current packs, not fork
+workflow logic behind a richer UI.
+
+| Shared meaning | Web/App reuse target |
+|---|---|
+| Project/session lifecycle | Show active project and session, start/resume/switch sessions, expose empty/error states, and keep a durable session timeline. |
+| Turn lifecycle | Start a turn, continue a blocked turn, interrupt safely, and render queued/running/blocked/done/failed transitions. |
+| Interactions | Render approvals, questions, pickers, and structured prompts as forms or modals with resolved/expired/failed states. |
+| Runtime visibility | Show status, progress, recent output, inspect detail, and health in panels rather than transient chat messages. |
+| Final answers and artifacts | Preserve final answers separately from progress, attach generated files/images where available, and provide history/search/navigation. |
+| Delivery outcomes | Represent sent, updated, deferred, failed, rate-limited, and degraded delivery without hiding partial results. |
+| Media and attachments | Normalize user-supplied images/files/audio descriptors before Core workflow use, while leaving upload/download handles platform-owned. |
+| Auth, binding, readiness | Bind one authorized operator/control surface, report ready/awaiting/unhealthy, and separate declared/configured/observed/UX-exposed readiness. |
+
+## Core, State, And API Surfaces To Expose Or Stabilize
+
+Before Web/App can be considered more than a prototype, these surfaces need explicit contracts.
+They may be internal APIs first; the point is stable ownership, not public network API shape.
+
+1. **Project/session surface**
+   - list selectable projects and recent sessions
+   - read active project/session and session metadata
+   - start, resume, switch, archive/unarchive, rename, and pin where the product supports it
+   - distinguish read-only browse/history from future project write operations
+
+2. **Turn lifecycle surface**
+   - submit a new text or structured task
+   - continue a blocked turn with a validated interaction response
+   - interrupt/stop an active turn
+   - expose canonical state transitions and timestamps
+
+3. **Runtime status surface**
+   - expose running, blocked, idle, degraded, unhealthy, failed, and recovered states
+   - provide compact status for badges and detailed status for panels
+   - avoid requiring chat-message ids to understand runtime progress
+
+4. **Interaction surface**
+   - describe approvals, questions, selections, pagination, and recovery notices as neutral models
+   - include expiry, stale-response, duplicate-response, and failure outcomes
+   - let Presentation choose forms, modals, drawers, or inline panels
+
+5. **Artifacts and final-answer surface**
+   - separate final answer, transient progress, logs/recent output, generated artifacts, and file references
+   - support long-form rendering without chat splitting as the primary UX
+   - expose downloadable or previewable artifacts through platform-owned media handles
+
+6. **Delivery and degraded-outcome surface**
+   - return delivery results that distinguish created, updated, deferred, failed, partially delivered,
+     rate-limited, and fallback-to-file/page outcomes
+   - keep degraded outcomes visible in the UI instead of silently failing or truncating
+
+7. **Media and attachment surface**
+   - accept normalized attachment descriptors for images, files, and future audio/remote URLs
+   - keep local temp paths, platform resource ids, upload tokens, and download URLs out of shared Core meaning
+   - provide size/type/readiness validation before a turn begins
+
+8. **Auth, binding, and readiness surface**
+   - bind the authorized operator/control surface without assuming Telegram chat ids or Feishu tenant ids
+   - expose readiness levels: static declared, configured, observed, and UX-exposed
+   - report setup gaps and health checks in terms a Web/App admin page can render
+
+## Pack And Presentation Responsibilities
+
+Web/App should be a richer native surface. The Pack/Presentation layer owns how Core state is
+reached, rendered, and delivered.
+
+| Area | Web/App responsibility |
+|---|---|
+| Routes | Define pages for dashboard, projects, sessions, runtime, interactions, artifacts, settings, and setup. |
+| Dashboards/panels | Render active session, running turn, blocked interactions, recent output, inspect/status detail, and degraded notices. |
+| Forms/modals | Collect approvals, questionnaire answers, project/session choices, setup inputs, and destructive-action confirmations. |
+| Live transport | Use Web/App-appropriate push such as WebSocket, SSE, native app bridge, or polling fallback; Core should not own transport plumbing. |
+| Notifications | Map Core notices to browser/app badges, toasts, native notifications, and unread counters with user-controlled settings. |
+| File picker/uploads | Own browser/app file selection, upload progress, previews, local permission errors, and conversion into neutral attachment descriptors. |
+| Admin/setup pages | Render credentials, pack readiness, app-server health, MCP/tooling state, diagnostics, and repair guidance. |
+| Layout/navigation | Choose sidebars, tabs, responsive panels, command palette, and history views without forcing chat chronology. |
+| Platform storage | Own cookies, browser/app storage, push subscription ids, CSRF/session mechanisms, and platform-specific security controls. |
+
+## Readiness Gates Before Claiming Web/App Support
+
+Do not advertise Web/App as a supported Codex Console surface until every baseline journey has
+at least fallback support and each required capability has crossed the right readiness level.
+
+1. **Static declared capability**
+   - Web/App declares baseline text input, interactions, live or refreshable updates, final-answer
+     delivery, media/file handling, auth binding, setup/health, and degraded-state rendering.
+
+2. **Configured capability**
+   - required server, local app, credentials, storage, app-server connection, and media/temp paths
+     are present and validated.
+   - notification and upload features report their own enabled/disabled status instead of hiding gaps.
+
+3. **Observed capability**
+   - the surface has successfully observed task ingress, interaction response, live/update delivery,
+     upload/download where configured, final-answer rendering, interrupt, and recovery/degraded paths.
+
+4. **UX-exposed capability**
+   - users can reach the complete journey through routes, panels, menus, forms, buttons, or setup pages,
+     not only by invoking internal APIs.
+
+Minimum support claim requires an operator to authorize, choose or confirm a project/session,
+submit a task, answer an interaction, inspect progress, interrupt when needed, receive the final
+answer, and understand any degraded or failed delivery state.
+
+## Migration Path From Telegram And Feishu Lessons
+
+Use the current packs as evidence, not templates to copy.
+
+1. **Preserve Core meaning that already generalized well.** Project/session selection, turn start,
+   blocked-turn continuation, runtime status, final-answer delivery, and degraded outcomes should stay
+   shared.
+2. **Retire chat-specific assumptions at the boundary.** Telegram message ids, callback payloads,
+   inline button layouts, Feishu card JSON, tenant tokens, and upload handles remain pack-owned.
+3. **Promote interaction models, not rendered controls.** Telegram callbacks and Feishu card actions
+   both imply neutral approvals/questions/selections; Web/App should render those as forms and modals.
+4. **Make readiness first-class.** Feishu showed that declared capability is not enough when scopes,
+   callbacks, uploads, or observed events are missing. Web/App should expose setup and observed health
+   directly.
+5. **Exploit richer surfaces carefully.** Web/App can provide dense inspect panels, history,
+   previews, and admin pages, but those features must call shared workflow/state contracts instead of
+   creating a parallel product.
+
+## Open Decisions
+
+These decisions are intentionally not made by this sketch:
+
+- Browser-only Web, desktop app, mobile app, or shared shell first?
+- Local-only access, reverse proxy, remote access, or hosted control plane?
+- Authentication model beyond the current high-trust single-operator assumption?
+- Live transport choice: WebSocket, SSE, native app bridge, polling fallback, or a layered mix?
+- Artifact storage and retention policy for final answers, uploads, previews, and generated files?
+- Notification model and opt-in requirements for browser/app/native notifications?
+- Whether Web/App should introduce multi-user collaboration, provider setup, raw terminal views,
+  project write operations, or team permissions as separate future tracks?
+- Which Core surfaces should become stable internal APIs versus documented external APIs?
+
+## Sequencing
+
+A safe sequence is:
+
+1. **Contract pass** — document the neutral Core/state/API surfaces above and map existing Telegram and
+   Feishu behavior to them without changing product support claims.
+2. **Readiness model pass** — make declared/configured/observed/UX-exposed readiness reportable for
+   every required Web/App baseline capability.
+3. **Prototype shell** — build a non-public Web/App shell that reads status, project/session, runtime,
+   interaction, and final-answer state through Core contracts.
+4. **Interaction and media pass** — add forms/modals and file picker/upload flows through neutral
+   interaction and attachment descriptors.
+5. **Degraded/recovery pass** — verify failure, stale interaction, duplicate response, rate limit,
+   upload failure, interrupted turn, and app-server recovery paths.
+6. **Support decision** — only after the baseline journey is configured, observed, UX-exposed, and
+   documented, decide whether Web/App becomes a supported Codex Console surface.

--- a/docs/operations/install-and-admin.md
+++ b/docs/operations/install-and-admin.md
@@ -41,6 +41,13 @@ Actual admin and runtime surface:
 Current pack rule:
 - `BRIDGE_PACK` defaults to `telegram`
 - current install, readiness, and skill-install flows are pack-aware even though the default shipped product truth remains Telegram-first
+- Telegram is the default quick-start pack; Feishu is a current pack with separate Feishu Open Platform setup requirements
+
+Pack setup quick reference:
+- Telegram direct install can use `--pack telegram --telegram-token <token>`; `--telegram-token` is the compatibility shortcut for the Telegram pack's bot token option
+- Feishu direct install can use `--pack feishu --pack-option app-id=<id> --pack-option app-secret=<secret>`; the equivalent persisted env keys are `FEISHU_APP_ID` and `FEISHU_APP_SECRET`
+- Feishu operators must also configure the Feishu app side: bot ability, long connection, `im.message.receive_v1`, `card.action.trigger`, upload permissions when file/image delivery is needed, and then publish the latest app version
+- for pack-specific setup beyond the options listed here, use the active pack's bundled Codex skill and `ctb doctor` output rather than inventing extra CLI flags
 
 Node requirement:
 - Node `>=24.0.0`
@@ -216,26 +223,45 @@ Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/InDre
 powershell -ExecutionPolicy Bypass -File $script
 ```
 
-Then in Codex:
+Then in Codex for the default Telegram pack:
 
 ```text
 Use $telegram-codex-linker to set up my Telegram bridge.
+```
+
+For Feishu, install the Feishu setup skill instead:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/InDreamer/telegram-codex-bridge/master/scripts/install-skill-from-github.sh | bash -s -- --pack feishu
+```
+
+Then in Codex:
+
+```text
+Use $feishu-codex-linker to set up my Feishu bridge.
 ```
 
 Pack-aware variants:
 - `install-skill-from-github.sh --pack feishu` installs the Feishu setup skill instead of the default Telegram one
 - `install-from-github.sh --pack <name>` forwards the selected pack into `ctb install`
 - repeated `--pack-option key=value` entries are forwarded into the active pack's install codec
+- current Feishu install options are `app-id`, `app-secret`, and `api-base-url`
 
 Reason:
 - install the skill once
 - let the skill take over bridge install, repair, token collection, authorization, and verification
 - interrupt the user only for unavoidable external actions such as providing platform credentials or messaging the bot once
 
-Bridge install from GitHub:
+Telegram bridge install from GitHub:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/InDreamer/telegram-codex-bridge/master/scripts/install-from-github.sh | bash -s -- --pack telegram --telegram-token "<BOT_TOKEN>" --project-scan-roots "$HOME/projects:$HOME/work"
+```
+
+Feishu bridge install from GitHub:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/InDreamer/telegram-codex-bridge/master/scripts/install-from-github.sh | bash -s -- --pack feishu --pack-option app-id="<FEISHU_APP_ID>" --pack-option app-secret="<FEISHU_APP_SECRET>" --project-scan-roots "$HOME/projects:$HOME/work"
 ```
 
 Windows bridge install from GitHub:

--- a/docs/plans/2026-04-26-codex-console-phase2-plan.md
+++ b/docs/plans/2026-04-26-codex-console-phase2-plan.md
@@ -1,0 +1,102 @@
+# Codex Console Phase 2 Implementation Plan
+
+> **For Hermes:** Coordinate with real Codex high runs phase-by-phase, then perform controller-side verification before each commit.
+
+**Goal:** Finish Codex Console next-step landing: clearer install/docs, Feishu official-doc-based capability audit, Core/Pack naming cleanup, Web/App integration sketch, and PR/release note.
+
+**Architecture:** Keep repository/package/CLI compatibility names unchanged. Treat Telegram as stable first/default pack and Feishu as serious current pack. Use official Feishu developer documentation plus implementation evidence before changing capability claims. Keep Web/App as a design plan, not implementation.
+
+**Tech Stack:** TypeScript, Node, markdown docs, Codex CLI, Feishu Developer Docs MCP.
+
+---
+
+### Task 1: README and install-entry de-Telegram-only docs
+
+**Objective:** Make the landing/install path explain Telegram default, Feishu setup entry, and capability boundaries without renaming package/CLI/service identifiers.
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/operations/install-and-admin.md`
+- Modify: `docs/product/v1-scope.md` if scope wording needs tightening
+- Optional Modify: `scripts/README` or installer docs only if such file exists and is routed
+
+**Steps:**
+1. Inspect README/install docs for Telegram-only public wording.
+2. Add explicit Telegram default path and Feishu pack-aware install examples.
+3. Preserve compatibility names: package `telegram-codex-bridge`, CLI `ctb`, existing service paths.
+4. Run `git diff --check` and `npm run check`.
+5. Commit as `docs: clarify Codex Console install paths`.
+
+### Task 2: Feishu official-doc-backed capability/smoke audit
+
+**Objective:** Compare current Feishu implementation and smoke-test requirements against official Feishu docs for messages, interactive cards, callbacks, files/images, events, and long connection.
+
+**Files:**
+- Create: `docs/plans/2026-04-26-feishu-official-capability-audit.md`
+- Modify: `docs/architecture/platform-capability-matrix.md` if claims need correction
+- Modify: `docs/architecture/platform-pack-boundary.md` if pack boundary caveats need correction
+
+**Official-doc evidence required:**
+- Feishu event subscription / long connection behavior
+- Message receive events and message resource download
+- Send/update interactive cards or card messages
+- Card action callbacks / triggers
+- Image/file upload and send-message APIs
+- Any documented constraints relevant to long output, markdown, or card content
+
+**Steps:**
+1. Use Feishu Developer Docs MCP and/or repo local docs cache if available.
+2. For each matrix row: text, cards, callback, file, image, long output, status/runtime cards, session switching, verify code path + official API feasibility.
+3. Produce smoke checklist: command/input, expected platform event/API, current code path, observed/log evidence needed, verdict.
+4. Patch docs only if current matrix overclaims or underclaims.
+5. Run doc/link checks, `git diff --check`, `npm run check`.
+6. Commit as `docs: audit Feishu capability against official APIs`.
+
+### Task 3: Core/Pack compatibility-shaped metadata cleanup
+
+**Objective:** Fix obvious naming/metadata mismatches such as Feishu pack saying `polling` / `bot_api` when the actual path is Feishu long-connection/OpenAPI compatibility adapters.
+
+**Files:**
+- Modify: `src/packs/contract.ts`
+- Modify: `src/packs/feishu/index.ts`
+- Modify: `src/packs/telegram/index.ts` only if the contract enum/type requires it
+- Modify tests adjacent to pack contract/registry/readiness if present
+- Modify docs that describe metadata if names change
+
+**Steps:**
+1. Inspect current contract literals and test expectations.
+2. Decide minimal backward-compatible vocabulary change.
+3. Add/update tests first for Feishu metadata values.
+4. Implement minimal code change.
+5. Run targeted tests plus `npm run check` and `npm test` if practical.
+6. Commit as `refactor: clarify Feishu pack transport metadata`.
+
+### Task 4: Web/App integration sketch
+
+**Objective:** Define how future Web/App pack connects to Codex Bridge Core without starting implementation.
+
+**Files:**
+- Create: `docs/future/web-app-control-surface-sketch.md`
+- Modify: `docs/future/README.md`
+- Modify: `docs/future/multi-platform-core-prd.md` if it should point to the sketch
+
+**Steps:**
+1. Reuse platform capability matrix and Core/Pack boundaries.
+2. Define required Core state/API surfaces: session, project, turn, runtime, interaction, artifacts/final answer, delivery outcomes.
+3. Define Web/App pack responsibilities: auth/session UI, routes, panels, forms, live transport, notifications, file picker/upload.
+4. List non-goals: multi-user, provider setup, raw terminal, project writes unless separately approved.
+5. Run docs checks.
+6. Commit as `docs: sketch Web App control surface`.
+
+### Task 5: PR/release note
+
+**Objective:** Package the changes as a readable owner-facing change set.
+
+**Files:**
+- Create: `docs/plans/2026-04-26-codex-console-phase2-release-note.md` or a PR body draft under `.hermes/`
+
+**Steps:**
+1. Summarize commits and user-visible changes.
+2. State compatibility: no package/CLI/service rename.
+3. State verification commands and results.
+4. Create PR if remote workflow is clean and user wants it; otherwise leave branch ready with PR body.

--- a/docs/plans/2026-04-26-codex-console-phase2-release-note.md
+++ b/docs/plans/2026-04-26-codex-console-phase2-release-note.md
@@ -1,0 +1,70 @@
+# Codex Console Phase 2 Release Note
+
+Status: ready for PR
+Branch: `feat/codex-console-phase2`
+Base: `master`
+
+## Summary
+
+This change continues the Codex Console platform-abstraction landing after the initial naming and capability-matrix work.
+
+It keeps all compatibility identifiers unchanged:
+
+- repository/package name remains `telegram-codex-bridge`
+- CLI remains `ctb`
+- existing service/config/state path names remain unchanged
+- Telegram remains the stable first/default pack
+- Feishu remains a serious current pack with explicit setup/readiness caveats
+
+## Commits
+
+1. `79bcb1d docs: clarify Codex Console install paths`
+   - Splits README install guidance into Telegram default path and Feishu pack path.
+   - Adds Feishu direct install examples using `--pack feishu` and `--pack-option`.
+   - Updates operations docs and product scope wording so Feishu is current but not treated as identical to Telegram UX.
+
+2. `a024753 docs: audit Feishu capability against official APIs`
+   - Adds an official Feishu developer-doc-backed capability audit.
+   - Covers long connection/events, text receive, cards, card callbacks, image/file upload and download, long-output risks, status cards, session/project flows, and bot-menu limits.
+   - Separates confirmed API+code support from items needing live tenant smoke.
+
+3. `0667c6f refactor: clarify Feishu pack transport metadata`
+   - Updates Feishu pack metadata from compatibility-shaped labels to actual current behavior:
+     - ingress: `long_connection`
+     - egress: `open_api`
+   - Adds tests for the metadata and updates docs caveats.
+   - Keeps broader compatibility-adapter caveats intact.
+
+4. `29e1593 docs: sketch Web App control surface`
+   - Adds a future Web/App control surface sketch.
+   - Defines Core reuse targets, Pack/Presentation responsibilities, readiness gates, migration lessons, open decisions, and sequencing.
+   - Explicitly does not claim current Web/App support.
+
+## User-visible impact
+
+- Codex Console docs are less Telegram-only while preserving Telegram as the default path.
+- Feishu setup and capability boundaries are easier to discover.
+- Feishu official API evidence is captured for future smoke testing.
+- The most obvious Feishu pack metadata mismatch is fixed and tested.
+- Web/App planning now has a concrete document that avoids forcing Web/App into a fake chat-pack shape.
+
+## Known remaining gaps
+
+- No live Feishu tenant smoke was performed in this change set.
+- Feishu pin/unpin remains non-native.
+- Feishu bot-menu discovery remains externally configured and smaller than Telegram command sync.
+- Feishu voice/audio and remote image URL support remain unsupported by current pack capabilities.
+- Web/App remains future design only.
+
+## Verification
+
+Run from the branch worktree:
+
+```bash
+git diff --check
+node --import tsx --test src/packs/feishu/index.test.ts src/packs/registry.test.ts
+npm run check
+npm test
+```
+
+Expected result: all pass.

--- a/docs/plans/2026-04-26-feishu-official-capability-audit.md
+++ b/docs/plans/2026-04-26-feishu-official-capability-audit.md
@@ -80,7 +80,6 @@ These should work given the primitives but require live Feishu client/tenant obs
 - Feishu command/menu discovery has no automatic `setMyCommands` equivalent; `src/feishu/api.ts#setMyCommands` is a no-op, so native menu setup remains external.
 - Feishu voice/audio input is not supported by the pack capability snapshot.
 - Remote image URL input/output is not supported by the current pack.
-- Feishu pack metadata still labels ingress/egress as compatibility-shaped (`polling`, `bot_api`) even though runtime behavior is long-connection/OpenAPI; this is already called out in the capability matrix and scheduled for a later cleanup task.
 
 ## Doc/API unknown
 

--- a/docs/plans/2026-04-26-feishu-official-capability-audit.md
+++ b/docs/plans/2026-04-26-feishu-official-capability-audit.md
@@ -1,0 +1,92 @@
+# Feishu Official Capability Audit
+
+## Verdict
+
+Feishu is a serious current Codex Console pack with official Feishu/Lark API support for the core READ/WRITE-DOCS smoke path: long-connection event ingress, text/card message send, card callbacks with toast response, message-resource download for user images/files, and image/file upload plus send. The current implementation maps those official capabilities through Feishu long-connection/OpenAPI compatibility adapters and shared Codex Bridge Core service paths.
+
+No live Feishu tenant smoke was run in this audit. Treat code/API-matched rows as implementation-confirmed, not production-observed. The main risks are setup-dependent: bot ability, published permissions/scopes, long-connection event subscription, `card.action.trigger` callback subscription, Feishu message/card size limits, and the remaining Telegram-shaped compatibility shell.
+
+## Official documentation retrieval
+
+Feishu Developer Docs MCP was available and returned official Feishu Open Platform documentation. Source URLs below are MCP-returned official `go.feishu.cn` short links unless otherwise noted.
+
+Key official sources used:
+
+- Event overview: https://go.feishu.cn/s/5_sDxkQ3802
+- Long connection/WebSocket event receiving: https://go.feishu.cn/s/626tU7DxM0s
+- Receive events: https://go.feishu.cn/s/626tU7DxI0s
+- Message overview/API list: https://go.feishu.cn/s/65wgBAU2801
+- Receive message event (`im.message.receive_v1`): https://go.feishu.cn/s/61BYfeQR80s
+- Get message resource file: https://go.feishu.cn/s/61BYfgpwQ01
+- Reply/send message constraints: https://go.feishu.cn/s/61BYfeQRw0s
+- Interactive card bot tutorial/callback sample: https://go.feishu.cn/s/6t-7Zt6lg04
+- Handle card callbacks: https://go.feishu.cn/s/6wrmRAExU04
+- Card JSON 2.0 structure: https://go.feishu.cn/s/6qEkCDfEk03
+- Card entity full update: https://go.feishu.cn/s/6qEkCDfEU03
+- Card entity settings patch: https://go.feishu.cn/s/6qEkCDfEE03
+
+## Official API facts relevant to smoke tests
+
+- Event subscription supports two modes: long connection via Feishu SDK WebSocket and webhook. Long connection is recommended for enterprise self-built apps, requires outbound public network access, and does not require separate event decryption/signature handling in the handler path.
+- Long connection constraints: enterprise self-built apps only, handler must complete within 3 seconds, max 50 connections per app, cluster mode is not broadcast and randomly delivers to one connected client.
+- Event push is at-least-once; docs recommend idempotency. For receive-message events, docs specifically warn duplicate pushes may happen and recommend `message_id` dedupe rather than relying on `event_id`.
+- `im.message.receive_v1` exposes `message_type` and serialized JSON `content`; docs point content shape to receive-message content docs and list text/post/image/file as supported message resources through the message APIs.
+- `GET /open-apis/im/v1/messages/:message_id/resources/:file_key` downloads user-sent message resources including images and files. It requires `type=image|file`, the bot must be in the conversation, the resource must match the message, and only resources up to 100 MB are supported.
+- Sending messages uses `POST /open-apis/im/v1/messages`; official overview lists text, post/rich text, image, file, and interactive card support. Image/file sends require prior upload to obtain image/file keys.
+- Uploading images uses `POST /open-apis/im/v1/images`; uploading files uses `POST /open-apis/im/v1/files`; the overview lists `im:resource` / upload-resource permission for these upload APIs.
+- Message/card constraints relevant to long output: text request body max 150 KB; rich text and card request bodies max 30 KB; cards using templates count template size too; Feishu may reject oversized content with error 230025. Message resources download max is 100 MB.
+- Interactive cards can be sent as `msg_type=interactive`; current-app card messages can be updated with `PATCH /open-apis/im/v1/messages/:message_id`; delayed card update uses `POST /open-apis/interactive/v1/card/update` after callback response.
+- Card callback docs recommend subscribing to `card.action.trigger`; callback service must respond within 3 seconds with HTTP 200. Response can be empty, toast-only, or include a replacement card. Callback interaction validity is 30 days; card update validity is 14 days; delayed-update token is valid 30 minutes and supports at most two updates.
+- Card JSON 2.0 supports markdown elements, streaming-mode settings, and shared-card `update_multi=true`; JSON 2.0 cards support up to 200 elements/components, and some CardKit update APIs enforce 30 KB card content and strictly increasing sequence numbers.
+
+## Smoke-test matrix
+
+| Capability | Official API/doc evidence | Current implementation path | Smoke test | Expected result | Gap/Risk | Verdict |
+|---|---|---|---|---|---|---|
+| Text input | `im.message.receive_v1` receive-message event exposes `message_type`, serialized `content`, sender, chat, and message IDs. Long connection can subscribe via WebSocket SDK. Sources: receive message, long connection. | `src/feishu/poller.ts` registers `im.message.receive_v1`, parses `text` content, translates to Telegram-like update; `src/service.ts` records Feishu text ingress and routes normal text. | Send a plain text task to the Feishu bot in a p2p chat after setup. | Bridge records text ingress, authorizes sender, and starts/routes a normal Codex turn. | Requires bot ability, receive-message event subscription, p2p message permission, published app version, and no competing long-connection client consuming events. | Confirmed (API + code); needs live smoke for tenant setup. |
+| Card/status/welcome rendering | Official messages support `msg_type=interactive`; Feishu card docs support JSON 2.0 markdown/card content. Sources: message overview, card JSON 2.0. | `src/feishu/api.ts` sends interactive messages when HTML/markup is present; `src/feishu/card-renderer.ts` builds JSON 2.0 cards; `src/feishu/ui.ts` builds welcome/status content; `src/service.ts` sends Feishu welcome/setup/status surfaces. | Enter bot p2p chat or trigger setup/status menu. | Feishu receives a card with welcome/status text and actions. | Card body size limit is 30 KB; card JSON/rendering must stay valid; setup readiness must permit interactive send. | Confirmed (API + code); needs live smoke for exact client rendering. |
+| Card callback/action trigger | Official card callback handling documents `card.action.trigger`, 3-second response, toast/card response, and long-connection callback subscription. Source: handle card callbacks; card bot tutorial. | `src/feishu/card-renderer.ts` emits callback behaviors with `callback_data`; `src/feishu/poller.ts` registers `card.action.trigger`, extracts callback data, returns toast, and enqueues callback query; `src/packs/feishu/setup.ts` tracks observed card callback readiness. | Click a Feishu card button such as Status/Inspect/Interrupt. | Feishu client shows toast; bridge receives callback and routes the associated action. | Requires callback subscription, long connection callback mode or valid callback endpoint, app publish, and callback handler under 3 seconds. Duplicate/old callbacks need stale handling in shared router. | Confirmed (API + code); needs live smoke. |
+| File receive | Official message-resource download supports files from a message using `GET /im/v1/messages/:message_id/resources/:file_key?type=file`, up to 100 MB. Receive-message event carries message ID and content/resource keys. Sources: receive message, get message resource file. | `src/feishu/poller.ts` parses `message_type=file` and emits bridge media with `resourceType=file`; `src/service/media-ingress.ts` calls `downloadMessageResource`; `src/feishu/api.ts` wraps `client.im.v1.messageResource.get`. | Send a small file to the bot with optional caption/text. | Bridge downloads the file to cache and passes an inbound media event to rich input handling. | Requires message-resource permission (`im:message`/readonly/history), bot in conversation, resource <=100 MB, and unsupported restricted/external cases may fail. | Confirmed (API + code); needs live smoke for permission set. |
+| Image receive | Official message-resource download supports images from messages using `type=image`, up to 100 MB. Receive-message content includes image resource key by message type. Sources: receive message, get message resource file. | `src/feishu/poller.ts` parses `message_type=image` and post images into bridge media; `src/service/media-ingress.ts` resolves Feishu resources; `src/feishu/api.ts` downloads message resources. | Send an image to the bot. | Bridge downloads the image to cache and passes it as image input. | Same resource-download risks as files; current code does not claim voice/audio support. | Confirmed (API + code); needs live smoke. |
+| File send | Official message API supports sending `file` messages after `POST /im/v1/files` upload; upload requires resource upload permission and message send requires bot/message permission. Sources: message overview, reply/send constraints. | `src/feishu/api.ts` uploads via `client.im.v1.file.create`, sends `msg_type=file`; `src/packs/feishu/index.ts` declares `send_feishu_file` dynamic tool and probes file upload scopes; `src/packs/feishu/egress-adapter.ts` exposes `sendDocument`. | Use the `send_feishu_file` dynamic tool or trigger a file fallback path. | Feishu receives a file message; optional caption is sent as a separate supplementary message. | Requires `im:resource` upload scope, message send scope, bot ability, file type mapping accepted by Feishu, and live tenant upload probe success. | Confirmed (API + code); needs live smoke. |
+| Image send | Official message API supports sending `image` messages after image upload; upload supports common image formats and requires resource upload permission. Sources: message overview, upload image API listing. | `src/feishu/api.ts` uploads via `client.im.v1.image.create` with `image_type=message`, sends `msg_type=image`; `src/packs/feishu/index.ts` declares `send_feishu_image` and probes image upload scopes; `src/packs/feishu/egress-adapter.ts` exposes `sendPhoto`. | Use the `send_feishu_image` dynamic tool with a PNG/JPEG. | Feishu receives an image message; optional caption is sent separately. | Requires `im:resource` scope and send scope; remote image URLs are not supported by current pack. | Confirmed (API + code); needs live smoke. |
+| Long output / long final answer | Official constraints: text body max 150 KB; rich text/card max 30 KB; card JSON 2.0 up to 200 elements; message-resource max 100 MB. Sources: reply/send constraints, card JSON 2.0, CardKit update docs. | Pack declares long-form pagination; Feishu API sends text or interactive cards; card renderer uses markdown sections. Matrix already marks final answers as adapted, not native parity. | Produce a final answer larger than one card/message and verify pagination/splitting/file fallback behavior. | User should receive complete answer without silent truncation, through pages/split messages or fallback artifact/file. | Biggest current risk: Feishu card 30 KB cap and 200-component cap can reject dense runtime/final cards; no live evidence in this audit that every long-final path stays below limits. | Likely but needs live smoke. |
+| Runtime status card / inspect detail | Official interactive cards support buttons/callbacks and updates; message patch can update app-sent card messages. Sources: message overview, handle card callbacks, card update docs. | `src/feishu/ui.ts` builds status/inspect/interrupt buttons; `src/feishu/card-renderer.ts` renders them; `src/feishu/api.ts` patches card messages or falls back to send/delete; `src/service.ts` sends setup/status surfaces. | Start a turn, open status, click Inspect, and observe runtime card updates. | Status card renders and actions route; card edits update or fallback to replacement message. | Runtime surface is adapted through Telegram-compatible IDs and message refs; patch failures can create replacement messages; live Feishu UX density needs checking. | Likely but needs live smoke. |
+| Session switching/project picker | Official card callbacks provide enough primitive support for button-driven pickers. Source: handle card callbacks. | `src/feishu/card-renderer.ts` maps Telegram-style inline keyboards into Feishu buttons/overflow; `src/feishu/poller.ts` translates callbacks; `src/feishu/ui.ts` exposes sessions/status/new buttons. | Open Sessions/Project picker and select a session/project from Feishu cards. | Shared service receives callback data and switches context as in the adapted control surface. | Product flow is still Telegram-shaped; Feishu can carry callbacks, but exact picker ergonomics and overflow behavior need live smoke. | Likely but needs live smoke. |
+| Bot menu/native command discovery | Official card-interaction tutorial uses `application.bot.menu_v6` with menu `event_key`; message overview also notes bot ability. Source: card interaction bot tutorial. | `src/feishu/poller.ts` registers `application.bot.menu_v6`; `src/feishu/ui.ts` maps native menu keys for `new`, `status`, `sessions`, `help`; `src/service.ts` routes those commands. `src/feishu/api.ts#setMyCommands` is intentionally no-op. | Configure Feishu bot menu entries with the expected event keys and click each entry. | Menu click routes to New, Status, Sessions, or Help. | Requires manual/admin Feishu bot menu configuration and publish; no automatic command sync equivalent to Telegram. Native discovery is smaller than Telegram. | Confirmed but limited; needs live smoke for menu config. |
+
+## Confirmed
+
+These are confirmed by official docs plus current code paths, but not by live tenant smoke in this audit:
+
+- Long-connection event ingress is an official Feishu SDK/WebSocket mode, and the current Feishu poller uses `Lark.WSClient` with `im.message.receive_v1`, p2p chat-entered, bot-menu, and `card.action.trigger` handlers.
+- Text input, image/file receive descriptors, and image/file message-resource download have matching official APIs and implementation paths.
+- Text/card send, card patch/fallback, image upload/send, and file upload/send have matching official APIs and implementation paths.
+- Card callback toast response is supported by official docs and implemented by the Feishu poller.
+- Feishu setup health tracks credentials, token validation, authorization binding, text ingress observation, interactive card delivery, callback observation, and upload-scope probes.
+
+## Likely but needs live smoke
+
+These should work given the primitives but require live Feishu client/tenant observation:
+
+- Long final answers and dense runtime cards, because Feishu card/rich text limits are materially lower than arbitrary Codex output.
+- Runtime status/inspect detail and project/session picker UX, because the implementation adapts Telegram-style callbacks/buttons into Feishu cards and overflow controls.
+- Bot menu/native discovery, because current code handles menu events but Feishu menu entries must be configured in the developer/admin console.
+- Callback/update timing under load, because Feishu requires the callback response path to complete within 3 seconds.
+
+## Current gap
+
+- Native pin/unpin is not implemented for Feishu; the compatibility API returns success without calling a native Feishu pin API. Existing matrix wording already warns not to treat this as native.
+- Feishu command/menu discovery has no automatic `setMyCommands` equivalent; `src/feishu/api.ts#setMyCommands` is a no-op, so native menu setup remains external.
+- Feishu voice/audio input is not supported by the pack capability snapshot.
+- Remote image URL input/output is not supported by the current pack.
+- Feishu pack metadata still labels ingress/egress as compatibility-shaped (`polling`, `bot_api`) even though runtime behavior is long-connection/OpenAPI; this is already called out in the capability matrix and scheduled for a later cleanup task.
+
+## Doc/API unknown
+
+- This audit did not retrieve a dedicated official Feishu page for every receive-message content subtype (`text`, `post`, `image`, `file`) beyond the receive-message event and message overview/resource API pages. The available official pages were sufficient to verify the event shape, message resource download, and send/upload APIs used by current code.
+- No official live tenant logs, Feishu event logs, or Codex Console runtime logs were reviewed, so observed success remains unknown.
+
+## Matrix/boundary doc impact
+
+No changes were made to the platform capability matrix or platform pack boundary docs in this audit. Their current Feishu caveats already match the evidence found here: Feishu is a current serious pack, it uses long-connection/OpenAPI compatibility adapters, upload/callback readiness is setup-dependent, rich runtime/session UX is adapted, and pin/unpin is not native.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -3,6 +3,9 @@ role: domain
 layer: 2
 parent: docs/INDEX.md
 children:
+  - docs/plans/2026-04-26-codex-console-phase2-release-note.md
+  - docs/plans/2026-04-26-codex-console-phase2-plan.md
+  - docs/plans/2026-04-26-feishu-official-capability-audit.md
   - docs/plans/2026-04-09-feishu-pack-setup-capability-and-hardening-plan.md
   - docs/plans/2026-04-08-multi-platform-core-and-feishu-implementation-plan.md
   - docs/plans/2026-03-30-binding-model-neutralization-note.md
@@ -18,33 +21,35 @@ skip_when:
   - the request is only about current shipped behavior or future product direction
 source_of_truth:
   - docs/plans/README.md
-  - docs/plans/2026-03-23-multi-platform-core-phase-1-implementation-plan.md
-  - docs/plans/2026-03-23-multi-platform-core-pending-task-tracker.md
+  - docs/roadmap/codex-console-continuation-brief.md
   - docs/plans
 -->
 
 # Plans Index
 
-Use this directory for sequencing, closeout status, and deferred-work tracking.
+Use this directory for active sequencing, closeout status, and deferred-work tracking.
 It is planning context, not current product truth.
+For new continuation work, start with `../roadmap/codex-console-continuation-brief.md` before opening any dated plan.
 
-## Open One Leaf
+## Active Or Recently Relevant Leaves
 
-- `2026-04-09-feishu-pack-setup-capability-and-hardening-plan.md` - capability definition and prioritized hardening backlog for making Feishu setup, callback readiness, and first-run binding work as one operator-safe flow.
-- `2026-04-08-multi-platform-core-and-feishu-implementation-plan.md` - executable 4-phase backlog that finishes platform abstraction by Phase 3 and lands Feishu as the second platform in Phase 4.
-- `2026-03-30-binding-model-neutralization-note.md` - current note for neutralizing auth and chat binding model fields without claiming multi-platform support.
-- `2026-03-30-platform-binding-boundary-design.md` - current boundary note for separating platform principal, surface target, and bridge session ownership.
-- `2026-03-30-platform-surface-adapter-and-capability-prep.md` - current predesign note for the next platform-surface adapter and capability slice.
-- `2026-03-23-multi-platform-core-phase-1-implementation-plan.md` - what the first abstraction wave landed, how it was scoped, and why it stopped where it did.
-- `2026-03-23-multi-platform-core-pending-task-tracker.md` - the original Phase-1 deferred-work baseline; use it as historical sequencing context, not as the current status page.
+- `2026-04-26-codex-console-phase2-release-note.md` - PR-ready summary of the install path, Feishu audit, metadata cleanup, Web/App sketch, and verification work.
+- `2026-04-26-codex-console-phase2-plan.md` - phase plan for the Phase 2 continuation branch.
+- `2026-04-26-feishu-official-capability-audit.md` - official-API-backed Feishu capability audit and live-smoke caveat.
+- `2026-04-09-feishu-pack-setup-capability-and-hardening-plan.md` - Feishu setup, callback readiness, and first-run binding hardening backlog.
+- `2026-04-08-multi-platform-core-and-feishu-implementation-plan.md` - four-phase backlog that completed platform abstraction and landed Feishu as the second platform.
+- `2026-03-30-binding-model-neutralization-note.md` - neutralizing auth and chat binding model fields without claiming broad multi-platform support.
+- `2026-03-30-platform-binding-boundary-design.md` - platform principal, surface target, and bridge session ownership boundary.
+- `2026-03-30-platform-surface-adapter-and-capability-prep.md` - platform-surface adapter and capability vocabulary predesign.
+- `2026-03-23-multi-platform-core-phase-1-implementation-plan.md` - first abstraction wave closeout and scope boundary.
+- `2026-03-23-multi-platform-core-pending-task-tracker.md` - original Phase-1 deferred-work baseline; historical sequencing context only.
 
-## Other Useful Plan Files
+## Archived Plan Material
 
-- `2026-03-18-v5-5-post-v5-slimming-plan.md` - active V5.5 cleanup tracker.
-- `2026-03-23-performance-monitoring-plan.md` - performance monitoring implementation notes.
-- older date-stamped files in this directory - historical implementation context only.
+Older March implementation plans moved to `../archive/plans/`. They are not active task context and should only be opened for historical reconstruction.
 
 ## Skip This Directory When
 
 - you need the shipped behavior right now
 - you need future product direction rather than implementation sequencing
+- the continuation brief plus one current-truth leaf is enough

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -9,9 +9,9 @@ children:
   - docs/product/codex-command-reference.md
   - docs/product/runtime-and-delivery.md
   - docs/product/callback-contract.md
-summary: router for current Telegram-first product behavior and user-facing command surfaces
+summary: router for current Codex Console product behavior, including Telegram-first command surfaces
 read_when:
-  - the request is about current user-facing Telegram behavior
+  - the request is about current user-facing Codex Console behavior
   - the request is about v1 scope, command UX, or callback behavior
 skip_when:
   - the request is mainly about code ownership, install/admin, or future Core direction
@@ -27,8 +27,9 @@ source_of_truth:
 
 # Product Index
 
-Use this directory for current Telegram-first product behavior.
-Do not use it for future Core direction.
+Use this directory for current Codex Console product behavior.
+Most leaf docs still describe the Telegram-first baseline and command surfaces; Feishu-specific setup and pack boundaries live in operations and architecture docs.
+Do not use this directory for future Codex Bridge Core direction.
 
 ## Open One Leaf
 
@@ -43,4 +44,4 @@ Do not use it for future Core direction.
 
 - you need current code ownership or runtime internals
 - you need install or diagnostics behavior
-- you need the future multi-platform Core direction
+- you need the future Codex Bridge Core direction

--- a/docs/product/v1-scope.md
+++ b/docs/product/v1-scope.md
@@ -3,7 +3,7 @@ role: leaf
 layer: 3
 parent: docs/product/README.md
 children: []
-summary: current shipped v1 scope, trust model, and out-of-scope boundary for the Telegram-first bridge
+summary: current shipped v1 scope, trust model, and out-of-scope boundary for Codex Console's Telegram-first baseline
 read_when:
   - the task is about what v1 includes, excludes, or deliberately does not promise
   - the task needs the current trust model before implementation or docs changes
@@ -14,17 +14,22 @@ source_of_truth:
   - docs/future/multi-platform-core-prd.md
 -->
 
-# Telegram Codex Bridge v1 Scope
+# Codex Console v1 Scope
 
 Current truth note:
-- this file describes the **current shipped Telegram-first product**
-- future repository direction beyond Telegram belongs in `docs/future/multi-platform-core-prd.md`
+- external product name is **Codex Console**
+- internal architecture name is **Codex Bridge Core**
+- this file describes the **current Telegram-first baseline and trust model**
+- Telegram remains the stable first pack and default install path
+- Feishu is a serious current pack, but broad multi-platform production maturity is not claimed here
+- the in-scope list below is the stable Telegram baseline; Feishu current-pack capability and readiness are covered by the pack boundary, operations docs, and platform capability matrix
+- future product direction belongs in `docs/future/multi-platform-core-prd.md`
 
 ## Goal
 
-Build a VPS-hosted Telegram bridge that wakes and controls the Codex installation that already exists on the server.
+Build a VPS-hosted Codex Console that wakes and controls the Codex installation that already exists on the server.
 
-Telegram is the control surface.
+Telegram is the stable first control surface.
 Codex remains the execution engine.
 The bridge is not a second Codex environment, not a provider-management layer, and not a second permission system.
 
@@ -54,7 +59,7 @@ The bridge is not a second Codex environment, not a provider-management layer, a
 - optional Telegram voice-message adaptation into transcribed text input when voice input is enabled
 - one-line install plus local self-check
 - operator-managed full-access runtime with adapted Telegram UX instead of a raw terminal
-- current repository direction may later grow into a broader Core, but that is not part of shipped v1 behavior
+- current repository direction is Codex Console powered by Codex Bridge Core, but this v1 baseline does not claim every surface is fully platform-neutral
 
 ## Out Of Scope
 
@@ -72,7 +77,7 @@ The bridge is not a second Codex environment, not a provider-management layer, a
 - client-managed ChatGPT token refresh via `account/chatgptAuthTokens/refresh`, because the bridge does not own ChatGPT access tokens or workspace ids and Telegram is not the provider-setup UX
 - `command/exec*`, `feedback/upload`, `fuzzyFileSearch*`, and `externalAgentConfig/*`
 - a first-class Telegram transport inside Codex core
-- multi-platform packs such as Slack or Discord
+- broad additional platform packs such as Slack or Discord
 - a first-class Web or App control console
 
 ## Runtime Assumption

--- a/docs/product/v1-scope.md
+++ b/docs/product/v1-scope.md
@@ -35,9 +35,10 @@ The bridge is not a second Codex environment, not a provider-management layer, a
 
 ## In Scope
 
-- single authorized Telegram user
-- Telegram private chat only
+- stable Telegram baseline: single authorized Telegram user
+- stable Telegram baseline: Telegram private chat only
 - one bridge service per server
+- Feishu can be selected as the active current pack, with its capability and setup completeness judged by the pack-aware docs rather than by this Telegram baseline list
 - reuse the server's existing Codex environment
 - project-aware session startup
 - read-only project file browsing for the active session, including directory navigation plus text and image preview inside the current project root

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -2,27 +2,33 @@
 role: domain
 layer: 2
 parent: docs/INDEX.md
-children: []
-summary: router for delivery ordering and acceptance-intent docs
+children:
+  - docs/roadmap/codex-console-continuation-brief.md
+  - docs/roadmap/phase-1-delivery.md
+summary: router for delivery ordering, continuation handoff, and acceptance-intent docs
 read_when:
+  - starting a new Codex Console continuation task
   - the request is about planned delivery order or acceptance intent
   - the request needs roadmap context rather than shipped behavior
 skip_when:
   - the request is about current behavior, current ownership, or detailed historical plans
 source_of_truth:
   - docs/roadmap/README.md
+  - docs/roadmap/codex-console-continuation-brief.md
   - docs/roadmap
 -->
 
 # Roadmap Index
 
-Use this directory for delivery ordering and acceptance intent.
+Use this directory for delivery ordering, continuation handoff, and acceptance intent.
 
 ## Open One Leaf
 
-- `phase-1-delivery.md` - planned delivery sequence and acceptance framing.
+- `codex-console-continuation-brief.md` - active low-context handoff for future Codex Console / multi-platform bridge work. Start here before reading dated plans.
+- `phase-1-delivery.md` - earlier planned delivery sequence and acceptance framing.
 
 ## Skip This Directory When
 
 - you need shipped behavior
 - you need a detailed implementation plan rather than a delivery view
+- you already know the current-truth leaf to open

--- a/docs/roadmap/codex-console-continuation-brief.md
+++ b/docs/roadmap/codex-console-continuation-brief.md
@@ -1,0 +1,104 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/roadmap/README.md
+children: []
+summary: active continuation brief for the next Codex Console tasks, optimized for low-context agent handoff
+read_when:
+  - starting any new Codex Console platform-abstraction task
+  - deciding which current docs are relevant and which historical docs to skip
+  - preparing future implementation or review prompts after the current continuation baseline
+skip_when:
+  - the task is only about shipped install/runtime behavior and a Tier-1 leaf is already known
+source_of_truth:
+  - docs/roadmap/codex-console-continuation-brief.md
+  - docs/architecture/platform-capability-matrix.md
+  - docs/architecture/platform-pack-boundary.md
+  - docs/future/multi-platform-core-prd.md
+  - docs/future/web-app-control-surface-sketch.md
+-->
+
+# Codex Console Continuation Brief
+
+Status: active continuation entrypoint
+Last updated: 2026-04-26
+
+Use this as the first task handoff for future Codex Console / multi-platform bridge work. It replaces ad-hoc reading of older dated plans.
+
+## One-Screen Current State
+
+- Compatibility names stay unchanged: repo/package `telegram-codex-bridge`, CLI `ctb`, existing service/config/state paths.
+- Product language is **Codex Console**.
+- Internal shared direction is **Codex Bridge Core**.
+- Telegram is the stable first/default pack.
+- Feishu is a serious current pack with explicit setup/readiness caveats.
+- Web/App is future design only; do not claim current support.
+- Recent Phase 2 work is captured in `docs/plans/2026-04-26-codex-console-phase2-release-note.md`.
+
+## Default Agent Reading Budget
+
+For a new task, read at most:
+
+1. this brief;
+2. one current-truth leaf from `docs/product/`, `docs/architecture/`, or `docs/operations/`;
+3. one implementation file or one protocol/future doc only if the task genuinely needs it.
+
+Do not read the old dated plan archive by default. It is for archaeology, not active task context.
+
+## Active Source Set
+
+| Need | Open |
+|---|---|
+| current Telegram/Feishu capability and Web/App target rows | `docs/architecture/platform-capability-matrix.md` |
+| current pack contract and Telegram/Feishu ownership split | `docs/architecture/platform-pack-boundary.md` |
+| current install/admin and pack selection | `docs/operations/install-and-admin.md` |
+| current product scope and compatibility boundary | `docs/product/v1-scope.md` |
+| future Core product/architecture direction | `docs/future/multi-platform-core-prd.md` |
+| future Web/App control surface sketch | `docs/future/web-app-control-surface-sketch.md` |
+| official-API-backed Feishu audit and live-smoke caveat | `docs/plans/2026-04-26-feishu-official-capability-audit.md` |
+| Phase 2 PR summary and verification | `docs/plans/2026-04-26-codex-console-phase2-release-note.md` |
+
+## Archive Policy
+
+Move a doc to `docs/archive/` when all are true:
+
+- it describes a closed historical milestone, superseded PRD, or implementation plan;
+- it is not the smallest source for any current or next task;
+- reading it before current docs would likely bias an agent toward stale Telegram-only or pre-Core assumptions.
+
+Archived docs remain searchable for reconstruction, but routers must not send agents there unless the task explicitly asks for history or current sources conflict.
+
+## Current Archive Decisions
+
+Archived from active routing in this cleanup:
+
+- old V2/V3 future PRDs and engineering-evaluation material;
+- old March implementation plans for V2/V3, runtime-card, project-picker, runtime-hub, systemd, performance, and final-answer recovery work.
+
+Kept outside archive because they still help the current direction:
+
+- March 23 and March 30 multi-platform Core / binding / surface notes;
+- April 8 multi-platform Core + Feishu implementation plan;
+- April 9 Feishu hardening plan;
+- April 26 Feishu official capability audit;
+- April 26 Phase 2 plan and release note.
+
+## Next Sustainable Task Queue
+
+1. **Live Feishu tenant smoke.** Verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery.
+2. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
+3. **Docs context budget enforcement.** Keep routers pointing to this brief plus one leaf; archive or demote any new dated plan after closeout.
+4. **Web/App pre-implementation gate.** Before coding Web/App, turn the sketch into stable Core/state/API contracts and readiness criteria.
+5. **PR hygiene.** Each continuation PR should include a short release note, verification commands, and an archive/demotion decision for any temporary plan files.
+
+## Noise Checks Before Adding A New Doc
+
+Before creating a new doc, answer:
+
+- Is this new doc the future entrypoint, or just a temporary plan?
+- Which existing doc becomes less important because this exists?
+- Should it be Tier 1 current truth, protocol evidence, future direction, active plan, or archive?
+- What is the maximum number of docs an agent should read before acting?
+- Will this doc cause an agent to overclaim current support?
+
+If those answers are unclear, add the information to this brief or an existing leaf instead of creating a new top-level plan.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "telegram-codex-bridge",
   "version": "0.1.0",
   "private": true,
-  "description": "Turn Telegram into a control plane for the Codex installation already running on your server.",
+  "description": "Codex Console: control the Codex installation already running on your server from supported chat platforms.",
   "type": "module",
   "homepage": "https://github.com/InDreamer/telegram-codex-bridge#readme",
   "repository": {

--- a/src/feishu/poller.test.ts
+++ b/src/feishu/poller.test.ts
@@ -199,6 +199,63 @@ test("FeishuTelegramPollerCompat translates image receive events into bridge med
   }
 });
 
+test("FeishuTelegramPollerCompat translates post messages with pasted images into bridge media updates", async () => {
+  const root = await mkdtemp(join(tmpdir(), "ctb-feishu-poller-test-"));
+  const paths = createPaths(root);
+
+  try {
+    const api = new FeishuTelegramApiCompat({
+      appId: "cli_test",
+      appSecret: "secret",
+      apiBaseUrl: "https://open.feishu.cn"
+    }, paths);
+    const poller = new FeishuTelegramPollerCompat(
+      api,
+      createConfig(),
+      paths,
+      testLogger,
+      async () => {},
+      {
+        createWsClient: () => ({
+          start: async () => {},
+          close: () => {}
+        }),
+        createEventDispatcher: () => ({
+          register: () => {}
+        })
+      }
+    );
+
+    const update = await (poller as any).translateMessageEvent({
+      sender: {
+        sender_id: {
+          open_id: "ou_user_3"
+        }
+      },
+      message: {
+        message_id: "om_message_post_image",
+        chat_id: "oc_chat_3",
+        create_time: "1710000002000",
+        message_type: "post",
+        content: JSON.stringify({
+          title: "",
+          content: [[{
+            tag: "img",
+            image_key: "img_key_post_1"
+          }]]
+        })
+      }
+    });
+
+    assert.equal(update?.message?.bridgeMedia?.[0]?.kind, "image");
+    assert.equal(update?.message?.bridgeMedia?.[0]?.resourceId, "img_key_post_1");
+    assert.equal(update?.message?.bridgeMedia?.[0]?.platformRef.platform, "feishu");
+    assert.equal(update?.message?.text, undefined);
+  } finally {
+    await rm(root, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
 test("FeishuTelegramPollerCompat accepts modern nested card callback payloads", async () => {
   const root = await mkdtemp(join(tmpdir(), "ctb-feishu-poller-test-"));
   const paths = createPaths(root);

--- a/src/feishu/poller.ts
+++ b/src/feishu/poller.ts
@@ -12,6 +12,7 @@ import type {
   TelegramUser
 } from "../telegram/api.js";
 import { parseCallbackData } from "../telegram/ui-callbacks.js";
+import { normalizeWhitespace } from "../util/text.js";
 import { resolveFeishuSdkDomain, type FeishuTelegramApiCompat } from "./api.js";
 
 interface PendingQueueWaiter {
@@ -63,6 +64,159 @@ function parseFeishuTextContent(content: string): string | null {
   } catch {
     return null;
   }
+}
+
+function buildFeishuImageBridgeMedia(
+  imageKey: string,
+  refs: {
+    messageId: string;
+    chatId: string;
+  }
+): NonNullable<TelegramMessage["bridgeMedia"]>[number] {
+  return {
+    kind: "image",
+    resourceId: imageKey,
+    platformRef: {
+      platform: "feishu",
+      conversationId: refs.chatId,
+      messageId: refs.messageId,
+      resourceType: "image"
+    }
+  };
+}
+
+function buildFeishuFileBridgeMedia(
+  fileKey: string,
+  refs: {
+    messageId: string;
+    chatId: string;
+  },
+  fileName?: string
+): NonNullable<TelegramMessage["bridgeMedia"]>[number] {
+  return {
+    kind: "file",
+    resourceId: fileKey,
+    ...(typeof fileName === "string" && fileName.trim() ? { fileName } : {}),
+    platformRef: {
+      platform: "feishu",
+      conversationId: refs.chatId,
+      messageId: refs.messageId,
+      resourceType: "file"
+    }
+  };
+}
+
+function parseFeishuPostContent(
+  parsed: {
+    title?: string;
+    content?: Array<Array<{
+      tag?: string;
+      text?: string;
+      image_key?: string;
+    }>>;
+  },
+  refs: {
+    messageId: string;
+    chatId: string;
+  }
+): {
+  text: string | null;
+  bridgeMedia: NonNullable<TelegramMessage["bridgeMedia"]>;
+} {
+  const textLines: string[] = [];
+  const bridgeMedia: NonNullable<TelegramMessage["bridgeMedia"]> = [];
+
+  if (typeof parsed.title === "string" && parsed.title.trim()) {
+    textLines.push(parsed.title);
+  }
+
+  for (const line of parsed.content ?? []) {
+    if (!Array.isArray(line)) {
+      continue;
+    }
+
+    const inlineText: string[] = [];
+    for (const element of line) {
+      if (element?.tag === "img" && typeof element.image_key === "string" && element.image_key.trim()) {
+        bridgeMedia.push(buildFeishuImageBridgeMedia(element.image_key, refs));
+        continue;
+      }
+
+      if (typeof element?.text === "string" && element.text.trim()) {
+        inlineText.push(element.text);
+      }
+    }
+
+    if (inlineText.length > 0) {
+      textLines.push(inlineText.join(" "));
+    }
+  }
+
+  return {
+    text: textLines.length > 0 ? normalizeWhitespace(textLines.join("\n")) : null,
+    bridgeMedia
+  };
+}
+
+function parseFeishuMessageContent(
+  messageType: string,
+  content: string,
+  refs: {
+    messageId: string;
+    chatId: string;
+  }
+): {
+  text: string | null;
+  bridgeMedia: NonNullable<TelegramMessage["bridgeMedia"]>;
+} {
+  if (messageType === "text") {
+    return {
+      text: parseFeishuTextContent(content),
+      bridgeMedia: []
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(content) as {
+      image_key?: string;
+      file_key?: string;
+      file_name?: string;
+      title?: string;
+      content?: Array<Array<{
+        tag?: string;
+        text?: string;
+        image_key?: string;
+      }>>;
+    };
+
+    if (messageType === "image" && typeof parsed.image_key === "string" && parsed.image_key.trim()) {
+      return {
+        text: null,
+        bridgeMedia: [buildFeishuImageBridgeMedia(parsed.image_key, refs)]
+      };
+    }
+
+    if (messageType === "file" && typeof parsed.file_key === "string" && parsed.file_key.trim()) {
+      return {
+        text: null,
+        bridgeMedia: [buildFeishuFileBridgeMedia(parsed.file_key, refs, parsed.file_name)]
+      };
+    }
+
+    if (messageType === "post") {
+      return parseFeishuPostContent(parsed, refs);
+    }
+  } catch {
+    return {
+      text: null,
+      bridgeMedia: []
+    };
+  }
+
+  return {
+    text: null,
+    bridgeMedia: []
+  };
 }
 
 function extractFeishuCallbackData(event: {
@@ -270,26 +424,11 @@ export class FeishuTelegramPollerCompat {
       date: Math.floor(Number.parseInt(event.message.create_time, 10) / 1000)
     };
 
-    if (event.message.message_type === "text") {
-      const text = parseFeishuTextContent(event.message.content);
-      if (!text) {
-        return null;
-      }
-
-      return {
-        update_id: this.nextUpdateId++,
-        message: {
-          ...messageBase,
-          text
-        }
-      };
-    }
-
-    const bridgeMedia = parseFeishuMediaContent(event.message.message_type, event.message.content, {
+    const parsedContent = parseFeishuMessageContent(event.message.message_type, event.message.content, {
       messageId: event.message.message_id,
       chatId: event.message.chat_id
     });
-    if (bridgeMedia.length === 0) {
+    if (!parsedContent.text && parsedContent.bridgeMedia.length === 0) {
       return null;
     }
 
@@ -297,7 +436,8 @@ export class FeishuTelegramPollerCompat {
       update_id: this.nextUpdateId++,
       message: {
         ...messageBase,
-        bridgeMedia
+        ...(parsedContent.text ? { text: parsedContent.text } : {}),
+        ...(parsedContent.bridgeMedia.length > 0 ? { bridgeMedia: parsedContent.bridgeMedia } : {})
       }
     };
   }
@@ -523,51 +663,4 @@ export class FeishuTelegramPollerCompat {
     this.wsClient = wsClient;
     this.eventDispatcher = eventDispatcher;
   }
-}
-
-function parseFeishuMediaContent(
-  messageType: string,
-  content: string,
-  refs: {
-    messageId: string;
-    chatId: string;
-  }
-): NonNullable<TelegramMessage["bridgeMedia"]> {
-  try {
-    const parsed = JSON.parse(content) as {
-      image_key?: string;
-      file_key?: string;
-      file_name?: string;
-    };
-    if (messageType === "image" && typeof parsed.image_key === "string" && parsed.image_key.trim()) {
-      return [{
-        kind: "image",
-        resourceId: parsed.image_key,
-        platformRef: {
-          platform: "feishu",
-          conversationId: refs.chatId,
-          messageId: refs.messageId,
-          resourceType: "image"
-        }
-      }];
-    }
-
-    if (messageType === "file" && typeof parsed.file_key === "string" && parsed.file_key.trim()) {
-      return [{
-        kind: "file",
-        resourceId: parsed.file_key,
-        ...(typeof parsed.file_name === "string" && parsed.file_name.trim() ? { fileName: parsed.file_name } : {}),
-        platformRef: {
-          platform: "feishu",
-          conversationId: refs.chatId,
-          messageId: refs.messageId,
-          resourceType: "file"
-        }
-      }];
-    }
-  } catch {
-    return [];
-  }
-
-  return [];
 }

--- a/src/packs/feishu/index.test.ts
+++ b/src/packs/feishu/index.test.ts
@@ -1,7 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { validateFeishuUploadScopes } from "./index.js";
+import { FEISHU_PACK, validateFeishuUploadScopes } from "./index.js";
+
+test("feishu pack metadata reflects long-connection ingress and OpenAPI egress", () => {
+  assert.equal(FEISHU_PACK.ingress.kind, "long_connection");
+  assert.equal(FEISHU_PACK.egress.kind, "open_api");
+});
 
 test("validateFeishuUploadScopes reports missing upload scopes clearly", async () => {
   const result = await validateFeishuUploadScopes({

--- a/src/packs/feishu/index.ts
+++ b/src/packs/feishu/index.ts
@@ -303,7 +303,7 @@ export const FEISHU_PACK: BridgePackDefinition<FeishuPackConfig> = {
   skillName: FEISHU_PACK_SKILL_NAME,
   capabilities: FEISHU_SURFACE_CAPABILITY_SNAPSHOT,
   ingress: {
-    kind: "polling",
+    kind: "long_connection",
     ownsCallbacks: true,
     ownsRichInput: false,
     ownsMediaIngress: false
@@ -312,7 +312,7 @@ export const FEISHU_PACK: BridgePackDefinition<FeishuPackConfig> = {
     preferBridgeCommandButtons: true
   },
   egress: {
-    kind: "bot_api",
+    kind: "open_api",
     syncControlSurface: async () => {}
   },
   authBinding: {

--- a/src/packs/feishu/setup.test.ts
+++ b/src/packs/feishu/setup.test.ts
@@ -6,6 +6,7 @@ import {
   applyFeishuSetupObservation,
   applyFeishuSetupToSnapshot,
   FEISHU_SETUP_CHECKLIST,
+  mergeStoredFeishuSetupMetadata,
   resetFeishuSetupCycle
 } from "./setup.js";
 
@@ -73,6 +74,40 @@ test("resetFeishuSetupCycle clears previous Feishu observations", () => {
   assert.equal(reset.details.packMetadata?.feishuLastTextIngressAt, null);
   assert.equal(reset.details.packMetadata?.feishuLastInteractiveCardSentAt, null);
   assert.equal(reset.details.packMetadata?.feishuLastCardCallbackAt, null);
+});
+
+test("mergeStoredFeishuSetupMetadata preserves stored observations when the fresh report omits them", () => {
+  const merged = mergeStoredFeishuSetupMetadata({
+    feishuAppId: "cli_test"
+  }, {
+    feishuAppId: "cli_test",
+    feishuSetupEpoch: "2026-04-09T00:00:00.000Z",
+    feishuLastTextIngressAt: "2026-04-09T00:01:00.000Z",
+    feishuLastInteractiveCardSentAt: "2026-04-09T00:02:00.000Z",
+    feishuLastCardCallbackAt: "2026-04-09T00:03:00.000Z"
+  });
+
+  assert.equal(merged.feishuSetupEpoch, "2026-04-09T00:00:00.000Z");
+  assert.equal(merged.feishuLastTextIngressAt, "2026-04-09T00:01:00.000Z");
+  assert.equal(merged.feishuLastInteractiveCardSentAt, "2026-04-09T00:02:00.000Z");
+  assert.equal(merged.feishuLastCardCallbackAt, "2026-04-09T00:03:00.000Z");
+});
+
+test("mergeStoredFeishuSetupMetadata does not reuse stored observations when the Feishu app changes", () => {
+  const merged = mergeStoredFeishuSetupMetadata({
+    feishuAppId: "new_app"
+  }, {
+    feishuAppId: "old_app",
+    feishuSetupEpoch: "2026-04-09T00:00:00.000Z",
+    feishuLastTextIngressAt: "2026-04-09T00:01:00.000Z",
+    feishuLastInteractiveCardSentAt: "2026-04-09T00:02:00.000Z",
+    feishuLastCardCallbackAt: "2026-04-09T00:03:00.000Z"
+  });
+
+  assert.equal(merged.feishuSetupEpoch, undefined);
+  assert.equal(merged.feishuLastTextIngressAt, undefined);
+  assert.equal(merged.feishuLastInteractiveCardSentAt, undefined);
+  assert.equal(merged.feishuLastCardCallbackAt, undefined);
 });
 
 test("feishu setup checklist includes upload scopes for file sending", () => {

--- a/src/packs/feishu/setup.ts
+++ b/src/packs/feishu/setup.ts
@@ -15,6 +15,7 @@ const FEISHU_TEXT_INGRESS_CHECK_ID = "feishu_text_ingress_observed";
 const FEISHU_INTERACTIVE_SEND_CHECK_ID = "feishu_interactive_card_delivery_observed";
 const FEISHU_CALLBACK_CHECK_ID = "feishu_card_callback_observed";
 const FEISHU_CONTENTION_CHECK_ID = "feishu_shared_app_contention_suspected";
+const FEISHU_APP_ID_METADATA_KEY = "feishuAppId";
 
 const FEISHU_OBSERVED_CHECK_IDS = new Set([
   FEISHU_TEXT_INGRESS_CHECK_ID,
@@ -114,6 +115,47 @@ export function mergeFeishuSetupMetadata(
   }
   if (patch.lastInteractiveError !== undefined) {
     next[FEISHU_SETUP_METADATA_KEYS.interactiveError] = patch.lastInteractiveError;
+  }
+
+  return next;
+}
+
+export function mergeStoredFeishuSetupMetadata(
+  metadata: PackMetadata | undefined,
+  storedMetadata: PackMetadata | undefined
+): PackMetadata {
+  const next = {
+    ...(metadata ?? {})
+  };
+  const currentAppId = readStringMetadata(next, FEISHU_APP_ID_METADATA_KEY);
+  const storedAppId = readStringMetadata(storedMetadata, FEISHU_APP_ID_METADATA_KEY);
+
+  if (!currentAppId || !storedAppId || currentAppId !== storedAppId) {
+    return next;
+  }
+
+  const current = readFeishuSetupObservations(next);
+  const stored = readFeishuSetupObservations(storedMetadata);
+  const storedEpoch = readStringMetadata(storedMetadata, FEISHU_SETUP_METADATA_KEYS.epoch);
+
+  if (!readStringMetadata(next, FEISHU_SETUP_METADATA_KEYS.epoch) && storedEpoch) {
+    next[FEISHU_SETUP_METADATA_KEYS.epoch] = storedEpoch;
+  }
+
+  if (current.lastTextIngressAt === null && stored.lastTextIngressAt !== null) {
+    next[FEISHU_SETUP_METADATA_KEYS.textIngressAt] = stored.lastTextIngressAt;
+  }
+  if (current.lastInteractiveCardSentAt === null && stored.lastInteractiveCardSentAt !== null) {
+    next[FEISHU_SETUP_METADATA_KEYS.interactiveCardSentAt] = stored.lastInteractiveCardSentAt;
+  }
+  if (current.lastCardCallbackAt === null && stored.lastCardCallbackAt !== null) {
+    next[FEISHU_SETUP_METADATA_KEYS.cardCallbackAt] = stored.lastCardCallbackAt;
+  }
+  if (current.lastInteractiveErrorCode === null && stored.lastInteractiveErrorCode !== null) {
+    next[FEISHU_SETUP_METADATA_KEYS.interactiveErrorCode] = stored.lastInteractiveErrorCode;
+  }
+  if (current.lastInteractiveError === null && stored.lastInteractiveError !== null) {
+    next[FEISHU_SETUP_METADATA_KEYS.interactiveError] = stored.lastInteractiveError;
   }
 
   return next;

--- a/src/packs/registry.test.ts
+++ b/src/packs/registry.test.ts
@@ -61,11 +61,12 @@ test("feishu pack exposes the phase 4 pack contract surface", () => {
   const pack = getBridgePack("feishu");
 
   assert.equal(pack.name, "feishu");
+  assert.equal(pack.ingress.kind, "long_connection");
   assert.equal(pack.ingress.ownsCallbacks, true);
   assert.equal(pack.ingress.ownsRichInput, false);
   assert.equal(pack.ingress.ownsMediaIngress, false);
   assert.equal(pack.presentation.preferBridgeCommandButtons, true);
-  assert.equal(pack.egress.kind, "bot_api");
+  assert.equal(pack.egress.kind, "open_api");
   assert.equal(pack.capabilities.supportsUploads, true);
   assert.equal(pack.capabilities.canReceiveImage, true);
   assert.deepEqual(

--- a/src/readiness.test.ts
+++ b/src/readiness.test.ts
@@ -8,6 +8,7 @@ import type { BridgeConfig } from "./config.js";
 import type { Logger } from "./logger.js";
 import type { BridgePaths } from "./paths.js";
 import type { PackHealthReport } from "./packs/contract.js";
+import { buildFeishuSetupHealth } from "./packs/feishu/setup.js";
 import { probeReadiness } from "./readiness.js";
 import { BridgeStateStore } from "./state/store.js";
 
@@ -58,6 +59,22 @@ const testConfig: BridgeConfig = {
   appServerGuardMcpWorkerThreshold: 6,
   appServerGuardConsecutiveWindows: 3,
   appServerGuardCooldownMs: 900_000
+};
+const feishuTestConfig: BridgeConfig = {
+  ...testConfig,
+  activePack: "feishu",
+  shared: {
+    ...testConfig.shared,
+    activePack: "feishu"
+  },
+  packs: {
+    ...testConfig.packs,
+    feishu: {
+      appId: "cli_test",
+      appSecret: "secret",
+      apiBaseUrl: "https://open.feishu.cn"
+    }
+  }
 };
 const REQUIRED_CLIENT_REQUESTS = [
   "thread/list",
@@ -172,6 +189,77 @@ function createTelegramPackHealthReport(
     },
     ...overrides
   };
+}
+
+function createFeishuPackHealthReport(
+  overrides?: Partial<PackHealthReport>
+): PackHealthReport {
+  const report: PackHealthReport = {
+    state: "ready",
+    checks: [
+      { id: "feishu_credentials", ok: true, summary: "feishu credentials configured" },
+      { id: "feishu_tenant_token_validation", ok: true, summary: "feishu tenant access token validated" },
+      { id: "feishu_authorization_binding", ok: true, summary: "feishu authorization is bound" }
+    ],
+    issues: [],
+    metadata: {
+      feishuAppId: "cli_test"
+    }
+  };
+
+  return {
+    ...report,
+    ...buildFeishuSetupHealth({
+      report,
+      authorized: true
+    }),
+    ...overrides
+  };
+}
+
+function createSuccessfulProbeDeps(runPackHealthCheck: () => Promise<PackHealthReport>) {
+  return {
+    nodeVersion: process.version,
+    detectServiceManager: async () => ({
+      manager: "none" as const,
+      health: "warning" as const,
+      issues: []
+    }),
+    commandExists: async () => true,
+    runCommand: async (_command: string, args: string[]) => {
+      if (args[0] === "--version") {
+        return { exitCode: 0, stdout: "codex-cli 0.114.0", stderr: "" };
+      }
+      if (args[0] === "login") {
+        return { exitCode: 0, stdout: "Logged in", stderr: "" };
+      }
+      throw new Error(`unexpected command: ${args.join(" ")}`);
+    },
+    runPackHealthCheck,
+    createAppServer: () => ({
+      pid: 123,
+      initializeAndProbe: async () => {},
+      stop: async () => {}
+    }),
+    evaluateCapabilities: async () => ({
+      ok: true,
+      source: "cache" as const,
+      issues: []
+    })
+  };
+}
+
+function authorizeFeishu(store: BridgeStateStore): void {
+  store.upsertPendingAuthorization({
+    platform: "feishu",
+    userId: "feishu-user",
+    chatId: "feishu-chat",
+    username: "feishu-user",
+    displayName: "Feishu User"
+  });
+  const candidate = store.listPendingAuthorizations({ platform: "feishu" })[0];
+  assert.ok(candidate);
+  store.confirmPendingAuthorization(candidate);
 }
 
 async function writeCapabilitySchemas(
@@ -831,6 +919,138 @@ test("probeReadiness caches capability mismatches that come from a successful sc
     assert.equal(second.snapshot.details.capabilityCheckSource, "cache");
     assert.match(second.snapshot.details.issues.join("\n"), /thread\/archived/u);
     assert.equal(schemaAttempts, 1);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("probeReadiness preserves stored Feishu setup observations during non-persistent recomputation", async () => {
+  const { paths, store, cleanup } = await createReadinessContext();
+
+  try {
+    authorizeFeishu(store);
+    store.writeReadinessSnapshot({
+      state: "ready",
+      checkedAt: "2026-04-21T00:03:00.000Z",
+      details: {
+        activePack: "feishu",
+        codexInstalled: true,
+        codexAuthenticated: true,
+        appServerAvailable: true,
+        packState: "ready",
+        setupState: "complete",
+        packMetadata: {
+          feishuAppId: "cli_test",
+          feishuSetupEpoch: "2026-04-21T00:00:00.000Z",
+          feishuLastTextIngressAt: "2026-04-21T00:01:00.000Z",
+          feishuLastInteractiveCardSentAt: "2026-04-21T00:02:00.000Z",
+          feishuLastCardCallbackAt: "2026-04-21T00:03:00.000Z"
+        },
+        authorizedUserBound: true,
+        issues: [],
+        sharedIssues: [],
+        packIssues: [],
+        packChecks: []
+      },
+      appServerPid: null
+    });
+
+    const result = await probeReadiness({
+      config: feishuTestConfig,
+      store,
+      paths,
+      logger: testLogger,
+      persist: false,
+      deps: createSuccessfulProbeDeps(async () => createFeishuPackHealthReport())
+    } as any);
+
+    assert.equal(result.snapshot.details.setupState, "complete");
+    assert.deepEqual(result.snapshot.details.packIssues, []);
+    assert.equal(result.snapshot.details.packMetadata?.feishuSetupEpoch, "2026-04-21T00:00:00.000Z");
+    assert.equal(result.snapshot.details.packMetadata?.feishuLastTextIngressAt, "2026-04-21T00:01:00.000Z");
+    assert.equal(result.snapshot.details.packMetadata?.feishuLastInteractiveCardSentAt, "2026-04-21T00:02:00.000Z");
+    assert.equal(result.snapshot.details.packMetadata?.feishuLastCardCallbackAt, "2026-04-21T00:03:00.000Z");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("probeReadiness does not reuse stored Feishu setup observations when the Feishu app changes", async () => {
+  const { paths, store, cleanup } = await createReadinessContext();
+
+  try {
+    authorizeFeishu(store);
+    store.writeReadinessSnapshot({
+      state: "ready",
+      checkedAt: "2026-04-21T00:03:00.000Z",
+      details: {
+        activePack: "feishu",
+        codexInstalled: true,
+        codexAuthenticated: true,
+        appServerAvailable: true,
+        packState: "ready",
+        setupState: "complete",
+        packMetadata: {
+          feishuAppId: "old_app",
+          feishuSetupEpoch: "2026-04-21T00:00:00.000Z",
+          feishuLastTextIngressAt: "2026-04-21T00:01:00.000Z",
+          feishuLastInteractiveCardSentAt: "2026-04-21T00:02:00.000Z",
+          feishuLastCardCallbackAt: "2026-04-21T00:03:00.000Z"
+        },
+        authorizedUserBound: true,
+        issues: [],
+        sharedIssues: [],
+        packIssues: [],
+        packChecks: []
+      },
+      appServerPid: null
+    });
+
+    const result = await probeReadiness({
+      config: feishuTestConfig,
+      store,
+      paths,
+      logger: testLogger,
+      persist: false,
+      deps: createSuccessfulProbeDeps(async () => createFeishuPackHealthReport({
+        metadata: {
+          feishuAppId: "new_app"
+        }
+      }))
+    } as any);
+
+    assert.equal(result.snapshot.details.setupState, "incomplete");
+    assert.equal(result.snapshot.details.packMetadata?.feishuSetupEpoch, undefined);
+    assert.equal(result.snapshot.details.packMetadata?.feishuLastTextIngressAt, undefined);
+    assert.equal(result.snapshot.details.packMetadata?.feishuLastInteractiveCardSentAt, undefined);
+    assert.equal(result.snapshot.details.packMetadata?.feishuLastCardCallbackAt, undefined);
+    const packIssues = result.snapshot.details.packIssues ?? [];
+    assert.match(packIssues.join("\n"), /text ingress has not been observed/u);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("probeReadiness still reports missing Feishu observations when none are stored", async () => {
+  const { paths, store, cleanup } = await createReadinessContext();
+
+  try {
+    authorizeFeishu(store);
+
+    const result = await probeReadiness({
+      config: feishuTestConfig,
+      store,
+      paths,
+      logger: testLogger,
+      persist: false,
+      deps: createSuccessfulProbeDeps(async () => createFeishuPackHealthReport())
+    } as any);
+
+    assert.equal(result.snapshot.details.setupState, "incomplete");
+    assert.match(result.snapshot.details.issues.join("\n"), /text ingress has not been observed/u);
+    assert.match(result.snapshot.details.issues.join("\n"), /interactive card delivery has not been observed/u);
+    assert.match(result.snapshot.details.issues.join("\n"), /card callback has not been observed/u);
+    assert.match(result.snapshot.details.issues.join("\n"), /another long-connection client may be consuming events/u);
   } finally {
     await cleanup();
   }

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path";
 import { CodexAppServerClient } from "./codex/app-server.js";
 import type { Logger } from "./logger.js";
 import type { BridgePaths } from "./paths.js";
+import { buildFeishuSetupHealth, mergeStoredFeishuSetupMetadata } from "./packs/feishu/setup.js";
 import { getActiveBridgePack } from "./packs/registry.js";
 import type { PackHealthReport } from "./packs/contract.js";
 import { commandExists, resolveCommand, runCommand, type CommandResult } from "./process.js";
@@ -702,7 +703,7 @@ export async function probeReadiness(options: {
     return finalizeFailure("bridge_unhealthy", details, store, persist);
   }
 
-  const packReport = await (deps.runPackHealthCheck
+  let packReport = await (deps.runPackHealthCheck
     ? deps.runPackHealthCheck({
         pack,
         config,
@@ -714,6 +715,21 @@ export async function probeReadiness(options: {
         store,
         logger
       }));
+  if (config.activePack === "feishu") {
+    const storedSnapshot = store.getReadinessSnapshot();
+    if (storedSnapshot?.details.activePack === "feishu") {
+      packReport = {
+        ...packReport,
+        ...buildFeishuSetupHealth({
+          report: {
+            ...packReport,
+            metadata: mergeStoredFeishuSetupMetadata(packReport.metadata, storedSnapshot.details.packMetadata)
+          },
+          authorized: pack.authBinding.isBound(store)
+        })
+      };
+    }
+  }
   packChecks.push(...packReport.checks);
   packIssues.push(...packReport.issues.map((issue) => normalizeIssue(issue)));
   details.issues.push(...packReport.issues.map((issue) => normalizeIssue(issue)));


### PR DESCRIPTION
# Codex Console Phase 2 Release Note

Status: ready for PR
Branch: `feat/codex-console-phase2`
Base: `master`

## Summary

This change continues the Codex Console platform-abstraction landing after the initial naming and capability-matrix work.

It keeps all compatibility identifiers unchanged:

- repository/package name remains `telegram-codex-bridge`
- CLI remains `ctb`
- existing service/config/state path names remain unchanged
- Telegram remains the stable first/default pack
- Feishu remains a serious current pack with explicit setup/readiness caveats

## Commits

1. `79bcb1d docs: clarify Codex Console install paths`
   - Splits README install guidance into Telegram default path and Feishu pack path.
   - Adds Feishu direct install examples using `--pack feishu` and `--pack-option`.
   - Updates operations docs and product scope wording so Feishu is current but not treated as identical to Telegram UX.

2. `a024753 docs: audit Feishu capability against official APIs`
   - Adds an official Feishu developer-doc-backed capability audit.
   - Covers long connection/events, text receive, cards, card callbacks, image/file upload and download, long-output risks, status cards, session/project flows, and bot-menu limits.
   - Separates confirmed API+code support from items needing live tenant smoke.

3. `0667c6f refactor: clarify Feishu pack transport metadata`
   - Updates Feishu pack metadata from compatibility-shaped labels to actual current behavior:
     - ingress: `long_connection`
     - egress: `open_api`
   - Adds tests for the metadata and updates docs caveats.
   - Keeps broader compatibility-adapter caveats intact.

4. `29e1593 docs: sketch Web App control surface`
   - Adds a future Web/App control surface sketch.
   - Defines Core reuse targets, Pack/Presentation responsibilities, readiness gates, migration lessons, open decisions, and sequencing.
   - Explicitly does not claim current Web/App support.

## User-visible impact

- Codex Console docs are less Telegram-only while preserving Telegram as the default path.
- Feishu setup and capability boundaries are easier to discover.
- Feishu official API evidence is captured for future smoke testing.
- The most obvious Feishu pack metadata mismatch is fixed and tested.
- Web/App planning now has a concrete document that avoids forcing Web/App into a fake chat-pack shape.

## Known remaining gaps

- No live Feishu tenant smoke was performed in this change set.
- Feishu pin/unpin remains non-native.
- Feishu bot-menu discovery remains externally configured and smaller than Telegram command sync.
- Feishu voice/audio and remote image URL support remain unsupported by current pack capabilities.
- Web/App remains future design only.

## Verification

Run from the branch worktree:

```bash
git diff --check
node --import tsx --test src/packs/feishu/index.test.ts src/packs/registry.test.ts
npm run check
npm test
```

Expected result: all pass.
