### PR TITLE
Codex Console Web owner preview

### DIFF
--- a/.hermes/web-chat-phase-d-status.md
+++ b/.hermes/web-chat-phase-d-status.md
@@ -8,6 +8,7 @@ YES
 - Added environment-gated live startup with `CTB_WEB_LIVE_ENABLED` / `CTB_WEB_CHAT_ENABLED`, local-only host validation, token requirement, and deterministic CSRF token derivation when no explicit token is supplied.
 - Built the live readonly provider from the running service store/runtime so conversation detail can include current active-turn status plus persisted results and pending interactions.
 - Added safe thread refresh affordance and send-status flash copy after POST redirects, without exposing raw chat/session/thread/turn ids, local paths, tokens, stack traces, or app-server payloads.
+- Kept disabled/read-only copy for the standalone harness while changing send-enabled Web Chat pages to describe the thread as live/continuable rather than view-only.
 - Updated the managed preview start script to support `CTB_WEB_PREVIEW_MODE=live`, reusing an already-listening live bridge Web Chat upstream instead of starting the DB-only readonly harness.
 
 ## Files changed
@@ -24,6 +25,7 @@ YES
 - `npx tsx --test src/web/readonly-http-server.test.ts src/service-web-submit.test.ts`
 - `npm run check`
 - `python3 scripts/web-owner-cookie-proxy.py --self-test`
+- `bash -n scripts/web-preview-start.sh`
 - `git diff --check`
 
 ## Live-service usability
@@ -36,7 +38,7 @@ Live-service wiring is now implemented. When the managed bridge service is start
 - Thread display remains session/result/runtime oriented until a chronological message projection lands.
 
 ## Next Phase E plan
-1. Commit and push Phase D accepted changes.
-2. Configure/start the managed bridge service with live Web Chat enabled.
-3. Restart managed preview in live mode and smoke login, home, conversation detail, composer presence, safe POST behavior, and public URL.
-4. Update the PR body with commits, URL, tests, and Windows out-of-scope note.
+1. Configure/start the managed bridge service with live Web Chat enabled.
+2. Restart managed preview in live mode and smoke login, home, conversation detail, composer presence, safe POST behavior, and public URL.
+3. Verify public pages/responses do not leak raw ids, local paths, tokens, passwords, or stack traces.
+4. Update the PR body with live preview URL, tests, and Windows out-of-scope note when requested.

--- a/.hermes/web-chat-phase-d-status.md
+++ b/.hermes/web-chat-phase-d-status.md
@@ -1,0 +1,42 @@
+# Web Chat Phase D Status
+
+## Completed YES/NO
+YES
+
+## Actual scope
+- Wired the Web Chat HTTP surface into the live `BridgeService` process via `createWebChatHttpServer(...)` and `startWebChatHttpServer(...)`.
+- Added environment-gated live startup with `CTB_WEB_LIVE_ENABLED` / `CTB_WEB_CHAT_ENABLED`, local-only host validation, token requirement, and deterministic CSRF token derivation when no explicit token is supplied.
+- Built the live readonly provider from the running service store/runtime so conversation detail can include current active-turn status plus persisted results and pending interactions.
+- Added safe thread refresh affordance and send-status flash copy after POST redirects, without exposing raw chat/session/thread/turn ids, local paths, tokens, stack traces, or app-server payloads.
+- Updated the managed preview start script to support `CTB_WEB_PREVIEW_MODE=live`, reusing an already-listening live bridge Web Chat upstream instead of starting the DB-only readonly harness.
+
+## Files changed
+- `src/service.ts`
+- `src/service-web-submit.test.ts`
+- `src/web/readonly-http-server.ts`
+- `src/web/readonly-http-server.test.ts`
+- `src/web/readonly-renderer.ts`
+- `scripts/web-preview-start.sh`
+- `docs/plans/2026-04-26-web-chat-platform-pm-ledger.md`
+- `.hermes/web-chat-phase-d-status.md`
+
+## Tests run
+- `npx tsx --test src/web/readonly-http-server.test.ts src/service-web-submit.test.ts`
+- `npm run check`
+- `python3 scripts/web-owner-cookie-proxy.py --self-test`
+- `git diff --check`
+
+## Live-service usability
+Live-service wiring is now implemented. When the managed bridge service is started with `CTB_WEB_LIVE_ENABLED=1`, a local owner-authenticated Web Chat upstream exposes the chat-first UI with an enabled composer and delegates browser text messages to the same service submit seam used by existing bridge turn semantics.
+
+## Risks / notes
+- The live Web Chat upstream is intentionally local-only and should stay behind the owner cookie proxy/public tunnel.
+- Managed preview live mode requires the live bridge service to be running with matching token/port environment; the preview script fails closed if the live upstream is absent.
+- The first refresh model is still HTTP refresh/poll-by-reload, not WebSocket streaming.
+- Thread display remains session/result/runtime oriented until a chronological message projection lands.
+
+## Next Phase E plan
+1. Commit and push Phase D accepted changes.
+2. Configure/start the managed bridge service with live Web Chat enabled.
+3. Restart managed preview in live mode and smoke login, home, conversation detail, composer presence, safe POST behavior, and public URL.
+4. Update the PR body with commits, URL, tests, and Windows out-of-scope note.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -81,6 +81,7 @@ Read the smallest matching leaf doc.
 | current Telegram/Feishu capability table, common capability vs platform-specific features, or future Web/App target capability rows | `docs/architecture/platform-capability-matrix.md` |
 | Web/App pre-implementation Core/state/API contract, readiness gates, or support-claim guardrails | `docs/architecture/web-app-preimplementation-contract.md` |
 | install flow, config keys, paths, services, update, diagnostics | `docs/operations/install-and-admin.md` |
+| active owner Web preview start/stop/status/smoke/rotate/rollback | `docs/operations/web-preview-runbook.md` |
 | exact current versions, module counts, size snapshot, other high-drift facts | `docs/generated/current-snapshot.md` |
 | authoritative Codex app-server protocol reference | `docs/research/codex-app-server-authoritative-reference.md` |
 | method-by-method protocol lookup | `docs/research/codex-app-server-api-quick-reference.md` |

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -79,6 +79,7 @@ Read the smallest matching leaf doc.
 | current Codex app-server adoption, supported request families, notification reduction, approvals, and rejected server requests | `docs/architecture/codex-app-server-adoption.md` |
 | current pack boundary, active pack selection, Telegram vs Feishu pack ownership, or platform capability routing | `docs/architecture/platform-pack-boundary.md` |
 | current Telegram/Feishu capability table, common capability vs platform-specific features, or future Web/App target capability rows | `docs/architecture/platform-capability-matrix.md` |
+| Web/App pre-implementation Core/state/API contract, readiness gates, or support-claim guardrails | `docs/architecture/web-app-preimplementation-contract.md` |
 | install flow, config keys, paths, services, update, diagnostics | `docs/operations/install-and-admin.md` |
 | exact current versions, module counts, size snapshot, other high-drift facts | `docs/generated/current-snapshot.md` |
 | authoritative Codex app-server protocol reference | `docs/research/codex-app-server-authoritative-reference.md` |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -37,7 +37,7 @@ Open one entrypoint, then one leaf, then stop.
 ## Current Truth
 
 - `docs/product/README.md` - current Codex Console product behavior, including Telegram-first scope, commands, and callback UX.
-- `docs/architecture/README.md` - current runtime shape, bridge-versus-platform decoupling status, state model, pack boundary, capability matrix, and code ownership.
+- `docs/architecture/README.md` - current runtime shape, bridge-versus-platform decoupling status, state model, pack boundary, capability matrix, code ownership, and clearly labeled future/pre-implementation Web/App contract leaf.
 - `docs/operations/README.md` - install, active-pack selection, config, service, update, and diagnostics.
 - `docs/generated/current-snapshot.md` - exact version baselines and other high-drift facts.
 
@@ -47,7 +47,7 @@ Open one entrypoint, then one leaf, then stop.
 
 ## Future, Planning, And History
 
-- `docs/future/README.md` - future product and architecture direction, including the broader Codex Bridge Core path and Web/App control surface sketch.
+- `docs/future/README.md` - future product and architecture direction, including the broader Codex Bridge Core path, Web/App control surface sketch, and contract-pass handoff.
 - `docs/plans/README.md` - active trackers, implementation sequencing, and closeout notes.
 - `docs/roadmap/README.md` - delivery ordering, continuation handoff, and acceptance intent.
 - `docs/archive/README.md` - historical material only when current sources conflict.

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,9 @@ If you are starting a new Codex Console continuation task, open `docs/roadmap/co
 - Exact Codex app-server capability or payload shape: `docs/research/README.md`
 - Future Codex Bridge Core direction: `docs/future/multi-platform-core-prd.md`
 - Future Web/App control surface sketch: `docs/future/web-app-control-surface-sketch.md`
+- Web-first MVP scope/readiness and VPS/mobile validation gates: `docs/future/web-mvp-scope-and-readiness.md`
+- Future Web prototype protected URL and mobile-access security plan: `docs/operations/web-vps-mobile-access-and-security.md`
+- Web/App pre-implementation contract and readiness gates: `docs/architecture/web-app-preimplementation-contract.md`
 - Phase 2 summary / PR note: `docs/plans/2026-04-26-codex-console-phase2-release-note.md`
 
 ## Rules That Matter

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -9,7 +9,8 @@ children:
   - docs/architecture/codex-app-server-adoption.md
   - docs/architecture/platform-pack-boundary.md
   - docs/architecture/platform-capability-matrix.md
-summary: router for the current runtime shape, decoupling status, state model, verified code ownership map, pack boundary, capability matrix, and app-server adoption boundary
+  - docs/architecture/web-app-preimplementation-contract.md
+summary: router for the current runtime shape, decoupling status, state model, verified code ownership map, pack boundary, capability matrix, app-server adoption boundary, and future Web/App pre-implementation contract
 read_when:
   - the request is about current runtime lifecycle, state, recovery, or code ownership
   - the request needs the current implementation map before opening source files
@@ -23,6 +24,7 @@ source_of_truth:
   - docs/architecture/codex-app-server-adoption.md
   - docs/architecture/platform-pack-boundary.md
   - docs/architecture/platform-capability-matrix.md
+  - docs/architecture/web-app-preimplementation-contract.md
   - src
 -->
 
@@ -39,6 +41,7 @@ This is still Telegram-first runtime truth, not future-Core intent.
 - `codex-app-server-adoption.md` - current bridge-owned app-server lifecycle, request families, server-request handling, and notification reduction.
 - `platform-pack-boundary.md` - current active-pack contract, runtime factory, health checks, and Telegram vs Feishu ownership split.
 - `platform-capability-matrix.md` - current Telegram/Feishu capability matrix, common product expectations, platform-specific features, and future Web/App target rows.
+- `web-app-preimplementation-contract.md` - future Web/App Core/state/API contract and readiness gates that must be used before any Web/App implementation begins.
 
 ## Skip This Directory When
 

--- a/docs/architecture/platform-capability-matrix.md
+++ b/docs/architecture/platform-capability-matrix.md
@@ -152,7 +152,7 @@ These rows decide how good the experience can be on a platform. They should not 
 
 For future pack planning, track four readiness levels separately:
 
-1. **Static declared capability** — the pack says the platform can do it.
+1. **Declared capability** — the pack says the platform can do it.
 2. **Configured capability** — credentials, scopes, app settings, and local dependencies are present.
 3. **Observed capability** — the bridge has seen text ingress, callback/action events, uploads, or other required platform signals.
 4. **UX-exposed capability** — users can reach it through menus, cards, commands, buttons, or docs.
@@ -195,7 +195,7 @@ But it should use native Web/App presentation:
 - live updates through Web/App transport
 - explicit admin/setup pages
 
-Separate product decisions are still required before Web/App expands scope into multi-user collaboration, provider setup, raw terminal views, project write operations, or team permissions.
+Before any Web/App implementation begins, use `web-app-preimplementation-contract.md` as the required neutral Core/state/API contract and readiness-gate artifact. Separate product decisions are still required before Web/App expands scope into multi-user collaboration, provider setup, raw terminal views, project write operations, or team permissions.
 
 ## Owner Decision Rules
 

--- a/docs/architecture/web-app-preimplementation-contract.md
+++ b/docs/architecture/web-app-preimplementation-contract.md
@@ -1,0 +1,280 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/architecture/README.md
+children: []
+summary: pre-implementation Core/state/API contracts and readiness gates for future Web/App Codex Console surfaces
+read_when:
+  - before starting any Web/App prototype or implementation for Codex Console
+  - the request needs neutral Core/state/API contracts for future Web/App work
+  - the request needs readiness gates before Web/App can be called supported
+skip_when:
+  - the request is about current Telegram or Feishu shipped behavior
+  - the request is asking for Web/App source code, routes, components, handlers, or transport plumbing
+source_of_truth:
+  - docs/architecture/web-app-preimplementation-contract.md
+  - docs/architecture/platform-capability-matrix.md
+  - docs/future/web-app-control-surface-sketch.md
+-->
+
+# Web/App Pre-Implementation Contract
+
+Status: Pre-implementation contract for future design only
+Owner: Architecture / Product
+Last updated: 2026-04-26
+
+This document is the contract-pass output for the future Web/App Codex Console surface.
+It defines the neutral Core, state, and API-surface meanings that a future Web/App prototype
+must use before any source-code implementation begins.
+
+It does **not** claim current Web/App support. Telegram remains the stable first/default pack.
+Feishu remains a serious current pack with explicit setup and readiness caveats. Compatibility
+names stay unchanged: repository/package `telegram-codex-bridge`, CLI `ctb`, and existing
+service, config, state, and environment paths.
+
+## Purpose
+
+A future Web/App surface must be a native control surface over shared Codex Bridge Core
+semantics, not a fake chat pack and not a parallel product. This contract exists to keep
+future implementation work small and reviewable by defining:
+
+- the shared product meanings Web/App must consume or expose;
+- the boundary between Core, Presentation, Pack, and Web/App-owned transport/storage/layout;
+- readiness gates that must pass before Web/App can be called supported;
+- non-goals and guardrails that prevent overclaiming current capability.
+
+## Contract Vocabulary
+
+Use these neutral terms in future Web/App implementation and docs:
+
+| Term | Contract meaning |
+|---|---|
+| **Control surface** | The authorized operator-facing UI, regardless of platform. It may be a chat, panel, page, app shell, or native window. |
+| **Project** | A selectable workspace/root known to the bridge. The contract covers selection and browsing, not future project write operations. |
+| **Session** | A durable conversation/workflow context associated with a project and operator binding. |
+| **Turn** | One submitted task or continuation, with lifecycle state and timestamps. |
+| **Interaction** | A Core-requested operator response such as an approval, question, picker choice, pagination action, or recovery decision. |
+| **Runtime status** | Current and recent workflow health, progress, blocked state, inspect detail, and degraded/recovered state. |
+| **Final answer** | The completed assistant answer, separate from transient progress, logs, recent output, and delivery status. |
+| **Artifact** | A generated or referenced file/image/result that can be previewed, downloaded, or linked through platform-owned handles. |
+| **Delivery outcome** | The result of attempting to render or deliver a Core event/result to a control surface. |
+| **Readiness level** | One of declared, configured, observed, or UX-exposed capability for a required baseline journey. |
+
+## Ownership Boundaries
+
+| Layer | Owns | Must not own |
+|---|---|---|
+| **Core** | Project/session meaning, turn lifecycle, interaction models, runtime status, final-answer meaning, artifact descriptors, delivery-outcome semantics. | Web routes, component layout, browser/app storage, WebSocket/SSE plumbing, cookies, push subscriptions, CSS, Telegram buttons, Feishu card JSON. |
+| **Presentation** | Mapping neutral state and interactions into surface-specific views such as panels, forms, modals, drawers, cards, pages, or streams. | Product workflow state machines, platform credentials, transport sessions, persistent browser/app secrets. |
+| **Pack** | Platform identity, ingress/egress adaptation, auth binding, health checks, dynamic tools, platform resource handles, setup probes. | Shared Codex workflow semantics or Web/App page layout. |
+| **Web/App transport/storage/layout** | Routes/pages, client state, live transport, cookies/session security, browser/app storage, upload widgets, responsive layout, notifications, previews. | Core-owned workflow decisions or support claims before readiness gates pass. |
+
+Future Web/App code may introduce internal APIs, but those APIs must carry these neutral
+meanings instead of leaking chat-message ids, Feishu card ids, browser component ids, upload
+tokens, or local temp paths into Core contracts.
+
+## Project And Session Surface Contract
+
+A future Web/App prototype must use a neutral project/session surface with these meanings:
+
+- list selectable projects with stable ids, display labels, path/workspace metadata where allowed,
+  and unavailable/empty/error states;
+- list recent sessions with stable ids, project association, title/summary where available, last
+  activity, archived/pinned state where supported, and continuation eligibility;
+- read the active project and session for the authorized control surface;
+- start a new session, resume an existing session, and switch active project/session through Core-owned
+  workflow rules;
+- expose archive, unarchive, rename, and pin only where the current product semantics support them;
+- separate read-only browsing/history from any future project write operation.
+
+The contract outcome is a Web/App view model that can render dashboards, sidebars, history lists,
+and empty-state panels without assuming chat chronology or platform message ids.
+
+## Turn Lifecycle Contract
+
+A future Web/App turn surface must represent canonical lifecycle transitions:
+
+1. **draft** — operator is composing input or structured fields locally;
+2. **submitted** — the control surface has accepted a task for Core processing;
+3. **queued** — the task is waiting for runtime capacity or app-server availability;
+4. **running** — the turn is actively executing;
+5. **blocked** — Core requires an interaction response before continuing;
+6. **interrupting** — an operator stop/interrupt request has been accepted;
+7. **done** — final answer and artifact descriptors are available;
+8. **failed** — the turn ended without a final answer;
+9. **recovered** — runtime restart/recovery restored a known state or produced a degraded outcome.
+
+Each turn state must include a stable turn id, session id, project id, state, creation/update
+timestamps, optional active interaction id, optional progress summary, and terminal outcome when
+known. Web/App may show these as timelines, cards, live streams, or detail panels, but it must not
+invent a parallel lifecycle outside Core semantics.
+
+## Runtime Status And Progress Contract
+
+Runtime status must be available as two neutral shapes:
+
+- **compact status** for badges, headers, lists, and quick health indicators;
+- **detailed status** for inspect panels, diagnostics pages, recent-output views, and recovery guidance.
+
+The minimum status vocabulary is: idle, queued, running, blocked, interrupting, done, failed,
+degraded, unhealthy, and recovered. Detailed status may include active turn/session, recent output,
+last event time, app-server health, pending interaction count, delivery warnings, and recovery notes.
+
+Progress is not final answer content. Web/App must render progress as live or refreshable runtime
+state and keep it visually separate from terminal answers and artifacts.
+
+## Interaction Contract
+
+Core-facing interactions must be neutral models. Web/App Presentation decides whether to render
+them as forms, modals, drawers, inline panels, command-palette prompts, or paginated lists.
+
+Required interaction families:
+
+- **approval** — approve/reject/modify a proposed action with risk text and optional details;
+- **question** — answer a free-form or constrained prompt;
+- **picker** — choose one or more options from projects, sessions, models, files, tools, skills,
+  apps, plugins, accounts, or other enumerated resources;
+- **pagination/navigation** — request next/previous page, expand/collapse, open detail, or return;
+- **recovery notice** — acknowledge or choose a recovery path after stale, duplicate, failed, or
+  degraded workflow events.
+
+Each interaction must carry a stable interaction id, family/type, title, body/details, options or
+fields where applicable, validation rules, expiry/staleness metadata, source turn/session ids, and
+terminal response outcome. Required outcomes are resolved, rejected, expired, stale, duplicate,
+failed, canceled, and superseded.
+
+## Final Answer And Artifact Contract
+
+Final answers must be modeled separately from progress and delivery attempts.
+
+A final-answer record should include a stable answer id, turn id, session id, project id, content
+summary or body, creation time, rendering hints, artifact descriptors, and delivery outcomes. It
+must support long-form rendering through pages, panels, preview panes, search, or history, not by
+requiring chat-style message splitting as the primary UX.
+
+Artifact descriptors must include neutral metadata such as artifact id, label, media type, size
+when known, previewability, source turn/session, retention hint, and a pack/Web/App-owned handle for
+preview or download. Core must not depend on a browser blob URL, upload token, platform file id, or
+local temp path as the artifact meaning.
+
+## Delivery And Degraded-Outcome Contract
+
+Delivery is a first-class state, not an implementation detail to hide.
+
+Required delivery outcomes:
+
+- created — a new surface element/page/card/panel entry was created;
+- updated — an existing element was updated;
+- deferred — delivery is pending or will retry;
+- partially delivered — some content or artifacts reached the surface, but not all;
+- failed — delivery did not reach the surface;
+- rate-limited — delivery was delayed or reduced by platform limits;
+- fallback — the surface used an alternate page/file/download/history entry;
+- degraded — the user-visible result is available with known limitations.
+
+Web/App must expose degraded and failed outcomes in status panels, final-answer views, notifications,
+or recovery notices. It must not silently truncate, drop artifacts, hide stale interactions, or treat
+transport success as product success.
+
+## Media And Attachment Descriptor Contract
+
+User-supplied media and generated artifacts must cross the Core boundary through descriptors.
+
+Minimum attachment descriptor fields:
+
+- attachment id;
+- kind: text, image, file, audio, remote-url, or future explicit extension;
+- display name and media type where known;
+- byte size/dimensions/duration where known;
+- readiness: pending, available, rejected, failed, expired;
+- validation errors or warnings;
+- source: upload, picker, paste, drag/drop, platform message, generated artifact, or remote URL;
+- opaque platform/Web/App-owned resource handle.
+
+Web/App owns browser/app file pickers, drag/drop, paste, upload progress, previews, permission
+errors, chunking, and resumable upload mechanics. Core owns only the normalized descriptor and
+whether the descriptor is valid for the requested workflow.
+
+## Auth, Binding, And Readiness Contract
+
+Web/App must keep the current high-trust operator model unless a separate future product decision
+changes it. The pre-implementation contract is single-operator/control-surface binding, not team or
+multi-tenant collaboration.
+
+Required auth/binding meanings:
+
+- identify the authorized operator/control surface without assuming Telegram chat ids or Feishu tenant ids;
+- bind sessions and runtime actions to that authorized surface;
+- reject unauthorized or unbound access before task submission or interaction response;
+- expose setup and health gaps in an admin/setup view;
+- preserve pack-specific credentials and security controls outside Core.
+
+Readiness must be reported separately for each required capability:
+
+1. **Declared** — the future surface declares it can support the capability.
+2. **Configured** — required server/app settings, local storage, credentials, app-server connection,
+   media paths, and security controls are present.
+3. **Observed** — the running system has successfully seen ingress, interaction response, live/update
+   delivery, upload/download where configured, interrupt, final-answer delivery, and recovery/degraded paths.
+4. **UX-exposed** — an operator can reach the capability through pages, panels, forms, buttons,
+   menus, setup screens, or documented fallbacks.
+
+## Minimum Acceptance Gates Before Support Claim
+
+Do not call Web/App a supported Codex Console surface until all gates below pass through UX-exposed
+journeys with documented fallback behavior:
+
+- authorized operator can complete setup/binding and see readiness status;
+- operator can choose or confirm a project and session;
+- operator can submit a text task and see queued/running/blocked/done/failed transitions;
+- operator can answer at least one approval/question interaction and see resolved/expired/stale states;
+- operator can inspect runtime status, progress, recent output, and app-server health;
+- operator can interrupt an active turn and see the outcome;
+- operator can receive a final answer separately from progress;
+- operator can preview or download at least baseline artifacts/files when configured;
+- degraded delivery, rate limits, stale/duplicate responses, upload failure, app-server recovery, and
+  final-answer fallback are visible and actionable;
+- capability readiness is tracked as declared, configured, observed, and UX-exposed, not as a
+  single boolean;
+- implementation reuses Core workflow semantics and does not fork Telegram or Feishu behavior into a
+  hidden Web-only product path.
+
+## Non-Goals
+
+This contract does not define or authorize:
+
+- Web/App source implementation, routes, components, CSS, API handlers, websocket/SSE servers, native
+  app bridges, or deployment topology;
+- a public network API or hosted control plane;
+- current Web/App support claims;
+- repo/package, CLI, service, config, state, or environment-variable renames;
+- multi-user collaboration, team permissions, provider setup, raw terminal access, project write
+  operations, or remote administration;
+- replacing Telegram as the stable/default pack or demoting Feishu as a serious current pack;
+- treating Telegram callback payloads, Feishu card schemas, or Web component ids as Core data.
+
+## Overclaim Guardrails
+
+Use this language discipline in future docs and release notes:
+
+- say **future Web/App surface**, **prototype**, or **pre-implementation contract** until readiness gates pass;
+- do not say Web/App is supported, shipped, enabled, or available unless the minimum acceptance gates
+  are verified;
+- keep Telegram and Feishu current behavior separate from Web/App target capability rows;
+- describe Web/App affordances as panels, forms, modals, pages, live streams, previews, uploads, and
+  admin/setup screens rather than copied chat flows;
+- treat protocol capability and static UI design as insufficient evidence of product support;
+- require a support-decision update before changing user-facing support claims.
+
+## First Prototype Preconditions
+
+Before a future coding task starts, the implementation plan should name:
+
+- the Core surfaces it will read or adapt for project/session, turns, runtime, interactions, final
+  answers, artifacts, and readiness;
+- the Web/App transport choice and fallback for live or refreshable updates;
+- the storage/security boundary for operator sessions, CSRF/session controls, uploads, previews, and
+  notifications;
+- the explicit subset of acceptance gates targeted by the prototype;
+- which current Telegram/Feishu lessons are evidence versus which platform details are intentionally
+  kept out of the Web/App design.

--- a/docs/archive/plans/2026-04-26-codex-console-phase2-plan.md
+++ b/docs/archive/plans/2026-04-26-codex-console-phase2-plan.md
@@ -1,3 +1,4 @@
+<!-- archived: moved from active plans after Phase 3 closeout; historical reconstruction only. Start new work from docs/roadmap/codex-console-continuation-brief.md. -->
 # Codex Console Phase 2 Implementation Plan
 
 > **For Hermes:** Coordinate with real Codex high runs phase-by-phase, then perform controller-side verification before each commit.

--- a/docs/archive/plans/2026-04-26-codex-console-phase2-release-note.md
+++ b/docs/archive/plans/2026-04-26-codex-console-phase2-release-note.md
@@ -1,3 +1,4 @@
+<!-- archived: moved from active plans after Phase 3 closeout; historical reconstruction only. Start new work from docs/roadmap/codex-console-continuation-brief.md. -->
 # Codex Console Phase 2 Release Note
 
 Status: ready for PR

--- a/docs/archive/plans/2026-04-26-web-first-phase-1-closeout.md
+++ b/docs/archive/plans/2026-04-26-web-first-phase-1-closeout.md
@@ -1,3 +1,4 @@
+<!-- archived: moved from active plans after Phase 3 closeout; historical reconstruction only. Start new work from docs/roadmap/codex-console-continuation-brief.md. -->
 <!-- docmeta
 role: leaf
 layer: 3

--- a/docs/archive/plans/2026-04-26-web-first-project-command-board.md
+++ b/docs/archive/plans/2026-04-26-web-first-project-command-board.md
@@ -1,3 +1,4 @@
+<!-- archived: moved from active plans after Phase 3 closeout; historical reconstruction only. Start new work from docs/roadmap/codex-console-continuation-brief.md. -->
 <!-- docmeta
 role: leaf
 layer: 3

--- a/docs/archive/plans/2026-04-26-web-mvp-controller-triage.md
+++ b/docs/archive/plans/2026-04-26-web-mvp-controller-triage.md
@@ -1,3 +1,4 @@
+<!-- archived: moved from active plans after Phase 3 closeout; historical reconstruction only. Start new work from docs/roadmap/codex-console-continuation-brief.md. -->
 # Web MVP Readiness Controller Triage
 
 Status: controller-approved scope cut

--- a/docs/archive/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
+++ b/docs/archive/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
@@ -1,3 +1,4 @@
+<!-- archived: moved from active plans after Phase 3 closeout; historical reconstruction only. Start new work from docs/roadmap/codex-console-continuation-brief.md. -->
 <!-- docmeta
 role: leaf
 layer: 3

--- a/docs/archive/plans/2026-04-26-web-viewmodel-inventory.md
+++ b/docs/archive/plans/2026-04-26-web-viewmodel-inventory.md
@@ -1,3 +1,4 @@
+<!-- archived: moved from active plans after Phase 3 closeout; historical reconstruction only. Start new work from docs/roadmap/codex-console-continuation-brief.md. -->
 <!-- docmeta
 role: leaf
 layer: 3

--- a/docs/archive/plans/README.md
+++ b/docs/archive/plans/README.md
@@ -1,5 +1,19 @@
 # Archived Plan Material
 
-Closed March implementation plans live here for historical reconstruction only.
+Closed implementation plans and completed dated planning artifacts live here for historical reconstruction only.
 
 Do not use these files as active task prompts. For current continuation work, start with `../../roadmap/codex-console-continuation-brief.md`; for active/recent plans, use `../../plans/README.md`.
+
+## April 26 Web / Codex Console material archived after Phase 3 closeout
+
+- `2026-04-26-codex-console-phase2-plan.md` - closed Phase 2 continuation plan.
+- `2026-04-26-codex-console-phase2-release-note.md` - Phase 2 PR/release note.
+- `2026-04-26-web-first-project-command-board.md` - superseded PM command board for Web-first continuation.
+- `2026-04-26-web-mvp-controller-triage.md` - superseded controller scope cut; active scope now lives in the Product Web Console MVP spec and continuation brief.
+- `2026-04-26-web-viewmodel-inventory.md` - historical implementation inventory for the read-only view-model seam.
+- `2026-04-26-web-readonly-prototype-implementation-plan.md` - superseded local read-only prototype implementation plan.
+- `2026-04-26-web-first-phase-1-closeout.md` - historical Phase 1 local prototype closeout.
+
+## Older plan material
+
+Older March implementation plans are also archived here. Open them only when current sources conflict or the task explicitly asks for history.

--- a/docs/catalog.yaml
+++ b/docs/catalog.yaml
@@ -200,6 +200,11 @@ documents:
     layer: 3
     parent: docs/plans/README.md
     summary: PR-ready Phase 2 closeout note with commits, user-visible impact, known gaps, and verification commands
+  - path: docs/plans/2026-04-26-product-web-console-mvp.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: Phase 3 Product Web Console MVP information architecture, core flows, acceptance criteria, guardrails, and next implementation slices
   - path: docs/plans/2026-04-26-web-first-project-command-board.md
     role: leaf
     layer: 3

--- a/docs/catalog.yaml
+++ b/docs/catalog.yaml
@@ -235,6 +235,11 @@ documents:
     layer: 3
     parent: docs/plans/README.md
     summary: protected owner-only access design gate for the local token-gated read-only Web prototype, including threat model, auth/session requirements, rollback drill, and acceptance checklist
+  - path: docs/plans/2026-04-26-web-gated-actions-design.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: docs-only design gate for future gated Web submit, approval-answer, and interrupt actions after read-only MVP and protected owner access pass
   - path: docs/plans/2026-04-26-codex-console-phase2-plan.md
     role: leaf
     layer: 3

--- a/docs/catalog.yaml
+++ b/docs/catalog.yaml
@@ -162,6 +162,11 @@ documents:
   layer: 3
   parent: docs/operations/README.md
   summary: current install, config, service-management, active-pack selection, update, and diagnostics contract for operators
+- path: docs/operations/web-preview-runbook.md
+  role: leaf
+  layer: 3
+  parent: docs/operations/README.md
+  summary: active owner-only Codex Console Web preview operations for start, stop, status, smoke, rotate, and rollback
 - path: docs/operations/web-vps-mobile-access-and-security.md
   role: leaf
   layer: 3

--- a/docs/catalog.yaml
+++ b/docs/catalog.yaml
@@ -220,6 +220,16 @@ documents:
     layer: 3
     parent: docs/plans/README.md
     summary: guardrails and future-work route for the read-only workspace/session-centric Web prototype after the first service adapter seam landed, including page skeletons, redacted data contracts, auth assumptions, validation flow, and forbidden first-lane scope
+  - path: docs/plans/2026-04-26-web-first-phase-1-closeout.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: phase-1 closeout for the local token-gated read-only Web prototype, including commits, verification, smoke proof, non-claims, and next-stage task board
+  - path: docs/plans/2026-04-26-web-first-pm-ledger.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: detailed PM/controller ledger for delegated Codex Console Web-first implementation runs, smoke evidence, guardrails, and recovery state
   - path: docs/plans/2026-04-26-codex-console-phase2-plan.md
     role: leaf
     layer: 3

--- a/docs/catalog.yaml
+++ b/docs/catalog.yaml
@@ -230,6 +230,11 @@ documents:
     layer: 3
     parent: docs/plans/README.md
     summary: detailed PM/controller ledger for delegated Codex Console Web-first implementation runs, smoke evidence, guardrails, and recovery state
+  - path: docs/plans/2026-04-26-web-protected-owner-access-plan.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: protected owner-only access design gate for the local token-gated read-only Web prototype, including threat model, auth/session requirements, rollback drill, and acceptance checklist
   - path: docs/plans/2026-04-26-codex-console-phase2-plan.md
     role: leaf
     layer: 3

--- a/docs/catalog.yaml
+++ b/docs/catalog.yaml
@@ -54,12 +54,12 @@ documents:
     role: domain
     layer: 2
     parent: docs/INDEX.md
-    summary: router for current runtime shape, decoupling status, state model, pack boundary, capability matrix, and app-server adoption boundary
+    summary: router for current runtime shape, decoupling status, state model, pack boundary, capability matrix, app-server adoption boundary, and Web/App pre-implementation contract
   - path: docs/operations/README.md
     role: domain
     layer: 2
     parent: docs/INDEX.md
-    summary: router for install, active-pack selection, configuration, service management, update, and diagnostics docs
+    summary: router for install, active-pack selection, configuration, service management, update, diagnostics, and future Web prototype access/security docs
   - path: docs/research/README.md
     role: domain
     layer: 2
@@ -69,7 +69,7 @@ documents:
     role: domain
     layer: 2
     parent: docs/INDEX.md
-    summary: router for future repository direction and forward-looking product or architecture intent
+    summary: router for future repository direction, forward-looking product or architecture intent, and Web/App contract-pass handoff
   - path: docs/plans/README.md
     role: domain
     layer: 2
@@ -115,6 +115,11 @@ documents:
     layer: 3
     parent: docs/architecture/README.md
     summary: current Telegram and Feishu capability matrix, common expectations, platform-specific features, and future Web/App target rows
+  - path: docs/architecture/web-app-preimplementation-contract.md
+    role: leaf
+    layer: 3
+    parent: docs/architecture/README.md
+    summary: pre-implementation Core/state/API contracts and readiness gates for future Web/App Codex Console surfaces
   - path: docs/product/v1-scope.md
     role: leaf
     layer: 3
@@ -150,6 +155,11 @@ documents:
     layer: 3
     parent: docs/operations/README.md
     summary: current install, config, service-management, active-pack selection, update, and diagnostics contract for operators
+  - path: docs/operations/web-vps-mobile-access-and-security.md
+    role: leaf
+    layer: 3
+    parent: docs/operations/README.md
+    summary: future workspace/session-centric Web prototype VPS/mobile validation, protected URL exposure, access-control, forbidden-data, and shutdown plan
   - path: docs/generated/current-snapshot.md
     role: leaf
     layer: 2
@@ -179,12 +189,37 @@ documents:
     role: leaf
     layer: 3
     parent: docs/future/README.md
-    summary: future design sketch for a richer Web/App Codex Console control surface powered by Codex Bridge Core
+    summary: future workspace/session/conversation-centric Web/App Codex Console surface powered by Codex Bridge Core
+  - path: docs/future/web-mvp-scope-and-readiness.md
+    role: leaf
+    layer: 3
+    parent: docs/future/README.md
+    summary: approved workspace/session-centric Web-first MVP scope, readiness model, validation path, and support-claim guardrails
   - path: docs/plans/2026-04-26-codex-console-phase2-release-note.md
     role: leaf
     layer: 3
     parent: docs/plans/README.md
     summary: PR-ready Phase 2 closeout note with commits, user-visible impact, known gaps, and verification commands
+  - path: docs/plans/2026-04-26-web-first-project-command-board.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: PM command board for the Web-first continuation with closeout state and prototype-planning next step
+  - path: docs/plans/2026-04-26-web-mvp-controller-triage.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: controller-approved workspace/session-centric Web MVP scope cut that keeps the first lane read-mostly, Web-only, and prototype-only
+  - path: docs/plans/2026-04-26-web-viewmodel-inventory.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: implementation-facing inventory of read-only Core/state/source facades, landed first adapter seam, redaction needs, and remaining read-only gaps for the future Web prototype
+  - path: docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
+    role: leaf
+    layer: 3
+    parent: docs/plans/README.md
+    summary: guardrails and future-work route for the read-only workspace/session-centric Web prototype after the first service adapter seam landed, including page skeletons, redacted data contracts, auth assumptions, validation flow, and forbidden first-lane scope
   - path: docs/plans/2026-04-26-codex-console-phase2-plan.md
     role: leaf
     layer: 3

--- a/docs/catalog.yaml
+++ b/docs/catalog.yaml
@@ -1,302 +1,324 @@
 version: 1
 documents:
-  - path: README.md
-    role: entry
-    layer: 1
-    parent: null
-    summary: public repository entry point for Codex Console and its documentation trees
-  - path: AGENTS.md
-    role: agent
-    layer: 1
-    parent: null
-    summary: root routing contract for coding agents working in this repository
-  - path: docs/INDEX.md
-    role: entry
-    layer: 1
-    parent: null
-    summary: canonical docs router with active continuation, current truth, protocol evidence, future/planning, and archive tiers
-  - path: docs/README.md
-    role: entry
-    layer: 1
-    parent: null
-    summary: human-readable companion to the canonical docs router
-  - path: docs/AGENTS.md
-    role: agent
-    layer: 2
-    parent: AGENTS.md
-    summary: docs-first routing contract for coding agents
-  - path: src/AGENTS.md
-    role: agent
-    layer: 2
-    parent: AGENTS.md
-    summary: code-first routing contract for current implementation work
-  - path: scripts/AGENTS.md
-    role: agent
-    layer: 2
-    parent: AGENTS.md
-    summary: local router for top-level GitHub install scripts
-  - path: skills/AGENTS.md
-    role: agent
-    layer: 2
-    parent: AGENTS.md
-    summary: local router for bundled Codex skills
-  - path: docs/roadmap/codex-console-continuation-brief.md
-    role: leaf
-    layer: 3
-    parent: docs/roadmap/README.md
-    summary: active low-context handoff for future Codex Console / multi-platform bridge continuation tasks and archive/noise decisions
-  - path: docs/product/README.md
-    role: domain
-    layer: 2
-    parent: docs/INDEX.md
-    summary: router for current Codex Console product behavior, Telegram-first baseline, and user-facing command surfaces
-  - path: docs/architecture/README.md
-    role: domain
-    layer: 2
-    parent: docs/INDEX.md
-    summary: router for current runtime shape, decoupling status, state model, pack boundary, capability matrix, app-server adoption boundary, and Web/App pre-implementation contract
-  - path: docs/operations/README.md
-    role: domain
-    layer: 2
-    parent: docs/INDEX.md
-    summary: router for install, active-pack selection, configuration, service management, update, diagnostics, and future Web prototype access/security docs
-  - path: docs/research/README.md
-    role: domain
-    layer: 2
-    parent: docs/INDEX.md
-    summary: router for Codex app-server protocol evidence and verification material
-  - path: docs/future/README.md
-    role: domain
-    layer: 2
-    parent: docs/INDEX.md
-    summary: router for future repository direction, forward-looking product or architecture intent, and Web/App contract-pass handoff
-  - path: docs/plans/README.md
-    role: domain
-    layer: 2
-    parent: docs/INDEX.md
-    summary: router for active trackers, implementation sequencing, and closeout notes
-  - path: docs/roadmap/README.md
-    role: domain
-    layer: 2
-    parent: docs/INDEX.md
-    summary: router for delivery ordering, continuation handoff, and acceptance intent
-  - path: docs/archive/README.md
-    role: domain
-    layer: 2
-    parent: docs/INDEX.md
-    summary: router for archived historical material kept for reconstruction only
-  - path: docs/architecture/platform-decoupling-status.md
-    role: leaf
-    layer: 3
-    parent: docs/architecture/README.md
-    summary: current bridge-versus-platform decoupling status, including what has landed and what remains Telegram-shaped
-  - path: docs/architecture/runtime-and-state.md
-    role: leaf
-    layer: 3
-    parent: docs/architecture/README.md
-    summary: current runtime lifecycle, SQLite state, recovery, and delivery rules for the Telegram-first bridge
-  - path: docs/architecture/current-code-organization.md
-    role: leaf
-    layer: 3
-    parent: docs/architecture/README.md
-    summary: verified owner map for the current src tree after the Core seam and pack boundary landed
-  - path: docs/architecture/codex-app-server-adoption.md
-    role: leaf
-    layer: 3
-    parent: docs/architecture/README.md
-    summary: current bridge-owned Codex app-server adoption boundary, request families, server requests, and notification reduction
-  - path: docs/architecture/platform-pack-boundary.md
-    role: leaf
-    layer: 3
-    parent: docs/architecture/README.md
-    summary: current pack boundary for active-pack selection, runtime factory ownership, platform capabilities, and Telegram vs Feishu split
-  - path: docs/architecture/platform-capability-matrix.md
-    role: leaf
-    layer: 3
-    parent: docs/architecture/README.md
-    summary: current Telegram and Feishu capability matrix, common expectations, platform-specific features, and future Web/App target rows
-  - path: docs/architecture/web-app-preimplementation-contract.md
-    role: leaf
-    layer: 3
-    parent: docs/architecture/README.md
-    summary: pre-implementation Core/state/API contracts and readiness gates for future Web/App Codex Console surfaces
-  - path: docs/product/v1-scope.md
-    role: leaf
-    layer: 3
-    parent: docs/product/README.md
-    summary: current shipped v1 scope, trust model, and out-of-scope boundary for Codex Console's Telegram-first baseline
-  - path: docs/product/chat-and-project-flow.md
-    role: leaf
-    layer: 3
-    parent: docs/product/README.md
-    summary: lightweight product router for current Telegram chat, project, command, runtime, and callback UX docs
-  - path: docs/product/auth-and-project-flow.md
-    role: leaf
-    layer: 3
-    parent: docs/product/README.md
-    summary: current authorization, project picker, session management, and browse-flow contract for Telegram
-  - path: docs/product/codex-command-reference.md
-    role: leaf
-    layer: 3
-    parent: docs/product/README.md
-    summary: current Telegram UX contract for Codex-backed commands and structured rich-input submission
-  - path: docs/product/runtime-and-delivery.md
-    role: leaf
-    layer: 3
-    parent: docs/product/README.md
-    summary: current runtime-hub, inspect, status, interrupt, and final-answer delivery contract for Telegram
-  - path: docs/product/callback-contract.md
-    role: leaf
-    layer: 3
-    parent: docs/product/README.md
-    summary: current callback namespace families, encoding rules, and stale-click contract for bridge-owned Telegram UI
-  - path: docs/operations/install-and-admin.md
-    role: leaf
-    layer: 3
-    parent: docs/operations/README.md
-    summary: current install, config, service-management, active-pack selection, update, and diagnostics contract for operators
-  - path: docs/operations/web-vps-mobile-access-and-security.md
-    role: leaf
-    layer: 3
-    parent: docs/operations/README.md
-    summary: future workspace/session-centric Web prototype VPS/mobile validation, protected URL exposure, access-control, forbidden-data, and shutdown plan
-  - path: docs/generated/current-snapshot.md
-    role: leaf
-    layer: 2
-    parent: docs/INDEX.md
-    summary: high-drift snapshot for current package version, source-tree size, and locally verifiable tooling facts
-  - path: docs/research/codex-app-server-authoritative-reference.md
-    role: leaf
-    layer: 3
-    parent: docs/research/README.md
-    summary: protocol-first authoritative reference for Codex app-server capability, schema inventory, host baseline, and refresh workflow
-  - path: docs/research/codex-app-server-api-quick-reference.md
-    role: leaf
-    layer: 3
-    parent: docs/research/README.md
-    summary: per-method quick reference for Codex app-server requests, notifications, and server-request gotchas
-  - path: docs/research/app-server-phase-0-verification.md
-    role: leaf
-    layer: 3
-    parent: docs/research/README.md
-    summary: dated phase-0 runtime verification sample kept as historical protocol evidence only
-  - path: docs/future/multi-platform-core-prd.md
-    role: leaf
-    layer: 3
-    parent: docs/future/README.md
-    summary: future product direction for Codex Console and Codex Bridge Core with Telegram as the stable first pack
-  - path: docs/future/web-app-control-surface-sketch.md
-    role: leaf
-    layer: 3
-    parent: docs/future/README.md
-    summary: future workspace/session/conversation-centric Web/App Codex Console surface powered by Codex Bridge Core
-  - path: docs/future/web-mvp-scope-and-readiness.md
-    role: leaf
-    layer: 3
-    parent: docs/future/README.md
-    summary: approved workspace/session-centric Web-first MVP scope, readiness model, validation path, and support-claim guardrails
-  - path: docs/plans/2026-04-26-codex-console-phase2-release-note.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: PR-ready Phase 2 closeout note with commits, user-visible impact, known gaps, and verification commands
-  - path: docs/plans/2026-04-26-product-web-console-mvp.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: Phase 3 Product Web Console MVP information architecture, core flows, acceptance criteria, guardrails, and next implementation slices
-  - path: docs/plans/2026-04-26-web-first-project-command-board.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: PM command board for the Web-first continuation with closeout state and prototype-planning next step
-  - path: docs/plans/2026-04-26-web-mvp-controller-triage.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: controller-approved workspace/session-centric Web MVP scope cut that keeps the first lane read-mostly, Web-only, and prototype-only
-  - path: docs/plans/2026-04-26-web-viewmodel-inventory.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: implementation-facing inventory of read-only Core/state/source facades, landed first adapter seam, redaction needs, and remaining read-only gaps for the future Web prototype
-  - path: docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: guardrails and future-work route for the read-only workspace/session-centric Web prototype after the first service adapter seam landed, including page skeletons, redacted data contracts, auth assumptions, validation flow, and forbidden first-lane scope
-  - path: docs/plans/2026-04-26-web-first-phase-1-closeout.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: phase-1 closeout for the local token-gated read-only Web prototype, including commits, verification, smoke proof, non-claims, and next-stage task board
-  - path: docs/plans/2026-04-26-web-first-pm-ledger.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: detailed PM/controller ledger for delegated Codex Console Web-first implementation runs, smoke evidence, guardrails, and recovery state
-  - path: docs/plans/2026-04-26-web-protected-owner-access-plan.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: protected owner-only access design gate for the local token-gated read-only Web prototype, including threat model, auth/session requirements, rollback drill, and acceptance checklist
-  - path: docs/plans/2026-04-26-web-gated-actions-design.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: docs-only design gate for future gated Web submit, approval-answer, and interrupt actions after read-only MVP and protected owner access pass
-  - path: docs/plans/2026-04-26-codex-console-phase2-plan.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: five-phase plan for install-path docs, Feishu audit, metadata cleanup, Web/App sketch, and release note
-  - path: docs/plans/2026-04-26-feishu-official-capability-audit.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: official Feishu API backed capability audit and live-smoke checklist
-  - path: docs/plans/2026-04-09-feishu-pack-setup-capability-and-hardening-plan.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: Feishu setup and hardening backlog for validation, binding, callbacks, and readiness
-  - path: docs/plans/2026-04-08-multi-platform-core-and-feishu-implementation-plan.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: four-phase implementation plan that completed platform abstraction and landed Feishu as the second platform
-  - path: docs/plans/2026-03-30-binding-model-neutralization-note.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: design note for neutralizing Telegram-first auth and session binding fields without overclaiming support
-  - path: docs/plans/2026-03-30-platform-binding-boundary-design.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: design note for platform principal, surface target, and bridge session ownership boundaries
-  - path: docs/plans/2026-03-30-platform-surface-adapter-and-capability-prep.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: predesign note for platform surface adapter boundaries and capability vocabulary
-  - path: docs/plans/2026-03-23-multi-platform-core-phase-1-implementation-plan.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: historical plan and landed outcome for the first internal multi-platform Core abstraction wave
-  - path: docs/plans/2026-03-23-multi-platform-core-pending-task-tracker.md
-    role: leaf
-    layer: 3
-    parent: docs/plans/README.md
-    summary: Phase-1 deferred-work baseline kept as sequencing context rather than current status truth
-  - path: docs/archive/future/README.md
-    role: archive
-    layer: 3
-    parent: docs/archive/README.md
-    summary: local index for superseded V2/V3 future PRDs and engineering evaluations; historical reconstruction only
-  - path: docs/archive/plans/README.md
-    role: archive
-    layer: 3
-    parent: docs/archive/README.md
-    summary: local index for closed March implementation plans removed from active agent routing; historical reconstruction only
+- path: README.md
+  role: entry
+  layer: 1
+  parent: null
+  summary: public repository entry point for Codex Console and its documentation trees
+- path: AGENTS.md
+  role: agent
+  layer: 1
+  parent: null
+  summary: root routing contract for coding agents working in this repository
+- path: docs/INDEX.md
+  role: entry
+  layer: 1
+  parent: null
+  summary: canonical docs router with active continuation, current truth, protocol evidence, future/planning, and archive
+    tiers
+- path: docs/README.md
+  role: entry
+  layer: 1
+  parent: null
+  summary: human-readable companion to the canonical docs router
+- path: docs/AGENTS.md
+  role: agent
+  layer: 2
+  parent: AGENTS.md
+  summary: docs-first routing contract for coding agents
+- path: src/AGENTS.md
+  role: agent
+  layer: 2
+  parent: AGENTS.md
+  summary: code-first routing contract for current implementation work
+- path: scripts/AGENTS.md
+  role: agent
+  layer: 2
+  parent: AGENTS.md
+  summary: local router for top-level GitHub install scripts
+- path: skills/AGENTS.md
+  role: agent
+  layer: 2
+  parent: AGENTS.md
+  summary: local router for bundled Codex skills
+- path: docs/roadmap/codex-console-continuation-brief.md
+  role: leaf
+  layer: 3
+  parent: docs/roadmap/README.md
+  summary: active low-context handoff for future Codex Console / multi-platform bridge continuation tasks and archive/noise
+    decisions
+- path: docs/product/README.md
+  role: domain
+  layer: 2
+  parent: docs/INDEX.md
+  summary: router for current Codex Console product behavior, Telegram-first baseline, and user-facing command surfaces
+- path: docs/architecture/README.md
+  role: domain
+  layer: 2
+  parent: docs/INDEX.md
+  summary: router for current runtime shape, decoupling status, state model, pack boundary, capability matrix, app-server
+    adoption boundary, and Web/App pre-implementation contract
+- path: docs/operations/README.md
+  role: domain
+  layer: 2
+  parent: docs/INDEX.md
+  summary: router for install, active-pack selection, configuration, service management, update, diagnostics, and future Web
+    prototype access/security docs
+- path: docs/research/README.md
+  role: domain
+  layer: 2
+  parent: docs/INDEX.md
+  summary: router for Codex app-server protocol evidence and verification material
+- path: docs/future/README.md
+  role: domain
+  layer: 2
+  parent: docs/INDEX.md
+  summary: router for future repository direction, forward-looking product or architecture intent, and Web/App contract-pass
+    handoff
+- path: docs/plans/README.md
+  role: domain
+  layer: 2
+  parent: docs/INDEX.md
+  summary: router for active trackers, implementation sequencing, and closeout notes
+- path: docs/roadmap/README.md
+  role: domain
+  layer: 2
+  parent: docs/INDEX.md
+  summary: router for delivery ordering, continuation handoff, and acceptance intent
+- path: docs/archive/README.md
+  role: domain
+  layer: 2
+  parent: docs/INDEX.md
+  summary: router for archived historical material kept for reconstruction only
+- path: docs/architecture/platform-decoupling-status.md
+  role: leaf
+  layer: 3
+  parent: docs/architecture/README.md
+  summary: current bridge-versus-platform decoupling status, including what has landed and what remains Telegram-shaped
+- path: docs/architecture/runtime-and-state.md
+  role: leaf
+  layer: 3
+  parent: docs/architecture/README.md
+  summary: current runtime lifecycle, SQLite state, recovery, and delivery rules for the Telegram-first bridge
+- path: docs/architecture/current-code-organization.md
+  role: leaf
+  layer: 3
+  parent: docs/architecture/README.md
+  summary: verified owner map for the current src tree after the Core seam and pack boundary landed
+- path: docs/architecture/codex-app-server-adoption.md
+  role: leaf
+  layer: 3
+  parent: docs/architecture/README.md
+  summary: current bridge-owned Codex app-server adoption boundary, request families, server requests, and notification reduction
+- path: docs/architecture/platform-pack-boundary.md
+  role: leaf
+  layer: 3
+  parent: docs/architecture/README.md
+  summary: current pack boundary for active-pack selection, runtime factory ownership, platform capabilities, and Telegram
+    vs Feishu split
+- path: docs/architecture/platform-capability-matrix.md
+  role: leaf
+  layer: 3
+  parent: docs/architecture/README.md
+  summary: current Telegram and Feishu capability matrix, common expectations, platform-specific features, and future Web/App
+    target rows
+- path: docs/architecture/web-app-preimplementation-contract.md
+  role: leaf
+  layer: 3
+  parent: docs/architecture/README.md
+  summary: pre-implementation Core/state/API contracts and readiness gates for future Web/App Codex Console surfaces
+- path: docs/product/v1-scope.md
+  role: leaf
+  layer: 3
+  parent: docs/product/README.md
+  summary: current shipped v1 scope, trust model, and out-of-scope boundary for Codex Console's Telegram-first baseline
+- path: docs/product/chat-and-project-flow.md
+  role: leaf
+  layer: 3
+  parent: docs/product/README.md
+  summary: lightweight product router for current Telegram chat, project, command, runtime, and callback UX docs
+- path: docs/product/auth-and-project-flow.md
+  role: leaf
+  layer: 3
+  parent: docs/product/README.md
+  summary: current authorization, project picker, session management, and browse-flow contract for Telegram
+- path: docs/product/codex-command-reference.md
+  role: leaf
+  layer: 3
+  parent: docs/product/README.md
+  summary: current Telegram UX contract for Codex-backed commands and structured rich-input submission
+- path: docs/product/runtime-and-delivery.md
+  role: leaf
+  layer: 3
+  parent: docs/product/README.md
+  summary: current runtime-hub, inspect, status, interrupt, and final-answer delivery contract for Telegram
+- path: docs/product/callback-contract.md
+  role: leaf
+  layer: 3
+  parent: docs/product/README.md
+  summary: current callback namespace families, encoding rules, and stale-click contract for bridge-owned Telegram UI
+- path: docs/operations/install-and-admin.md
+  role: leaf
+  layer: 3
+  parent: docs/operations/README.md
+  summary: current install, config, service-management, active-pack selection, update, and diagnostics contract for operators
+- path: docs/operations/web-vps-mobile-access-and-security.md
+  role: leaf
+  layer: 3
+  parent: docs/operations/README.md
+  summary: future workspace/session-centric Web prototype VPS/mobile validation, protected URL exposure, access-control, forbidden-data,
+    and shutdown plan
+- path: docs/generated/current-snapshot.md
+  role: leaf
+  layer: 2
+  parent: docs/INDEX.md
+  summary: high-drift snapshot for current package version, source-tree size, and locally verifiable tooling facts
+- path: docs/research/codex-app-server-authoritative-reference.md
+  role: leaf
+  layer: 3
+  parent: docs/research/README.md
+  summary: protocol-first authoritative reference for Codex app-server capability, schema inventory, host baseline, and refresh
+    workflow
+- path: docs/research/codex-app-server-api-quick-reference.md
+  role: leaf
+  layer: 3
+  parent: docs/research/README.md
+  summary: per-method quick reference for Codex app-server requests, notifications, and server-request gotchas
+- path: docs/research/app-server-phase-0-verification.md
+  role: leaf
+  layer: 3
+  parent: docs/research/README.md
+  summary: dated phase-0 runtime verification sample kept as historical protocol evidence only
+- path: docs/future/multi-platform-core-prd.md
+  role: leaf
+  layer: 3
+  parent: docs/future/README.md
+  summary: future product direction for Codex Console and Codex Bridge Core with Telegram as the stable first pack
+- path: docs/future/web-app-control-surface-sketch.md
+  role: leaf
+  layer: 3
+  parent: docs/future/README.md
+  summary: future workspace/session/conversation-centric Web/App Codex Console surface powered by Codex Bridge Core
+- path: docs/future/web-mvp-scope-and-readiness.md
+  role: leaf
+  layer: 3
+  parent: docs/future/README.md
+  summary: approved workspace/session-centric Web-first MVP scope, readiness model, validation path, and support-claim guardrails
+- path: docs/archive/plans/2026-04-26-codex-console-phase2-release-note.md
+  role: archive
+  layer: 3
+  parent: docs/archive/plans/README.md
+  summary: archived historical PR-ready Phase 2 closeout note with commits, user-visible impact, known gaps, and verification
+    commands
+- path: docs/plans/2026-04-26-product-web-console-mvp.md
+  role: leaf
+  layer: 3
+  parent: docs/plans/README.md
+  summary: Phase 3 Product Web Console MVP information architecture, core flows, acceptance criteria, guardrails, and next
+    implementation slices
+- path: docs/archive/plans/2026-04-26-web-first-project-command-board.md
+  role: archive
+  layer: 3
+  parent: docs/archive/plans/README.md
+  summary: archived historical PM command board for the Web-first continuation with closeout state and prototype-planning
+    next step
+- path: docs/archive/plans/2026-04-26-web-mvp-controller-triage.md
+  role: archive
+  layer: 3
+  parent: docs/archive/plans/README.md
+  summary: archived historical controller-approved workspace/session-centric Web MVP scope cut that keeps the first lane read-mostly,
+    Web-only, and prototype-only
+- path: docs/archive/plans/2026-04-26-web-viewmodel-inventory.md
+  role: archive
+  layer: 3
+  parent: docs/archive/plans/README.md
+  summary: archived historical implementation-facing inventory of read-only Core/state/source facades, landed first adapter
+    seam, redaction needs, and remaining read-only gaps for the future Web prototype
+- path: docs/archive/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
+  role: archive
+  layer: 3
+  parent: docs/archive/plans/README.md
+  summary: archived historical guardrails and future-work route for the read-only workspace/session-centric Web prototype
+    after the first service adapter seam landed, including page skeletons, redacted data contracts, auth assumptions, validation
+    flow, and forbidden first-lane scope
+- path: docs/archive/plans/2026-04-26-web-first-phase-1-closeout.md
+  role: archive
+  layer: 3
+  parent: docs/archive/plans/README.md
+  summary: archived historical phase-1 closeout for the local token-gated read-only Web prototype, including commits, verification,
+    smoke proof, non-claims, and next-stage task board
+- path: docs/plans/2026-04-26-web-first-pm-ledger.md
+  role: leaf
+  layer: 3
+  parent: docs/plans/README.md
+  summary: detailed PM/controller ledger for delegated Codex Console Web-first implementation runs, smoke evidence, guardrails,
+    and recovery state
+- path: docs/plans/2026-04-26-web-protected-owner-access-plan.md
+  role: leaf
+  layer: 3
+  parent: docs/plans/README.md
+  summary: protected owner-only access design gate for the local token-gated read-only Web prototype, including threat model,
+    auth/session requirements, rollback drill, and acceptance checklist
+- path: docs/plans/2026-04-26-web-gated-actions-design.md
+  role: leaf
+  layer: 3
+  parent: docs/plans/README.md
+  summary: docs-only design gate for future gated Web submit, approval-answer, and interrupt actions after read-only MVP and
+    protected owner access pass
+- path: docs/archive/plans/2026-04-26-codex-console-phase2-plan.md
+  role: archive
+  layer: 3
+  parent: docs/archive/plans/README.md
+  summary: archived historical five-phase plan for install-path docs, Feishu audit, metadata cleanup, Web/App sketch, and
+    release note
+- path: docs/plans/2026-04-26-feishu-official-capability-audit.md
+  role: leaf
+  layer: 3
+  parent: docs/plans/README.md
+  summary: official Feishu API backed capability audit and live-smoke checklist
+- path: docs/plans/2026-04-09-feishu-pack-setup-capability-and-hardening-plan.md
+  role: leaf
+  layer: 3
+  parent: docs/plans/README.md
+  summary: Feishu setup and hardening backlog for validation, binding, callbacks, and readiness
+- path: docs/plans/2026-04-08-multi-platform-core-and-feishu-implementation-plan.md
+  role: leaf
+  layer: 3
+  parent: docs/plans/README.md
+  summary: four-phase implementation plan that completed platform abstraction and landed Feishu as the second platform
+- path: docs/plans/2026-03-30-binding-model-neutralization-note.md
+  role: leaf
+  layer: 3
+  parent: docs/plans/README.md
+  summary: design note for neutralizing Telegram-first auth and session binding fields without overclaiming support
+- path: docs/plans/2026-03-30-platform-binding-boundary-design.md
+  role: leaf
+  layer: 3
+  parent: docs/plans/README.md
+  summary: design note for platform principal, surface target, and bridge session ownership boundaries
+- path: docs/plans/2026-03-30-platform-surface-adapter-and-capability-prep.md
+  role: leaf
+  layer: 3
+  parent: docs/plans/README.md
+  summary: predesign note for platform surface adapter boundaries and capability vocabulary
+- path: docs/plans/2026-03-23-multi-platform-core-phase-1-implementation-plan.md
+  role: leaf
+  layer: 3
+  parent: docs/plans/README.md
+  summary: historical plan and landed outcome for the first internal multi-platform Core abstraction wave
+- path: docs/plans/2026-03-23-multi-platform-core-pending-task-tracker.md
+  role: leaf
+  layer: 3
+  parent: docs/plans/README.md
+  summary: Phase-1 deferred-work baseline kept as sequencing context rather than current status truth
+- path: docs/archive/future/README.md
+  role: archive
+  layer: 3
+  parent: docs/archive/README.md
+  summary: local index for superseded V2/V3 future PRDs and engineering evaluations; historical reconstruction only
+- path: docs/archive/plans/README.md
+  role: archive
+  layer: 3
+  parent: docs/archive/README.md
+  summary: local index for closed March implementation plans removed from active agent routing; historical reconstruction
+    only

--- a/docs/future/README.md
+++ b/docs/future/README.md
@@ -5,7 +5,9 @@ parent: docs/INDEX.md
 children:
   - docs/future/multi-platform-core-prd.md
   - docs/future/web-app-control-surface-sketch.md
-summary: router for future Codex Console product direction and Codex Bridge Core architecture intent
+  - docs/future/web-mvp-scope-and-readiness.md
+  - docs/architecture/web-app-preimplementation-contract.md
+summary: router for future Codex Console product direction, Codex Bridge Core architecture intent, Web MVP scope/readiness, and Web/App pre-implementation contract handoff
 read_when:
   - the request is about future product direction rather than current shipped behavior
   - the request is about the broader Codex Bridge Core direction
@@ -15,6 +17,8 @@ source_of_truth:
   - docs/future/README.md
   - docs/future/multi-platform-core-prd.md
   - docs/future/web-app-control-surface-sketch.md
+  - docs/future/web-mvp-scope-and-readiness.md
+  - docs/architecture/web-app-preimplementation-contract.md
 -->
 
 # Future Index
@@ -26,6 +30,8 @@ It does not override current truth: Codex Console is Telegram-first by default p
 
 - `multi-platform-core-prd.md` - product and architecture direction for Codex Console powered by Codex Bridge Core, with Telegram as the stable first pack and Feishu as a serious current pack.
 - `web-app-control-surface-sketch.md` - future design sketch for a richer Web/App control surface that reuses Codex Bridge Core without claiming current Web/App support.
+- `web-mvp-scope-and-readiness.md` - approved Web-first, App-later MVP scope, read-mostly first lane, readiness model, VPS/mobile validation path, and support-claim gates.
+- `../architecture/web-app-preimplementation-contract.md` - contract-pass output with neutral Core/state/API surfaces and readiness gates required before any Web/App implementation begins.
 
 ## Archived Future Material
 

--- a/docs/future/multi-platform-core-prd.md
+++ b/docs/future/multi-platform-core-prd.md
@@ -119,7 +119,7 @@ Use `../architecture/platform-capability-matrix.md` as the current planning tabl
 It translates implementation-level capability fields into owner-facing product expectations, UX richness tiers, ingress/egress rows, readiness levels, and new-platform decision rules.
 Do not use the matrix to claim broad multi-platform maturity; use it to keep Core semantics and platform-specific affordances separated.
 
-For a narrower future Web/App integration sketch, use `web-app-control-surface-sketch.md`. It describes how a richer native surface could reuse Core semantics through dashboards, panels, forms, live transport, media flows, readiness gates, and setup/admin pages without becoming a fake chat pack or claiming current support.
+For a narrower future Web/App integration sketch, use `web-app-control-surface-sketch.md`. It describes how a richer native surface could reuse Core semantics through Web Home, Workspace Home, workspace sessions/conversations, conversation results, contextual panels, forms, live transport, media flows, readiness gates, and setup/readiness pages without becoming a fake chat pack, generic admin dashboard, or current support claim. Before any Web/App implementation begins, use `../architecture/web-app-preimplementation-contract.md` as the contract-pass output for neutral Core/state/API surfaces and support-readiness gates.
 
 ## Relationship To Skills
 

--- a/docs/future/web-app-control-surface-sketch.md
+++ b/docs/future/web-app-control-surface-sketch.md
@@ -12,6 +12,7 @@ skip_when:
   - the request is asking for Web/App implementation details or source code
 source_of_truth:
   - docs/future/web-app-control-surface-sketch.md
+  - docs/architecture/web-app-preimplementation-contract.md
   - docs/future/multi-platform-core-prd.md
   - docs/architecture/platform-capability-matrix.md
 -->
@@ -23,9 +24,11 @@ Owner: Product / Architecture
 Last updated: 2026-04-26
 
 This sketch describes how a future Web or App surface for **Codex Console** could use
-**Codex Bridge Core** without becoming a fake chat pack. It is forward-looking only:
-Telegram remains the stable/default pack, Feishu is a serious current pack, and Web/App
-support is not claimed by this document.
+**Codex Bridge Core** without becoming a fake chat pack or a generic admin dashboard. The preferred
+product shape is workspace/session/conversation centric: start from workspaces, inspect a
+workspace's conversations, and open or resume a conversation when the relevant action gates exist.
+It is forward-looking only: Telegram remains the stable/default pack, Feishu is a serious current
+pack, and Web/App support is not claimed by this document.
 
 ## Goal
 
@@ -33,8 +36,9 @@ Define a Web/App control surface direction that:
 
 - reuses shared Core semantics for projects, sessions, turns, interactions, runtime state,
   final answers, artifacts, and delivery outcomes
-- presents those semantics through native Web/App affordances such as dashboards, panels,
-  forms, modals, durable history, file pickers, uploads, and live updates
+- presents those semantics through native Web/App affordances such as Web Home, Workspace Home,
+  conversation/session lists, result detail pages, contextual panels, forms, modals, durable history,
+  file pickers, uploads, and live updates
 - keeps platform-specific transport, credentials, layout, browser/app storage, and notification
   behavior out of Core
 - makes readiness measurable before any user-facing claim that Web/App is supported
@@ -48,7 +52,7 @@ This sketch does not:
 - replace Telegram or Feishu as current packs
 - copy Telegram chat UX into a browser or app shell
 - expand scope into multi-user collaboration, provider setup, raw terminal access, project write
-  operations, or team permissions unless those are chosen as explicit future decisions
+  operations, generic admin dashboards, or team permissions unless those are chosen as explicit future decisions
 - make browser, desktop, and mobile app packaging decisions
 
 ## Core Reuse Target
@@ -69,8 +73,10 @@ workflow logic behind a richer UI.
 
 ## Core, State, And API Surfaces To Expose Or Stabilize
 
-Before Web/App can be considered more than a prototype, these surfaces need explicit contracts.
-They may be internal APIs first; the point is stable ownership, not public network API shape.
+The contract pass for these surfaces now lives in `../architecture/web-app-preimplementation-contract.md`.
+That document is the required pre-implementation artifact for neutral Core/state/API meanings,
+ownership boundaries, and readiness gates. The sketch below remains future design context, not
+a current support claim or public network API shape.
 
 1. **Project/session surface**
    - list selectable projects and recent sessions
@@ -111,8 +117,8 @@ They may be internal APIs first; the point is stable ownership, not public netwo
 
 8. **Auth, binding, and readiness surface**
    - bind the authorized operator/control surface without assuming Telegram chat ids or Feishu tenant ids
-   - expose readiness levels: static declared, configured, observed, and UX-exposed
-   - report setup gaps and health checks in terms a Web/App admin page can render
+   - expose readiness levels: declared, configured, observed, and UX-exposed
+   - report setup gaps and health checks in terms a Web/App setup or readiness page can render
 
 ## Pack And Presentation Responsibilities
 
@@ -121,13 +127,13 @@ reached, rendered, and delivered.
 
 | Area | Web/App responsibility |
 |---|---|
-| Routes | Define pages for dashboard, projects, sessions, runtime, interactions, artifacts, settings, and setup. |
-| Dashboards/panels | Render active session, running turn, blocked interactions, recent output, inspect/status detail, and degraded notices. |
+| Routes | Define pages for Web Home, Workspace Home, workspace sessions/conversations, conversation results, runtime context, interactions, artifacts, settings, and setup/readiness. |
+| Workspace/session panels | Render active workspace/session, conversation list/detail, running turn, blocked interactions, recent output, inspect/status detail, and degraded notices. |
 | Forms/modals | Collect approvals, questionnaire answers, project/session choices, setup inputs, and destructive-action confirmations. |
 | Live transport | Use Web/App-appropriate push such as WebSocket, SSE, native app bridge, or polling fallback; Core should not own transport plumbing. |
 | Notifications | Map Core notices to browser/app badges, toasts, native notifications, and unread counters with user-controlled settings. |
 | File picker/uploads | Own browser/app file selection, upload progress, previews, local permission errors, and conversion into neutral attachment descriptors. |
-| Admin/setup pages | Render credentials, pack readiness, app-server health, MCP/tooling state, diagnostics, and repair guidance. |
+| Setup/readiness pages | Render access status, pack readiness, app-server health, MCP/tooling state, diagnostics, and repair guidance without making setup the primary UX. |
 | Layout/navigation | Choose sidebars, tabs, responsive panels, command palette, and history views without forcing chat chronology. |
 | Platform storage | Own cookies, browser/app storage, push subscription ids, CSRF/session mechanisms, and platform-specific security controls. |
 
@@ -136,7 +142,7 @@ reached, rendered, and delivered.
 Do not advertise Web/App as a supported Codex Console surface until every baseline journey has
 at least fallback support and each required capability has crossed the right readiness level.
 
-1. **Static declared capability**
+1. **Declared capability**
    - Web/App declares baseline text input, interactions, live or refreshable updates, final-answer
      delivery, media/file handling, auth binding, setup/health, and degraded-state rendering.
 
@@ -193,8 +199,8 @@ These decisions are intentionally not made by this sketch:
 
 A safe sequence is:
 
-1. **Contract pass** — document the neutral Core/state/API surfaces above and map existing Telegram and
-   Feishu behavior to them without changing product support claims.
+1. **Contract pass** — complete in `../architecture/web-app-preimplementation-contract.md`; use it
+   as the required pre-implementation contract before any Web/App source work.
 2. **Readiness model pass** — make declared/configured/observed/UX-exposed readiness reportable for
    every required Web/App baseline capability.
 3. **Prototype shell** — build a non-public Web/App shell that reads status, project/session, runtime,

--- a/docs/future/web-mvp-scope-and-readiness.md
+++ b/docs/future/web-mvp-scope-and-readiness.md
@@ -1,0 +1,216 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/future/README.md
+children: []
+summary: approved Web-first Codex Console MVP scope, readiness model, validation path, and support-claim guardrails
+read_when:
+  - planning the first Web Codex Console MVP
+  - deciding what the Web MVP may claim, show, or defer
+  - preparing VPS/mobile validation, readiness evidence, or support go/no-go review
+skip_when:
+  - the request is about current Telegram or Feishu shipped behavior
+  - the request is asking for Web routes, components, API handlers, or implementation code
+source_of_truth:
+  - docs/future/web-mvp-scope-and-readiness.md
+  - docs/plans/2026-04-26-web-mvp-controller-triage.md
+  - docs/architecture/web-app-preimplementation-contract.md
+-->
+
+# Web MVP Scope And Readiness
+
+Status: Approved Web-first MVP scope, future prototype only
+Owner: Product / Architecture
+Last updated: 2026-04-26
+
+This document lands the approved first-lane scope for a **Web-first Codex Console MVP** and the
+readiness model required before any Web support claim. The product direction is a
+workspace/session/conversation-centric Web app, similar in spirit to T3 Chat, Code Web, or the Codex
+app: users start from workspaces, inspect each workspace's conversations, and open conversation
+results. It is not a generic management dashboard or admin console. This is a planning and
+validation contract, not an implementation plan. It does not authorize Web routes, components, API
+handlers, native App work, public support claims, or repository/package/CLI/service/environment
+renames.
+
+## Decision
+
+Codex Console should validate **Web first, App later**.
+
+- Web is the first future control-surface target because the owner runs the service on VPS Linux and
+  validates from a phone.
+- App remains alive, but deferred until Web proves the shared Codex Bridge Core path and support
+  readiness model.
+- The first Web lane is **read-mostly**, **single-operator**, **non-public**, and **prototype only**.
+- Early owner validation uses screenshots and recordings. A protected URL comes only after login and
+  access control are ready.
+
+## Current Support Truth
+
+| Surface | Current truth | Product wording |
+|---|---|---|
+| Telegram | Current stable/default surface. | Supported/default pack for current shipped behavior. |
+| Feishu | Serious current pack with setup, permission, callback, and readiness caveats. | Current pack that needs explicit readiness validation. |
+| Web | Future prototype only; no current support claim. | Web-first MVP target after readiness gates. |
+| App | Future and alive, but later. | Deferred until Web proves the shared contract path. |
+
+Do not describe Web as shipped, supported, enabled, generally available, or a replacement for
+Telegram/Feishu until the support go/no-go gates in this document pass.
+
+## MVP Goal
+
+The first Web MVP should prove that a browser can consume shared Codex Bridge Core semantics without
+forking Telegram or Feishu behavior. It should orient the owner around workspaces, sessions, and
+conversation results from a phone: workspace list, active workspace, per-workspace conversations,
+conversation detail, final answers, and artifacts. Runtime/status, readiness, and access state are
+contextual information and setup gates around that experience, not the whole product.
+
+## Approved First-Lane Pages
+
+| Page | First-lane content | First-lane posture |
+|---|---|---|
+| Web Home | Workspace list, active workspace/session summary, recent conversations, compact runtime and readiness badges, degraded warnings. | Read-only after auth; landing page, not an admin dashboard. |
+| Workspace Sessions | Active workspace/session, per-workspace conversation list, recent sessions, empty/error/unavailable states. | Read-only first; open details only, no switch/resume control. |
+| Conversation Detail / Results | Conversation/session detail, final answer separated from progress, artifact descriptors and safe availability, preview, or download states. | Preview/download only where configured and safe. |
+| Runtime | Idle, queued, running, blocked, done, failed, degraded, unhealthy, recovered; compact and detailed status; recent output summary. | Contextual status only; no raw terminal. |
+| Interactions | Pending, resolved, expired, stale, duplicate, and failed states tied to their source conversation/session. | Read-only first. |
+| Setup / Readiness | Declared/configured/observed/UX-exposed matrix, auth/access status, capability gaps. | Setup gate before exposure decisions, not primary UX. |
+
+## Explicit Deferred Scope
+
+Deferred does not mean canceled. These items are outside the first Web MVP lane:
+
+- native App implementation;
+- public Web support claim;
+- multi-user/team collaboration;
+- raw terminal or shell controls;
+- arbitrary project writes/file editing;
+- full upload flow;
+- browser/mobile push notifications;
+- hosted/SaaS control plane or public network API;
+- provider/admin console expansion beyond narrow setup/readiness gaps;
+- repo/package/CLI/service/config/state/environment-variable renames;
+- replacing Telegram as the current default surface or demoting Feishu as a serious current pack.
+
+## Action Gates
+
+| Action | First-lane decision | Gate before enabling |
+|---|---|---|
+| View Web Home, workspace sessions, conversation history/results, status, artifacts, and readiness | Approved after auth | Login/access control works and unauthorized access is rejected. |
+| Switch or resume project/session | Deferred | Owner approves action audit, active-context semantics, failure visibility, and recovery behavior. |
+| Submit a text task | Deferred | CSRF/action protection, lifecycle visibility, failure visibility, and audit trail exist. |
+| Answer approval/question | Deferred | Stale, duplicate, expiry, failure, and resolved outcomes are visible. |
+| Interrupt | Deferred | Action audit trail, interrupt outcome, degraded/recovery state, and owner warning copy are visible. |
+| Upload files | Deferred | Attachment validation, storage, retention, size/type limits, and security posture are approved. |
+
+The first implementation package must remain read-mostly. Action gates are later-lane gates only;
+task submission, approval/question response, interrupt, upload, switch/resume, and write controls
+must not enter the first Web MVP lane.
+
+## Readiness Model
+
+Readiness is a matrix, not a boolean. Each baseline capability reports four levels:
+
+| Level | Meaning | Evidence |
+|---|---|---|
+| Declared | The capability is included in the approved Web MVP target. | Scope row and readiness row exist. |
+| Configured | Required config, process, storage, auth, handles, and app-server connection exist. | Setup/readiness page or operator checklist. |
+| Observed | A real run exercised the path successfully or produced an understood degraded outcome. | Timestamped run note, screenshot, recording, or status evidence. |
+| UX-exposed | The owner can use or inspect the capability in the Web UI or a documented fallback. | Reachable page, panel, state, form, action, or fallback. |
+
+## Baseline Capability Rows
+
+| Capability | MVP target | Minimum gate |
+|---|---|---|
+| Login/access control | Required before any URL exposure. | No exposed unauthenticated Web Home or workspace state. |
+| Operator binding | Required before state or action display. | Authorized control surface is clear; unbound access is rejected. |
+| Workspace/session/conversation visibility | Required for screenshot prototype. | Workspace list, active workspace, recent conversations, and empty/error/unavailable cases render safely. |
+| Runtime status visibility | Required for screenshot prototype. | Running/blocked/done/failed/degraded states are understandable. |
+| Final answer visibility | Required for Web usefulness. | Final answer is visually separate from progress/recent output. |
+| Artifact/file visibility | Required where configured. | Descriptor, unavailable, expired, failure, preview, or download state is visible. |
+| Interaction visibility | Required before action controls. | Pending/resolved/expired/stale/duplicate/failed states are visible. |
+| Delivery/degraded outcome visibility | Required before support claim. | Partial, failed, rate-limited, fallback, and degraded outcomes are visible. |
+| Mobile URL validation | Required before owner acceptance of protected URL. | Owner opens authenticated URL from phone and validates baseline read-only flows. |
+| Screenshot/recording evidence path | Required before protected URL trial. | Owner can review captured evidence without public exposure. |
+
+Action capabilities such as interaction response, text task submission, interrupt, and upload are
+tracked separately after their gates are approved; they are not part of the first read-mostly lane.
+
+## VPS And Mobile Validation Plan
+
+The owner-operated validation sequence is mandatory:
+
+1. **Local VPS run with screenshots/recordings.** Validate information architecture and mobile-sized
+   layouts without exposing a URL.
+2. **Protected URL only after login/access control exists.** Use temporary, reversible, allowlisted,
+   or otherwise controlled exposure.
+3. **Owner phone validation of read-only flows.** Confirm Web Home, workspace sessions, conversation detail/results, runtime context, artifact, readiness, and degraded states are readable from a phone.
+4. **Controlled actions only after security/readiness approval.** Enable one action class at a time
+   only after the relevant gate passes.
+
+Minimum protected-phone acceptance:
+
+| Check | Pass condition |
+|---|---|
+| Login | Owner signs in from phone; unauthenticated access is rejected. |
+| Web Home | Workspace list, active workspace/session, recent conversations, current turn, and contextual readiness/status are readable. |
+| Runtime | Running/blocked/done/failed/degraded state is clear without horizontal scrolling. |
+| Final answer | Completed answer is readable separately from progress. |
+| Artifacts | Artifact availability or unavailability is understandable. |
+| Security | No raw secrets, local sensitive paths, raw terminal controls, or verbose logs are exposed by default. |
+
+## Security And Access Guardrails
+
+Security blocks exposure. If login, authorization, or action protection is missing, the prototype may
+be reviewed only through screenshots/recordings.
+
+| Guardrail | Required posture |
+|---|---|
+| Authentication | Mandatory before any external URL exposure. |
+| Authorization | Single high-trust operator binding for MVP; reject unbound access. |
+| Network exposure | No unauthenticated public URL; prefer temporary, reversible, allowlisted, or proxied access. |
+| Session security | Use server-side sessions or equivalent; avoid durable browser secrets beyond need. |
+| CSRF/action protection | Required before task submission, interaction responses, interrupt, or upload. |
+| Secrets | Do not display tokens, env vars, raw credentials, or sensitive config values. |
+| Paths/logs | Avoid raw local paths and verbose logs by default; expose diagnostics only intentionally. |
+| Terminal | No raw terminal or shell controls in the first Web lane. |
+| Writes | No arbitrary project writes in the first Web lane. |
+| Artifacts | Use controlled handles; show expired/unavailable/failure states safely. |
+| Auditability | Record visible outcomes for every enabled action and failure path. |
+| Failure visibility | Failed, degraded, rate-limited, and fallback outcomes must be shown, not hidden. |
+
+## Owner Go/No-Go Gates
+
+| Gate | Go condition | No-go condition |
+|---|---|---|
+| Scope lock | Owner accepts Web-first/App-later, read-mostly first lane, and deferred scope. | App-first, public support, raw terminal, uploads, or writes enter the first lane. |
+| Screenshot prototype | Owner can understand the pages from screenshots/recordings on phone-sized views. | Key states are missing, confusing, or expose sensitive details. |
+| Protected URL | Login/access control and forbidden-data guardrails are configured. | Any unauthenticated Web Home/state page, secret/path/log leak, or unclear operator binding. |
+| Phone read-only trial | Owner validates read-only Web Home, workspace sessions, conversation detail/results, runtime context, artifact, readiness, and degraded states. | Baseline flows cannot be inspected from phone. |
+| Controlled action trial | A single approved action class has CSRF/action protection, audit trail, stale/failure handling, and recovery visibility. | Actions would mutate runtime state without clear outcome and recovery visibility. |
+| Support claim | Required baseline journeys are declared, configured, observed, and UX-exposed, with documented fallbacks. | Any required baseline remains only designed, only configured, or only internally observable. |
+
+Minimum support claim also requires the owner to authenticate, confirm project/session, submit a text
+task, answer at least one approval/question, inspect progress, interrupt when needed, receive the
+final answer, access baseline artifacts where configured, and understand degraded/failure states
+through Web UI or documented fallback.
+
+## Status And Reporting Format
+
+Each Web MVP status update should be short and evidence-based:
+
+```text
+WEB_MVP_PHASE: Scope | Screenshot | Protected URL | Read-only phone | Controlled action | Support decision
+STATUS: Green | Yellow | Red
+DATE:
+ENVIRONMENT: local VPS | protected URL | phone browser
+SUMMARY:
+READINESS CHANGES:
+- Capability: declared/configured/observed/UX-exposed delta and evidence
+SECURITY NOTES:
+OWNER EVIDENCE: screenshot/recording/status link or note
+BLOCKERS:
+NEXT GATE:
+```
+
+Use Green only when the current phase gate passed with evidence. Use Yellow for useful progress with
+known gaps. Use Red for a security, readiness, or scope issue that prevents the next exposure level.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -4,6 +4,7 @@ layer: 2
 parent: docs/INDEX.md
 children:
   - docs/operations/install-and-admin.md
+  - docs/operations/web-preview-runbook.md
   - docs/operations/web-vps-mobile-access-and-security.md
 summary: router for install, configuration, service management, update, diagnostics, and future Web prototype access/security docs
 read_when:
@@ -19,11 +20,12 @@ source_of_truth:
 
 # Operations Index
 
-Use this directory for install, configuration, service management, update, diagnostics, and future Web prototype access/security planning.
+Use this directory for install, configuration, service management, update, diagnostics, the active owner Web preview runbook, and future Web prototype access/security planning.
 
 ## Open One Leaf
 
 - `install-and-admin.md` - install flow, config keys, paths, services, voice-input backends, update and restart behavior, and diagnostics.
+- `web-preview-runbook.md` - active owner-only Codex Console Web preview operations: start, stop, status, smoke, rotate, and rollback.
 - `web-vps-mobile-access-and-security.md` - future Web prototype VPS/mobile validation phases, protected URL exposure choices, access-control gates, forbidden-data defaults, and shutdown plan.
 
 ## Skip This Directory When

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -4,9 +4,11 @@ layer: 2
 parent: docs/INDEX.md
 children:
   - docs/operations/install-and-admin.md
-summary: router for install, configuration, service management, update, and diagnostics docs
+  - docs/operations/web-vps-mobile-access-and-security.md
+summary: router for install, configuration, service management, update, diagnostics, and future Web prototype access/security docs
 read_when:
   - the request is about install flow, config, service management, update, or diagnostics
+  - the request is about future Web prototype VPS/mobile access, protected URL exposure, or security gates
   - the request is about operator or admin behavior rather than Telegram UX
 skip_when:
   - the request is about current user-facing behavior or future Core direction
@@ -17,14 +19,15 @@ source_of_truth:
 
 # Operations Index
 
-Use this directory for install, configuration, service management, update, and diagnostics.
+Use this directory for install, configuration, service management, update, diagnostics, and future Web prototype access/security planning.
 
 ## Open One Leaf
 
 - `install-and-admin.md` - install flow, config keys, paths, services, voice-input backends, update and restart behavior, and diagnostics.
+- `web-vps-mobile-access-and-security.md` - future Web prototype VPS/mobile validation phases, protected URL exposure choices, access-control gates, forbidden-data defaults, and shutdown plan.
 
 ## Skip This Directory When
 
 - you need current Telegram UX
 - you need current code ownership instead of operator behavior
-- you need future Core direction rather than the current admin surface
+- you need future Core direction rather than operator/admin access planning

--- a/docs/operations/web-preview-runbook.md
+++ b/docs/operations/web-preview-runbook.md
@@ -1,0 +1,124 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/operations/README.md
+summary: active owner runbook for the managed Codex Console Web preview on codex.guicheng.xyz
+read_when:
+  - operating the personal Codex Console Web owner preview
+  - starting, stopping, checking, smoking, rotating, or rolling back the Web preview stack
+skip_when:
+  - changing Web product UI or adding multi-user/action controls
+source_of_truth:
+  - docs/operations/web-preview-runbook.md
+  - scripts/web-preview-start.sh
+  - scripts/web-preview-stop.sh
+  - scripts/web-preview-status.sh
+  - scripts/web-preview-rotate-secrets.sh
+  - scripts/web-preview-smoke.sh
+  - scripts/web-owner-cookie-proxy.py
+-->
+
+# Codex Console Web Managed Preview Runbook
+
+This is the active owner-only preview path for `https://codex.guicheng.xyz`.
+
+Architecture: localhost read-only Web app on `127.0.0.1:45682` -> localhost owner cookie proxy on `127.0.0.1:45683` -> Cloudflare named tunnel `codex-console`.
+
+## Limits
+
+- Personal project only: one owner, no multi-user auth system.
+- Read-only Web state only: no Web action controls.
+- No public unauthenticated bridge state: unauthenticated users see only the owner login page and `/healthz` proxy health.
+- Scripts use local background processes and pid files. Systemd installation is intentionally deferred.
+
+## Files and secrets
+
+Default env file:
+
+```sh
+~/.config/codex-telegram-bridge/web-preview.env
+```
+
+The start script creates it with mode `600` and fills missing values:
+
+- `CTB_WEB_READONLY_TOKEN`
+- `CTB_WEB_PREVIEW_PASS` (or existing `CTB_WEB_BASIC_PASS` is accepted by the proxy)
+- `CTB_WEB_SESSION_SECRET`
+- `CTB_WEB_READONLY_PLATFORM=feishu`
+- `CTB_WEB_READONLY_PORT=45682`
+- `PROXY_PORT=45683`
+- `UPSTREAM=http://127.0.0.1:45682`
+
+Do not put these secrets in URLs, command lines, chat messages, docs, or logs.
+
+State, pid files, and logs default to:
+
+```sh
+~/.local/state/codex-telegram-bridge/web-preview/
+```
+
+## Start
+
+```sh
+scripts/web-preview-start.sh
+```
+
+The script starts, in order:
+
+1. read-only Web app
+2. owner cookie proxy
+3. Cloudflare named tunnel `codex-console`
+
+It prints the public URL and the password file location, but not bearer/session secrets.
+
+## Status
+
+```sh
+scripts/web-preview-status.sh
+```
+
+Check this before sharing or using the public URL. It reports managed pid files, ports, proxy `/healthz`, and the configured Cloudflare ready endpoint without printing secrets.
+
+## Smoke
+
+```sh
+scripts/web-preview-smoke.sh
+```
+
+The smoke verifies:
+
+- proxy `/healthz`
+- unauthenticated login page
+- owner login POST
+- authenticated Home
+- authenticated `/interactions`
+- an optional conversation detail route when one is linked
+- direct read-only app is not public without bearer auth
+- obvious token/password/session-secret leaks in smoke responses
+
+## Rotate secrets
+
+```sh
+scripts/web-preview-rotate-secrets.sh
+scripts/web-preview-stop.sh
+scripts/web-preview-start.sh
+scripts/web-preview-smoke.sh
+```
+
+Rotation updates the bearer token, session secret, and owner preview password in the env file without printing them. Current processes keep old secrets until restart.
+
+## Stop / rollback
+
+```sh
+scripts/web-preview-stop.sh
+```
+
+Stop order is public ingress first, then proxy, then read-only app. The script only uses the managed preview pid files and does not stop unrelated Cloudflare quick tunnels such as previews on `:8088`.
+
+Rollback checklist:
+
+1. Stop the preview.
+2. Run status and confirm `45682`/`45683` are not listening for the managed stack.
+3. If access was suspect, rotate secrets before the next start.
+4. Confirm `https://codex.guicheng.xyz` shows a tunnel failure or login page only, never bridge state.
+5. Keep the env file mode at `600`.

--- a/docs/operations/web-vps-mobile-access-and-security.md
+++ b/docs/operations/web-vps-mobile-access-and-security.md
@@ -1,0 +1,190 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/operations/README.md
+children: []
+summary: future Web prototype VPS/mobile validation, protected URL exposure, access-control, and shutdown plan
+read_when:
+  - planning owner validation for the future Web-first Codex Console prototype from a VPS
+  - deciding when screenshots are enough versus when a protected phone-accessible URL may be exposed
+  - reviewing security gates, forbidden data, or rollback for the future Web prototype
+skip_when:
+  - the request is about current Telegram or Feishu shipped behavior
+  - the request is asking for Web server, auth, proxy, tunnel, route, or networking implementation
+source_of_truth:
+  - docs/operations/web-vps-mobile-access-and-security.md
+  - docs/future/web-mvp-scope-and-readiness.md
+  - docs/architecture/web-app-preimplementation-contract.md
+-->
+
+# Web VPS Mobile Access And Security Plan
+
+Status: Future Web prototype validation plan only
+Owner: Product / Operations / Security
+Last updated: 2026-04-26
+
+This plan defines how the owner should validate a future **Web-first Codex Console** prototype that
+runs on an owner-controlled VPS Linux server and is normally inspected from a phone. The Web product
+shape being validated is workspace/session/conversation centric: Web Home, workspace sessions, and
+conversation results first; runtime, readiness, and access state as supporting context. It is not an
+implementation plan and does not authorize Web routes, servers, auth middleware, proxy config,
+tunnels, scripts, networking changes, public support claims, or native App work.
+
+Web remains a future/prototype surface. Telegram remains the current stable/default pack. Feishu
+remains a serious current pack with explicit setup and readiness caveats.
+
+## Assumptions
+
+- The prototype runtime is on a VPS Linux server controlled by the owner.
+- The owner normally validates from a phone, not by opening a browser on the VPS itself.
+- Early validation evidence should be captured by the controller as screenshots or recordings.
+- A phone-accessible URL is allowed only after login, access control, and forbidden-data guardrails
+  are ready.
+- The first Web MVP lane is single-operator, read-mostly, non-public, and prototype only.
+- The first lane must not include raw terminal access, arbitrary project writes, upload flow, or
+  action controls. Action controls are later-lane work only after separate review and approval.
+
+## Validation Phases
+
+| Phase | Purpose | Allowed exposure | Exit gate |
+|---|---|---|---|
+| 1. Controller screenshots/recordings | Validate information architecture, state coverage, and mobile-sized layout without giving the owner a live URL. | Controller-only local or tunneled access; no owner-facing URL required. | Owner can review captured mobile-sized evidence and identify missing/confusing states. |
+| 2. Protected URL readiness | Prove the prototype can reject unauthorized access and hide sensitive data before a phone trial. | Reversible, temporary, authenticated, and preferably allowlisted access. | Login/access control, operator binding, forbidden-data checks, and shutdown path are verified. |
+| 3. Read-only phone trial | Let the owner open the protected URL from a phone and inspect baseline read-only flows. | Protected URL for the owner only. | Owner can read Web Home, workspace sessions, conversation results/artifacts, runtime context, interactions, readiness, and degraded states from phone. |
+| 4. Controlled actions later | Add one approved action class at a time after security/readiness review. | Protected URL with action-specific controls. | The specific action has CSRF/action protection, audit trail, stale/failure handling, and rollback visibility. |
+
+Do not skip directly from phase 1 to action controls. Do not expose any unauthenticated Web Home or
+state page during any phase.
+
+## Exposure Patterns To Consider
+
+These are patterns to evaluate before implementation, not instructions to configure them now.
+
+| Pattern | Good fit | Main risks | Required guardrails |
+|---|---|---|---|
+| SSH tunnel for controller-only screenshot capture | Phase 1 evidence collection where only the controller needs browser access. | Not usable by the owner from phone unless additional access is created; can hide mobile-network issues. | Keep access local to the controller session; capture mobile-sized screenshots/recordings; tear down after evidence capture. |
+| Reverse proxy with authentication | Phase 2 or 3 owner phone trial when a stable protected URL is needed. | Misconfigured auth, broad public exposure, weak session handling, leaked headers/logs. | Enforce auth before the app; use HTTPS; bind to the single operator; prefer allowlisting where practical; log minimal metadata. |
+| Temporary tunnel such as cloudflared/ngrok-style access | Short-lived phone trial when DNS/proxy setup is not ready. | Accidental public reachability, stale tunnel left running, provider account/config leakage. | Use temporary URLs only; require auth at the app or tunnel layer; set an expiry; stop the tunnel immediately after trial. |
+| VPN/Tailscale-style private access | Owner-only trials where installing or using a private network from phone is acceptable. | Device enrollment friction, stale device access, unclear ownership of network policy. | Restrict to owner devices; remove trial devices when done; still require app login before showing state. |
+| IP allowlist where possible | Extra defense for known owner/controller networks. | Mobile networks change; allowlist alone is not authentication. | Treat as defense-in-depth only; combine with login; keep a documented emergency remove/deny rule. |
+
+## Recommended Default For First External Owner Trial
+
+Use a **protected URL behind authentication with a reversible exposure mechanism**, and prefer an IP
+allowlist or private-network restriction where practical. For the first external owner trial, the
+recommended default is:
+
+1. finish phase 1 with controller-captured mobile-sized screenshots/recordings;
+2. expose a short-lived protected URL for the owner-only read-only phone trial;
+3. require login before rendering any Web Home or state;
+4. disable the exposure immediately after the trial unless a follow-up review explicitly keeps it on.
+
+A reverse proxy with authentication is the steadier default if the owner will repeat phone trials.
+A temporary tunnel is acceptable for a short one-off trial only when it is authenticated, time-bound,
+and easy to shut down. VPN/Tailscale-style access is acceptable when the owner prefers private-device
+access over a public internet URL.
+
+## Login And Access-Control Requirements
+
+Before any exposed URL exists, the prototype must satisfy all of these requirements:
+
+- unauthenticated requests see no Web Home, workspace/session state, runtime state, final answers,
+  artifacts, readiness details, logs, local paths, or terminal-like output;
+- only the intended high-trust operator can authenticate;
+- authenticated access is bound to the owner/operator context, not to anonymous browser state;
+- sessions expire or can be revoked without changing application code;
+- logout or revoke removes access from the phone browser;
+- access denial is safe and generic, without revealing projects, paths, tokens, provider names, or
+  local configuration details;
+- CSRF/action protection is present before any state-changing route, even if action buttons are not
+  yet visible;
+- auth and exposure settings are visible in the setup/readiness view as configured/observed status,
+  without printing secrets.
+
+## Forbidden Data By Default
+
+The future Web prototype must not render these by default:
+
+- tokens, API keys, OAuth secrets, bot tokens, tunnel credentials, cookies, session ids, or raw env
+  values;
+- full local sensitive paths, home-directory paths, temp paths, socket paths, raw artifact backing
+  paths, or config-file locations unless intentionally redacted;
+- raw terminal, shell prompt, command-entry controls, or unbounded command output;
+- verbose logs, stack traces, request headers, full payload dumps, provider debug blobs, or app-server
+  protocol dumps;
+- arbitrary project file contents or diffs outside an explicitly approved read-only preview path;
+- upload widgets, file write controls, project mutation controls, or action controls before their
+  separate gate passes.
+
+Preferred defaults are redacted labels, stable opaque ids, summarized status, safe artifact
+descriptors, and explicit unavailable/expired/failure states.
+
+## Mobile UX Acceptance Checklist
+
+A protected phone trial passes only when the owner can validate all required read-only flows from a
+normal phone viewport:
+
+- login works from the phone, and unauthenticated access is rejected;
+- Web Home workspace/session status is readable without horizontal scrolling;
+- active project/session, recent session, and empty/error/unavailable states are understandable;
+- runtime states such as idle, queued, running, blocked, done, failed, degraded, unhealthy, and
+  recovered are visually distinct;
+- progress/recent output is clearly separate from final answers;
+- final answers are readable as long-form content, not only as transient progress;
+- artifact rows show safe availability, preview/download eligibility, unavailable, expired, and
+  failure states without leaking local paths;
+- interaction states show pending, resolved, expired, stale, duplicate, and failed outcomes even
+  while response actions remain disabled;
+- readiness shows declared/configured/observed/UX-exposed status and the next missing gate;
+- error, degraded, and recovery messages are understandable on a phone;
+- no raw secrets, sensitive local paths, raw terminal controls, verbose logs, uploads, or write
+  actions appear by default.
+
+## Go/No-Go Gates For Exposing A URL
+
+| Gate | Go | No-go |
+|---|---|---|
+| Scope | Web-first, App-later, read-mostly prototype scope is still intact. | First trial includes raw terminal, uploads, arbitrary writes, action controls, or public support wording. |
+| Screenshot evidence | Controller screenshots/recordings show baseline pages and mobile-sized states. | Owner cannot evaluate the prototype before live exposure, or key states are missing. |
+| Authentication | Login is required before any state renders, and unauthorized access is rejected. | Any Web Home/state page is reachable without auth. |
+| Operator binding | Access is limited to the intended high-trust operator. | Access is anonymous, shared, or not revocable. |
+| Forbidden data | Secrets, raw env, sensitive paths, terminal, verbose logs, and unsafe artifacts are absent or redacted. | Any secret/path/log/terminal leak appears in the UI or default error path. |
+| Exposure control | The selected exposure is temporary or reversible, with allowlist/private access where practical. | Nobody can quickly identify or stop the exposure. |
+| Read-only posture | The URL exposes read-only pages only. | Browser can submit tasks, answer interactions, interrupt, upload, or write without separate action approval. |
+| Shutdown drill | The owner/controller knows the exact stop path and expected result. | Rollback requires code changes, searching for process ids blindly, or waiting on a third party. |
+
+## Incident And Rollback Plan
+
+If the URL, auth, tunnel, proxy, or UI exposes more than intended, treat it as a stop-the-trial event.
+The rollback path must be known before exposure starts.
+
+Immediate actions:
+
+1. disable the external exposure path first, before debugging the UI;
+2. stop or remove the temporary tunnel, proxy route, DNS mapping, allowlist entry, or private-network
+   share used for the trial;
+3. revoke sessions or invalidate auth credentials used for the trial;
+4. rotate any token or secret that may have been displayed, logged, copied, or included in a
+   screenshot/recording;
+5. preserve only redacted evidence needed for root-cause review;
+6. record the incident in the readiness/security notes with date, impact, exposure window, data
+   class involved, rollback completed, and follow-up gate.
+
+A trial may resume only after the leaked data class is removed or redacted, unauthorized access is
+retested, and the owner approves the next gate.
+
+## Decisions Required Before Implementation
+
+Before any coding, proxy, auth, tunnel, or networking task starts, decide:
+
+- which phase is being implemented or validated;
+- who is the single authorized operator for the first trial;
+- which authentication mechanism and session revocation path will be used;
+- whether the first owner URL uses reverse proxy, temporary tunnel, VPN/private network, allowlist,
+  or a combination;
+- whether the URL will be temporary by default and what event shuts it down;
+- what evidence the controller must capture before live URL exposure;
+- what forbidden-data redaction rules apply to paths, artifacts, logs, errors, and readiness details;
+- which mobile browsers/viewports are accepted for the first read-only trial;
+- which action classes remain disabled and what separate gate would enable each one;
+- who can declare no-go, execute rollback, and approve resuming the trial.

--- a/docs/plans/2026-04-26-product-web-console-mvp.md
+++ b/docs/plans/2026-04-26-product-web-console-mvp.md
@@ -1,0 +1,355 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/plans/README.md
+children: []
+summary: Phase 3 Product Web Console MVP information architecture, core flows, acceptance criteria, and next implementation slices
+read_when:
+  - starting Phase 3 Product Web Console MVP work
+  - deciding whether a Web change is product UI, substrate, action, or support-claim scope
+  - preparing the first real Console shell/readable conversation detail implementation slice
+skip_when:
+  - the task is only about current Telegram or Feishu shipped behavior
+  - the task is implementing runtime code without needing Product Web Console scope
+source_of_truth:
+  - docs/plans/2026-04-26-product-web-console-mvp.md
+  - docs/future/web-mvp-scope-and-readiness.md
+  - docs/architecture/web-app-preimplementation-contract.md
+-->
+
+# Product Web Console MVP — Phase 3 First Slice
+
+Status: Phase 3 docs/planning landing; no runtime implementation in this slice
+Owner: Product / Architecture
+Last updated: 2026-04-26
+
+## Current Correction
+
+The current browser preview is an owner-visible temporary read-only debug/admin preview. It is useful proof that a browser can reach sanitized Bridge state, but it is not a user-facing Web product, not public, and not supported Web Console behavior.
+
+Phase 3 shifts the lane from substrate/security plumbing toward a real Product Web Console MVP: Web first, App later; single high-trust operator first; owner/private; denied-by-default; read-mostly until the read experience is useful.
+
+## Product Goal
+
+The MVP should let the owner open a browser on phone or desktop and immediately answer:
+
+- What is my Codex Bridge doing right now?
+- Which workspaces/projects and conversations/tasks exist?
+- Which conversation or task is running, blocked, done, failed, or degraded?
+- What was the final useful result, shown in a readable Web layout?
+- What needs my attention, without exposing raw platform internals or unsafe controls?
+
+A usable Web Console is not a debug portal. It should feel like a workspace/conversation/task product surface: clear navigation, readable details, human status copy, safe degraded states, and mobile-first result reading. Runtime, readiness, and access information support the product experience; they are not the product by themselves.
+
+## MVP Navigation And Information Architecture
+
+### 1. Home
+
+Purpose: fast orientation.
+
+Content:
+
+- Product header: `Codex Console` plus environment label such as `Owner preview` or `Read-only prototype`.
+- Compact system state cards:
+  - current runtime state: idle, running, blocked, degraded, failed, or unavailable;
+  - pending attention count: approvals/questions needing review, shown read-only in this lane;
+  - readiness summary: ready, degraded, setup needed, or unavailable.
+- Active workspace/project card, if known: safe label, last activity, active conversation/task summary.
+- Recent conversations/tasks list: title or safe summary, workspace label, state, last update, and link to detail.
+- Empty/degraded states when data is absent: explain what is unavailable and what the owner can still do.
+
+Must not show raw chat IDs, session IDs, local paths, tokens, callback payloads, terminal logs, or platform-shaped copy.
+
+### 2. Workspaces / Projects
+
+Purpose: browse safe workspace context without changing runtime state.
+
+Content:
+
+- Workspace/project rows with safe display label, optional redacted/relative metadata where approved, last activity, conversation count if available, and readiness hints.
+- Active workspace marker if known.
+- Per-workspace entry points to conversations/tasks.
+- Safe unavailable state when the workspace reader is missing, unbound, filtered, or degraded.
+
+First lane behavior: read-only browse and open only. No project switching, renaming, pinning, archiving, writes, file browsing, or raw path reveal.
+
+### 3. Conversations / Tasks
+
+Purpose: give the owner a scannable work queue/history.
+
+Content:
+
+- Unified rows for sessions/conversations/tasks using Web-neutral labels.
+- State badge: running, blocked, pending input, pending approval, done, failed, degraded, or unavailable.
+- Short safe summary, workspace/project label, last update, and final-answer availability.
+- Attention grouping: `Needs attention`, `Running now`, `Recently completed`, `Older` when data supports it.
+- Empty state that distinguishes no conversations from data unavailable.
+
+First lane behavior: open detail only. No submit-new-task, resume, interrupt, approval answer, question answer, raw logs, downloads, or platform message links.
+
+### 4. Conversation / Task Detail
+
+Purpose: make the result readable and separate final output from progress/debug state.
+
+Content:
+
+- Header: title/safe summary, workspace label, state badge, timestamps where available, and read-only/action-disabled posture.
+- Status panel: current lifecycle state in user language, including running/blocked/pending/degraded explanation.
+- Final answer panel:
+  - render sanitized Web-neutral final answer body when present;
+  - show a clear unavailable/degraded message when no safe body source exists;
+  - keep progress, runtime output, delivery warnings, and final answer visually separate.
+- Pending interaction panel: approval/question/picker read-only summary when present, including state and expiry/stale wording when known.
+- Artifacts panel: descriptor-only labels and availability states; no raw paths or unsafe downloads in this first slice.
+- Runtime/delivery notes: concise degraded/failed/fallback messages, not terminal dumps.
+
+### 5. Pending / Approvals
+
+Purpose: show what needs owner attention before action controls are enabled.
+
+Content:
+
+- Pending approval/question/picker cards grouped by conversation/task.
+- Risk/title/body summary sanitized for Web.
+- State: pending, resolved, expired, stale, duplicate, failed, or unavailable.
+- Expiry or last update when available.
+- Disabled or absent action controls in the read-only MVP; copy should say actions are not enabled in this preview.
+
+This page is the handoff point for the later gated action lane, but this first slice only specifies the read view.
+
+### 6. Runtime / Readiness / Settings
+
+Purpose: explain whether the Console is safe and useful right now.
+
+Content:
+
+- Runtime compact and detailed state: idle, queued, running, blocked, interrupting, done, failed, degraded, unhealthy, recovered, or unavailable.
+- Readiness matrix for baseline capabilities: declared, configured, observed, UX-exposed.
+- Access posture: owner/private, authenticated/denied-by-default, active binding known or unavailable.
+- Setup gaps and degraded reasons in safe language.
+- Kill-switch/rollback readiness may be listed as status only; no live destructive controls in this MVP slice.
+
+This area must not become the primary landing page or a generic admin dashboard.
+
+## Core Flows
+
+### Flow A — Open Console And Understand State Quickly
+
+1. Owner opens the protected Console on phone or desktop.
+2. Unauthorized access is denied before state is shown.
+3. Home loads with clear owner-preview/read-only posture.
+4. Owner sees runtime state, pending-attention count, active workspace, and recent conversations/tasks above the fold.
+5. If state is unavailable, the page explains the degraded source instead of showing empty debug tables.
+
+Acceptance:
+
+- The owner can tell within one screen whether the system is idle, running, blocked, degraded, or unavailable.
+- Mobile layout works without horizontal scrolling.
+- No raw IDs, paths, tokens, callback data, or platform-specific terms are required to understand the page.
+
+### Flow B — Browse Workspace / Session / Task Rows Safely
+
+1. Owner opens Workspaces/Projects or Conversations/Tasks.
+2. Rows use safe labels and human states.
+3. Owner can filter mentally by attention/running/recent groupings where present.
+4. Empty and degraded states distinguish `nothing here` from `data source unavailable`.
+5. Owner opens a detail page through an opaque Web handle.
+
+Acceptance:
+
+- Rows are cards or responsive list items, not table-only debug dumps.
+- Opaque handles may exist in URLs but are not presented as meaningful user content.
+- No row includes raw platform IDs, local absolute paths, tokens, or terminal output.
+
+### Flow C — Open Conversation / Task Detail And Read Status / Result
+
+1. Owner opens a conversation/task detail page.
+2. Header identifies the work using safe summary, workspace label, and state.
+3. Final answer appears as readable Web content when a safe source exists.
+4. If the final answer body is absent, the page says it is unavailable because no sanitized Web body source exists.
+5. Pending state, artifacts, runtime notes, and degraded delivery are separate panels.
+
+Acceptance:
+
+- Final answer is not confused with progress, recent output, or delivery status.
+- Long text wraps and is readable on phone.
+- Detail page never scrapes Telegram HTML, Feishu card JSON, callback markup, or debug pages as body content.
+
+### Flow D — See Running / Blocked / Pending States In User Language
+
+1. Owner sees a running task as `Running` with a short explanation such as `Codex is working; results will appear here when complete.`
+2. Owner sees a pending question as `Needs answer` with the question summary and read-only action-disabled copy.
+3. Owner sees a pending approval as `Approval needed` with safe risk text and read-only action-disabled copy.
+4. Owner sees degraded runtime as `Status degraded` with the missing source or stale data caveat.
+
+Acceptance:
+
+- The page uses owner-language state labels, not raw app-server event names or internal enum dumps.
+- Pending states are visible before any action lane is enabled.
+- Degraded runtime is explicit and safe; it does not look like a successful idle state.
+
+### Flow E — Later Gated Action Lane Handoff
+
+The first action lane comes after read UX is useful and protected owner access/action guardrails are accepted. Candidate first actions are:
+
+1. approval/question answer first; or
+2. submit draft first, only if explicitly chosen later.
+
+This MVP spec does not choose or implement an action. It defines the handoff requirements:
+
+- visible pending/readiness state exists before enabling controls;
+- owner auth/session binding is confirmed;
+- CSRF/replay protection or equivalent exists;
+- action nonce/idempotency and audit exist;
+- stale, duplicate, expired, failed, canceled, and resolved outcomes are visible;
+- kill switch and rollback drill are verified;
+- no action silently mutates runtime state without an owner-visible outcome.
+
+## Readable UI Acceptance Criteria
+
+- Mobile-first: primary flows work at phone width without horizontal scrolling, tiny tap targets, or table-only layouts.
+- Desktop-friendly: wide screens may add sidebars/panels but cannot hide key state behind debug tables.
+- Accessible static HTML baseline: semantic headings, landmarks or clear sections, readable focus order, sufficient contrast, escaped content, and usable no-JavaScript fallback for read views.
+- Product language: use Web-neutral terms such as workspace, project, conversation, task, result, runtime, pending, approval, question, readiness.
+- No Telegram-shaped or Feishu-shaped copy in Web UI, except when explicitly naming a configured platform in a safe settings/readiness context.
+- No raw internals: do not show raw IDs, local paths, tokens, env vars, callback payloads, platform message IDs, app-server JSON, stack traces, or raw terminal output.
+- No debug feel: cards, sections, readable prose, badges, and empty states should replace table-only pages as the primary UX.
+- Safe stale data: timestamps or copy should make stale/degraded data clear when known.
+- Read-only posture: disabled/absent controls should not invite actions that are not enabled.
+
+## Data And Source Contract For Final Answer / Body Rendering
+
+Final answer body rendering is allowed only from Web-neutral sanitized sources owned by the bridge/Core/Web view-model boundary.
+
+Allowed source examples:
+
+- sanitized final-answer body already exposed by the Web read model;
+- persisted neutral final-answer record created for Web/Core consumption;
+- sanitized plain text or safe markdown produced by a bridge-owned final-answer pipeline;
+- artifact descriptors that point to availability state, not raw files, when body is unavailable.
+
+Forbidden body sources:
+
+- Telegram message HTML, Telegram callback markup, Telegram message IDs, or Telegram-rendered pages;
+- Feishu card JSON, Feishu event payloads, or platform callback/action payloads;
+- browser debug/admin pages or scraped prototype HTML;
+- raw terminal output, logs, app-server protocol dumps, local filesystem paths, or secret-bearing config;
+- tokenized download URLs or platform resource handles treated as body text.
+
+If no safe Web-neutral body exists, the detail page must render an explicit unavailable/degraded state, for example:
+
+- `Final answer body unavailable: this run has no sanitized Web-readable answer source yet.`
+- `Result metadata is available, but the answer text was not captured in a Web-safe format.`
+
+It must not silently fall back to scraping a chat transcript or debug preview.
+
+## Runtime And Pending State Acceptance Copy
+
+Required user-language states:
+
+- `Idle` — no active task is known.
+- `Queued` — a task is waiting to start.
+- `Running` — Codex is working; result will appear when complete.
+- `Needs answer` — Codex asked a question; action is read-only until the action lane is enabled.
+- `Approval needed` — Codex requested approval; action is read-only until the action lane is enabled.
+- `Blocked` — progress is stopped until a required owner interaction is resolved.
+- `Done` — final result or completion metadata is available.
+- `Failed` — the task ended without a usable final answer.
+- `Degraded` — state is partial, stale, or missing a source; the visible data may be incomplete.
+- `Unavailable` — the required reader/source is not connected or not authorized.
+- `Recovered` — runtime restarted or state was restored with known caveats.
+
+Acceptance:
+
+- Running state includes what is happening and where the owner should look next.
+- Pending question/approval states are prominent on Home, list rows, detail, and Pending/Approvals.
+- Degraded runtime names the missing class of source without leaking internals.
+- Failed/unavailable states provide safe next-step copy such as refresh, check readiness, or use the current Telegram/Feishu fallback if applicable; they do not imply Web support is complete.
+
+## Guardrails And Non-Goals
+
+Guardrails:
+
+- Web is not shipped, public, supported, or product-complete.
+- First lane remains single-operator, owner/private, denied-by-default, and read-mostly.
+- Protected access must exist before owner URL exposure; screenshots/recordings remain acceptable proof before that.
+- Web UI must consume neutral Core/bridge view models, not fork Telegram or Feishu UI semantics.
+- Platform-specific credentials, tokens, local secret files, raw app-server payloads, and callback data stay out of UI and docs.
+- Readiness is a matrix, not a boolean support claim.
+- Action controls require a separate explicit implementation gate.
+
+Non-goals for this MVP lane:
+
+- native App work;
+- public hosted service or SaaS control plane;
+- multi-user/team collaboration;
+- submit-new-task, approval answer, question answer, interrupt, upload, project switching, session resume, or file/project writes;
+- raw terminal, shell, log console, arbitrary command execution, or debug protocol explorer;
+- artifact download/preview unless a later slice explicitly supplies safe handles and retention rules;
+- repo/package/binary/config/state renames;
+- replacing Telegram as the current stable/default surface or overstating Feishu/Web support.
+
+## Implementation Slices After This Spec
+
+Order matters: the immediate next code slice should deliver the first real Console shell/readable conversation detail UI, not more substrate-only work.
+
+1. **Console shell and readable conversation detail UI**
+   - Convert the existing read-only HTML into a mobile-first Console shell with Home navigation, safe badges, readable cards, and conversation/task detail layout.
+   - Use existing safe view-model fields only.
+   - Preserve token/auth gate and opaque handles.
+   - Tests: static render assertions for nav, mobile-friendly structure classes/sections, escaped content, no raw IDs/paths/tokens, and unavailable final-answer copy.
+
+2. **Final-answer body source refinement**
+   - Wire only existing sanitized Web-neutral final-answer body where present.
+   - Add explicit unavailable/degraded rendering when absent.
+   - Tests: present body renders escaped/readable; absent source never scrapes Telegram/Feishu/debug HTML.
+
+3. **Conversation/task list grouping and state language**
+   - Add user-language groups and state labels for running, blocked, pending question, pending approval, done, failed, degraded, unavailable.
+   - Tests: all canonical states render safe copy and no platform enum leaks.
+
+4. **Pending/Approvals read-only page or section**
+   - Surface pending interactions as read-only cards linked to source conversation/task.
+   - Tests: pending/resolved/expired/stale/duplicate/failed states render; no action submission endpoints or controls are active.
+
+5. **Runtime/readiness/settings read page**
+   - Render compact and detailed runtime/readiness matrix in safe owner language.
+   - Tests: degraded/unavailable runtime copy, denied-by-default posture, no secrets/paths/log dumps.
+
+6. **Owner proof package**
+   - Produce screenshot/HTML proof from local/protected owner preview after readable UI lands.
+   - Tests/smoke: unauthenticated denial, authenticated Home/detail, mobile-sized screenshot, token/path/raw ID absence.
+
+7. **First gated action decision doc/update**
+   - Choose approval/question answer first or submit draft first only after read UX and proof pass.
+   - No implementation until security/action gates are accepted.
+
+## Verification Plan
+
+This docs slice:
+
+- `git diff --check` must pass.
+- `npm run check` must pass.
+- If router/catalog links are updated, run the cheapest available catalog/link check; otherwise note not applicable.
+
+Future code slices:
+
+- targeted unit tests around view-model rendering and HTTP route output;
+- static HTML assertions for semantic sections, escaped content, state copy, unavailable/degraded copy, and forbidden internals;
+- smoke test unauthenticated denial and authenticated Home/detail;
+- mobile-width screenshot proof before owner review;
+- regression proof that no action endpoints, downloads, uploads, raw terminal, platform callback markup, or support claims were added.
+
+## Acceptance Checklist For Phase 3 MVP Scope
+
+This spec is complete when it defines:
+
+- owner/user product goal beyond debug portal;
+- concrete Home, Workspaces/Projects, Conversations/Tasks, Detail, Pending/Approvals, Runtime/Readiness/Settings IA;
+- core read flows and later action-lane handoff;
+- readable UI acceptance criteria;
+- safe final-answer/body source contract;
+- runtime and pending state acceptance copy;
+- explicit guardrails and non-goals;
+- ordered small implementation slices with the first real UI slice next;
+- verification plan for docs now and code/smoke/screenshot proof later.

--- a/docs/plans/2026-04-26-product-web-console-mvp.md
+++ b/docs/plans/2026-04-26-product-web-console-mvp.md
@@ -27,7 +27,9 @@ Last updated: 2026-04-26
 
 The current browser preview is an owner-visible temporary read-only debug/admin preview. It is useful proof that a browser can reach sanitized Bridge state, but it is not a user-facing Web product, not public, and not supported Web Console behavior.
 
-Phase 3 shifts the lane from substrate/security plumbing toward a real Product Web Console MVP: Web first, App later; single high-trust operator first; owner/private; denied-by-default; read-mostly until the read experience is useful.
+**Important owner correction:** this is a personal project. Do not let future agents turn the Web Console into a security/readiness/admin product. Safety is a background guardrail, not the main user experience. The next Web work should make the Console feel like a real personal Web app: dashboard, continue-working flows, workspace/conversation/task browsing, readable results, attention cards, and friendly empty states.
+
+Phase 3 shifts the lane from substrate/security plumbing toward a real Product Web Console MVP: Web first, App later; single high-trust operator first; owner/private; read-mostly until the read experience is useful. Keep token-gated access and no-leak/no-destructive-action constraints, but avoid centering the UI around denied-by-default/security-posture copy.
 
 ## Product Goal
 
@@ -39,24 +41,24 @@ The MVP should let the owner open a browser on phone or desktop and immediately 
 - What was the final useful result, shown in a readable Web layout?
 - What needs my attention, without exposing raw platform internals or unsafe controls?
 
-A usable Web Console is not a debug portal. It should feel like a workspace/conversation/task product surface: clear navigation, readable details, human status copy, safe degraded states, and mobile-first result reading. Runtime, readiness, and access information support the product experience; they are not the product by themselves.
+A usable Web Console is not a debug portal and not a security center. It should feel like a workspace/conversation/task product surface: clear navigation, readable details, human status copy, friendly empty states, recent results, and mobile-first result reading. Runtime, readiness, and access information support the product experience; they are secondary utilities, not the product by themselves.
 
 ## MVP Navigation And Information Architecture
 
 ### 1. Home
 
-Purpose: fast orientation.
+Purpose: fast orientation and continuation, like a personal work console home screen.
 
 Content:
 
-- Product header: `Codex Console` plus environment label such as `Owner preview` or `Read-only prototype`.
-- Compact system state cards:
-  - current runtime state: idle, running, blocked, degraded, failed, or unavailable;
-  - pending attention count: approvals/questions needing review, shown read-only in this lane;
-  - readiness summary: ready, degraded, setup needed, or unavailable.
-- Active workspace/project card, if known: safe label, last activity, active conversation/task summary.
-- Recent conversations/tasks list: title or safe summary, workspace label, state, last update, and link to detail.
-- Empty/degraded states when data is absent: explain what is unavailable and what the owner can still do.
+- Product header: `Codex Console` plus a concise personal-console subtitle and at most one subtle `view-only preview` label.
+- Primary workflow sections:
+  - `Continue working`: active or recent conversations/tasks with clear open links;
+  - `Needs attention`: blocked turns, pending questions/approvals, failed/degraded tasks, shown as read-only cards in this lane;
+  - `Recent results`: recent completed conversations/tasks and whether a readable result is available;
+  - `Projects / workspaces`: safe workspace cards with counts and last activity.
+- Secondary utility links/cards for Runtime, Readiness, and Settings. These must not dominate the Home page.
+- Friendly empty states when data is absent: explain what will appear here once the bridge has conversations/results, rather than leading with scary degraded/security language.
 
 Must not show raw chat IDs, session IDs, local paths, tokens, callback payloads, terminal logs, or platform-shaped copy.
 

--- a/docs/plans/2026-04-26-product-web-console-mvp.md
+++ b/docs/plans/2026-04-26-product-web-console-mvp.md
@@ -33,7 +33,7 @@ Phase 3 shifts the lane from substrate/security plumbing toward a real Product W
 
 ## Product Goal
 
-The MVP should let the owner open a browser on phone or desktop and immediately answer:
+The MVP direction has been superseded by the Web Chat Platform pivot: the owner should open a browser on phone or desktop and land in a conversation-first surface. The browser home should still answer:
 
 - What is my Codex Bridge doing right now?
 - Which workspaces/projects and conversations/tasks exist?
@@ -41,13 +41,13 @@ The MVP should let the owner open a browser on phone or desktop and immediately 
 - What was the final useful result, shown in a readable Web layout?
 - What needs my attention, without exposing raw platform internals or unsafe controls?
 
-A usable Web Console is not a debug portal and not a security center. It should feel like a workspace/conversation/task product surface: clear navigation, readable details, human status copy, friendly empty states, recent results, and mobile-first result reading. Runtime, readiness, and access information support the product experience; they are secondary utilities, not the product by themselves.
+A usable Web Console is not a debug portal, status dashboard, or security center. It should feel like a chat platform for Codex Bridge: conversations first, composer posture visible, readable details/results, human status copy, friendly empty states, recent results, and mobile-first result reading. Runtime, readiness, and access information support the product experience; they are secondary utilities, not the product by themselves.
 
 ## MVP Navigation And Information Architecture
 
 ### 1. Home
 
-Purpose: fast orientation and continuation, like a personal work console home screen.
+Purpose: primary chat home for continuing Codex Bridge conversations. `/` is the canonical Web Chat landing route; `/chat` may exist only as an alias.
 
 Content:
 
@@ -57,6 +57,7 @@ Content:
   - `Needs attention`: blocked turns, pending questions/approvals, failed/degraded tasks, shown as read-only cards in this lane;
   - `Recent results`: recent completed conversations/tasks and whether a readable result is available;
   - `Projects / workspaces`: safe workspace cards with counts and last activity.
+- Composer posture for the active/open conversation. It may be disabled in the read-only slice, but it must point clearly to the message-send slice.
 - Secondary utility links/cards for Runtime, Readiness, and Settings. These must not dominate the Home page.
 - Friendly empty states when data is absent: explain what will appear here once the bridge has conversations/results, rather than leading with scary degraded/security language.
 

--- a/docs/plans/2026-04-26-product-web-console-mvp.md
+++ b/docs/plans/2026-04-26-product-web-console-mvp.md
@@ -293,26 +293,24 @@ Non-goals for this MVP lane:
 
 Order matters: the immediate next code slice should deliver the first real Console shell/readable conversation detail UI, not more substrate-only work.
 
-1. **Console shell and readable conversation detail UI**
-   - Convert the existing read-only HTML into a mobile-first Console shell with Home navigation, safe badges, readable cards, and conversation/task detail layout.
-   - Use existing safe view-model fields only.
-   - Preserve token/auth gate and opaque handles.
-   - Tests: static render assertions for nav, mobile-friendly structure classes/sections, escaped content, no raw IDs/paths/tokens, and unavailable final-answer copy.
+1. **Console shell and readable conversation detail UI — landed in `75271a6`**
+   - Existing read-only HTML now uses a mobile-first Console shell with Home navigation, safe badges, readable cards, and conversation/task detail layout.
+   - Token/auth gate, opaque handles, escaping/scrubbing, and unavailable final-answer copy were preserved.
 
-2. **Final-answer body source refinement**
-   - Wire only existing sanitized Web-neutral final-answer body where present.
-   - Add explicit unavailable/degraded rendering when absent.
-   - Tests: present body renders escaped/readable; absent source never scrapes Telegram/Feishu/debug HTML.
+2. **Final-answer body source refinement — landed in `530b9d3`**
+   - Existing sanitized Web-neutral final-answer body renders when present.
+   - Missing/rejected body sources render explicit unavailable/degraded copy.
+   - Telegram/Feishu/debug HTML, local paths, token URLs, callbacks, raw logs, and protocol payloads remain forbidden body sources.
 
-3. **Conversation/task list grouping and state language**
-   - Add user-language groups and state labels for running, blocked, pending question, pending approval, done, failed, degraded, unavailable.
-   - Tests: all canonical states render safe copy and no platform enum leaks.
+3. **Conversation/task list grouping and state language — landed in `afcf574`**
+   - Home and workspace conversation/task rows are grouped into owner-visible states such as Needs attention, Running now, Recently completed, and Other/Older.
+   - Canonical states render user-language labels/copy instead of raw enum-style display.
 
-4. **Pending/Approvals read-only page or section**
-   - Surface pending interactions as read-only cards linked to source conversation/task.
-   - Tests: pending/resolved/expired/stale/duplicate/failed states render; no action submission endpoints or controls are active.
+4. **Pending/Approvals read-only page or section — landed in `d66ff3d`**
+   - Pending interactions render as read-only owner attention cards with safe grouped states.
+   - Responses are explicitly disabled; no action submission endpoints or controls are active.
 
-5. **Runtime/readiness/settings read page**
+5. **Runtime/readiness/settings read page — next**
    - Render compact and detailed runtime/readiness matrix in safe owner language.
    - Tests: degraded/unavailable runtime copy, denied-by-default posture, no secrets/paths/log dumps.
 

--- a/docs/plans/2026-04-26-web-chat-platform-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-chat-platform-pm-ledger.md
@@ -87,10 +87,23 @@ Goal: restart managed preview, smoke public URL, capture proof, update PR, mark 
 ## Active processes
 
 - Phase D live wiring: completed and accepted 2026-04-27.
+- Phase E live preview proof: completed 2026-04-27.
 
 ## Next action
 
-Commit/push Phase D live Web Chat wiring, then execute Phase E: enable live managed preview, smoke owner login/home/conversation/composer/POST behavior, verify no raw internals leak, update PR body, and pause this cron when Web Chat is proven usable.
+Web Chat is live on the managed owner preview. The browser chat surface is owner-authenticated, shows conversations, exposes an enabled composer, accepts Web POST submissions into the live bridge, and shows refresh/status affordances. No further autonomous PM loop is needed unless the owner reopens scope.
+
+## Phase E live proof
+
+Completed: 2026-04-27
+
+- Deployed the live Web Chat build to the managed bridge install.
+- Enabled the bridge-owned local Web Chat upstream behind the owner cookie proxy.
+- Restarted the managed preview in live mode at `https://codex.guicheng.xyz`.
+- Smoked owner login, Home, conversation detail, composer presence, direct unauthenticated upstream denial, public URL auth, and safe POST behavior.
+- Sent one harmless local live Web message through the Web composer path and received `accepted` from the bridge submit seam.
+- Verified smoke responses did not include bearer/session/owner secrets, raw chat/session/thread/turn ids, local paths, stack traces, or app-server payloads.
+- Updated PR #16 with live Web Chat scope, tests, preview URL, and Ubuntu/Windows scope note.
 
 ## Phase A findings
 

--- a/docs/plans/2026-04-26-web-chat-platform-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-chat-platform-pm-ledger.md
@@ -86,11 +86,11 @@ Goal: restart managed preview, smoke public URL, capture proof, update PR, mark 
 
 ## Active processes
 
-- Phase B implementation: `proc_3a89c065bbf3` launched 2026-04-26 after Phase A contract commit `6cac234`.
+- Phase C implementation: `proc_99f79c93cc14` launched 2026-04-26 after Phase B chat-first read UI commit `0aaa9e3`.
 
 ## Next action
 
-Monitor Phase B Codex high implementation run. On completion, review diff, run targeted tests plus `npm run check` and `git diff --check`, then commit/push if accepted and launch Phase C send-path tests/implementation.
+Monitor Phase C Codex high implementation run. On completion, review diff, run targeted tests plus `npm run check` and `git diff --check`, then commit/push if accepted and launch Phase D refresh/live-result observation slice.
 
 ## Phase A findings
 

--- a/docs/plans/2026-04-26-web-chat-platform-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-chat-platform-pm-ledger.md
@@ -1,0 +1,209 @@
+# Web Chat Platform Landing PM Ledger
+
+Status: active autonomous execution ledger  
+Owner: Tuzi/Hermes as PM/controller; Codex runs implement/audit  
+Started: 2026-04-26
+
+## Owner mandate
+
+The owner is asleep and explicitly delegated execution. Do not stop halfway waiting for routine decisions. Continue planning, delegating, reviewing, committing, pushing, restarting preview, and verifying until the Web becomes a usable chat platform.
+
+## Product direction
+
+Web is not primarily a dashboard. Web is a first-class chat surface for Codex Bridge, analogous to Feishu/Telegram:
+
+- user opens browser;
+- sees conversations;
+- opens a conversation thread;
+- types a message in a composer;
+- Bridge receives the message and starts/continues work;
+- replies/results/status appear in the Web thread;
+- artifacts/results are accessible from the Web UI.
+
+Dashboard/runtime/readiness pages are secondary utilities only.
+
+## Execution rule
+
+Tuzi should report only meaningful milestones, hard failures, verification failures, or owner decisions that truly cannot be made safely. Routine Codex launches and passing checks stay in this ledger.
+
+## Current branch
+
+- Repo/worktree: `/tmp/codex-console-phase2`
+- Branch: `feat/codex-console-phase2`
+- PR: #16 `Codex Console Web owner preview`
+- Latest baseline commit before Web Chat pivot: `892e04a feat: add managed Web preview operations`
+- Ubuntu checks green at baseline; Windows out of scope per owner.
+- Managed preview currently running at `https://codex.guicheng.xyz`.
+
+## Completed before pivot
+
+- App-like owner preview shell, CSS, Home/result/workspace cards.
+- Managed preview start/stop/status/smoke/rotate scripts.
+- Tracked cookie proxy and runbook.
+
+## New phase queue: Web Chat Platform
+
+### Phase A — Web Chat contract and send-path audit
+
+Goal: identify the smallest safe path for Web to act as a chat surface.
+
+Deliverables:
+- Durable doc/ledger update explaining Web Chat as first-class surface.
+- Exact code hook for sending a browser message into Bridge/Core.
+- Exact data model for conversation thread display.
+- Implementation plan split into minimal slices.
+
+### Phase B — Chat UI read surface
+
+Goal: replace/augment dashboard with chat-first layout.
+
+Deliverables:
+- Home/chat route with conversation list + active thread + composer UI.
+- Thread reads existing safe conversation/session data.
+- Composer may be disabled only if send-path implementation is not yet landed, but copy must point to next slice.
+
+### Phase C — Minimal Web message send
+
+Goal: authenticated Web POST can submit a text message to Bridge for selected conversation/project/session.
+
+Deliverables:
+- Backend route/API for message submit.
+- Safe CSRF/session/auth handling through existing owner proxy/bearer path.
+- Starts or continues a bridge turn using existing service abstractions.
+- Tests for success, denial, invalid input, no raw IDs/secrets.
+
+### Phase D — Thread refresh/results
+
+Goal: after sending, Web can observe updated thread/status/result.
+
+Deliverables:
+- Polling or refresh route; no WebSocket required initially.
+- Owner sees queued/running/done/failed/waiting states and final result.
+
+### Phase E — Live preview proof and PR closure
+
+Goal: restart managed preview, smoke public URL, capture proof, update PR, mark ready/merge if acceptable.
+
+## Active processes
+
+None at ledger creation.
+
+## Next action
+
+Launch Phase A Codex high audit/contract run. Then controller triages and launches Phase B/C implementation slices.
+
+## Phase A findings
+
+Completed: 2026-04-26  
+Mode: read-only source audit plus docs/status contract; no source code changed.
+
+### 1. Existing inbound chat turn path
+
+Current Telegram and Feishu ingress share the Telegram-shaped bridge path:
+
+- Telegram polling reads updates and passes each update to the bridge service update handler.
+- Feishu websocket events are translated by the Feishu compatibility poller into Telegram-shaped updates, including text messages, media descriptors, bot-menu events, and card callbacks; those translated updates enter the same bridge service update handler.
+- The bridge service message handler authorizes the private sender, flushes runtime notices, handles pending rename/manual-path/interaction/rich-input states, resolves media, routes slash commands, and treats non-command text as normal work.
+- Normal text uses the active bound session. If the active session is running and steer is available, it calls the app-server steer path to continue the active turn. If an interaction is pending or the session is busy, it blocks with the existing notices. If the session is idle, it starts a real text turn through the turn coordinator.
+- The turn coordinator owns start-turn execution: capacity check, app-server availability, thread creation/reuse, startTurn request construction, session status updates, active-turn tracking, runtime-card reanchoring, and final-answer/runtime handoff.
+
+Implication for Web: do not invent a second Codex start path. The Web send endpoint should adapt browser input into the same `chatId + SessionRow + text` semantics and call a small service-owned submit method that reuses the existing normal-text/turn coordinator behavior.
+
+### 2. State/store/session APIs Web can use for read UI today
+
+Existing read-safe inputs already support a useful conversation thread view:
+
+- Operator binding: chat bindings can be listed and filtered by active platform, giving a single owner `chatId` for the Web view.
+- Sessions/conversations: sessions can be listed by `chatId`, fetched by session id, listed with threads, and read as active session. Session rows include display name, project/workspace metadata, status, archived state, timestamps, thread id, and last turn status.
+- Final answers: persisted final-answer/terminal-result views can be listed by `chatId` and filtered by session. They include answer id, session/thread/turn ids, delivery state, preview HTML/pages, and timestamps. The existing Web read model only renders bodies when a sanitized final-answer body provider supplies safe text.
+- Pending interactions: pending interactions can be listed by chat, request, or turn and are already adapted into Web-safe pending cards.
+- Runtime state: active turns are held by the running service; the current standalone read-only harness does not expose live active-turn data unless injected.
+- Current Web read model: the Web readonly live provider scopes store reads to the single operator binding, hashes raw session/project ids into opaque workspace/conversation handles, lists workspace/conversation rows, and renders conversation detail from sessions, final answers, pending interactions, runtime, readiness, and artifact descriptors.
+
+Gap: there is no persisted chronological user/assistant message table. Today Web can display a conversation/task thread as a session-centric detail page with final answers, pending cards, and runtime state, but not a full chat transcript of every user message unless a new neutral message/turn event projection is added later.
+
+### 3. Smallest safe Web send endpoint design
+
+Recommended first send contract:
+
+- Route: `POST /conversations/:handle/messages`.
+- Inputs: authenticated owner request, opaque `cv_...` conversation handle, plain text field `message`, optional idempotency nonce.
+- Limits: text only, trimmed non-empty, explicit max byte/character limit, no attachments, no project/session creation, no raw ids in request or response.
+- Binding/session resolution: resolve the single operator binding, map the opaque handle back to a session only inside the server, require the session to belong to the bound `chatId`, and reject archived/missing sessions generically.
+- Execution: call a service-owned `submitWebTextMessage(conversationHandle, text, nonce)` or equivalent adapter that reuses the same normal-text semantics as platform messages: continue via steer when allowed, block on pending interaction/busy state, or start a turn through the turn coordinator when idle.
+- Response: redirect back to `/conversations/:handle` for HTML form submissions, or return a tiny JSON outcome for fetch clients. The response should say accepted/blocked/invalid/unavailable in owner language, not expose thread id, turn id, app-server ids, chat ids, local paths, or stack traces.
+- Auth/CSRF: keep the existing owner-only token/cookie proxy posture, but before enabling POST through the cookie proxy add same-origin CSRF protection. Practical first slice: hidden per-session CSRF token rendered into the composer, require it on POST, keep `SameSite=Lax`, reject unsafe origins, and continue generic denial for unauthorized requests.
+- Endpoint placement: do not bolt this onto the standalone DB-only readonly harness as a fake write path. The endpoint must run in the live bridge process or receive a live bridge submit dependency, because only the running service has the app-server client, turn coordinator, active-turn map, runtime reanchoring, and pending-interaction state needed to behave like Telegram/Feishu.
+
+### 4. Primary UI route
+
+Use `/` as the primary chat home. The owner should land directly in a chat/work queue with conversation list, active conversation/result panel, and composer posture. Keep `/conversations/:handle` as the durable thread/detail route because it already uses opaque handles. Add `/chat` only as a convenience alias to `/`, not as the canonical product route. Runtime/readiness/settings remain secondary utility routes.
+
+### 5. Exact files for Phase B and Phase C
+
+Phase B — chat read UI, no writes:
+
+1. `src/service/web-readonly-view-model.ts` — reshape the home/detail view model around chat-first sections and any disabled composer metadata; keep opaque handles and sanitized data boundaries.
+2. `src/web/readonly-renderer.ts` — make `/` render as the chat home, add disabled composer/readiness copy, and keep utility cards secondary.
+3. `src/web/readonly-http-server.ts` — optionally add `/chat` as an alias to `/`; keep `/conversations/:handle` as the thread route.
+4. `src/service/web-readonly-view-model.test.ts` — lock chat-first home/detail view models, no raw ids/paths/tokens, and no action claim before Phase C.
+5. `src/web/readonly-http-server.test.ts` — lock routing, no forms/actions before Phase C unless the composer is visibly disabled, security headers, and generic denial behavior.
+
+Phase C — minimal message send:
+
+1. `src/service.ts` — add a narrow Web submit method on the live bridge service that resolves the active store/session and delegates to existing normal-text/turn coordinator behavior; keep current Telegram/Feishu behavior unchanged.
+2. `src/service/turn-coordinator.ts` only if a tiny reusable return/outcome is needed; otherwise do not touch it.
+3. `src/web/readonly-http-server.ts` or a new small `src/web/chat-http-server.ts` — add `POST /conversations/:handle/messages` with injected `submitTextMessage` dependency. Prefer a new chat server/module if it avoids making the readonly harness pretend to own writes.
+4. `src/web/readonly-renderer.ts` — enable the composer form only when the send capability is injected/ready; otherwise keep it disabled.
+5. `src/web/readonly-access.ts` — extend access checks only if the POST path needs method-aware auth/CSRF helpers.
+6. `scripts/web-owner-cookie-proxy.py` — allow authenticated POST forwarding to the upstream chat endpoint while keeping `/owner-login` special, limiting body size, forwarding content type safely, and preserving no-secret logging.
+7. `src/cli.ts` and `scripts/web-preview-start.sh` only if the preview command must start the live chat-capable server differently from the readonly harness.
+8. Tests beside each touched file: service submit tests, web HTTP POST contract tests, renderer composer tests, access/CSRF tests, and proxy self-test update if POST forwarding changes.
+
+### 6. Tests to write first
+
+Phase B tests first:
+
+1. View-model test: home returns chat-first data (`recentConversations`, pending attention, runtime) with opaque conversation handles and no raw session/chat/thread ids.
+2. HTTP/render test: `GET /` is the chat home and contains conversation links plus disabled composer copy when send is unavailable.
+3. HTTP/render test: `GET /chat` aliases to the same chat home if the alias is added.
+4. Detail test: `GET /conversations/cv_...` renders final answer, pending state, runtime state, and disabled composer posture without raw internals.
+5. Regression test: no form POST/action controls exist until send capability is explicitly enabled.
+
+Phase C tests first:
+
+1. Unauthorized POST and wrong-token POST return generic denial and do not invoke submit dependencies.
+2. Invalid handle, missing/blank/oversize message, archived/mismatched session, and missing CSRF all reject without invoking turn start/steer.
+3. Successful idle-session POST resolves the opaque handle to the bound session and calls the live submit adapter exactly once with `chatId`, session, text, and nonce.
+4. Running-session cases preserve current semantics: steer when available, block when interaction-pending or busy, and do not start a parallel turn incorrectly.
+5. Response safety: accepted/blocked/invalid responses and redirects do not include raw ids, local paths, tokens, stack traces, or app-server payloads.
+6. Proxy self-test: authenticated owner cookie can forward POST to the upstream endpoint with Authorization injected; unauthenticated POST remains denied except `/owner-login`.
+
+### 7. Risks and blockers
+
+- Current Web preview is a standalone DB reader. It can render read state, but it cannot safely start/continue turns by itself because it lacks the live app-server client and turn coordinator.
+- Existing persisted data is session/final-answer oriented, not full chronological chat transcript. A real chat timeline may need a neutral persisted turn/message projection after the minimal send path lands.
+- Opaque conversation handles are currently hash-derived one-way handles. Send needs a server-side reverse lookup through scoped sessions, not client-supplied raw session ids.
+- Active runtime state is in memory in the live bridge service; the standalone preview only sees what is persisted/injected. Live Web Chat should run against the live service boundary for accurate running/blocked behavior.
+- Cookie proxy currently forwards only GET/HEAD to the upstream and treats non-login POST as not found. Phase C must update it before browser form POST works through the owner preview URL.
+- CSRF is not needed for the current bearer-only readonly upstream, but becomes relevant once cookie-authenticated browser POST is allowed.
+- Keep the first action lane text-only. Attachments, approvals, interrupts, project/session writes, downloads, and multi-user auth should remain out of the first send slice.
+
+## Ordered Phase B/C implementation plan
+
+### Phase B — Chat read UI, still no writes
+
+1. Make `/` visibly chat-first: conversation/work queue first, active/attention/result sections next, utilities secondary.
+2. Keep `/conversations/:handle` as the thread/detail page and add a disabled composer panel that clearly says sending is the next slice.
+3. Optionally add `/chat` as an alias to `/`; do not make runtime/readiness the landing flow.
+4. Preserve all current safety properties: opaque handles, sanitized labels/body sources, no raw ids/paths/tokens, no enabled forms/buttons/actions.
+5. Run targeted Web view-model and HTTP renderer tests, then `npm run check`.
+
+### Phase C — Minimal Web message send
+
+1. Write failing tests for the POST contract, auth/CSRF rejection, invalid input, generic errors, and successful dependency invocation.
+2. Add an injected Web submit contract that resolves `cv_...` to the bound session and calls a live service submit method; avoid direct app-server calls from Web HTTP code.
+3. Add `POST /conversations/:handle/messages` with strict text-only parsing, body limits, idempotency/nonce field, generic denial, and safe redirect/JSON outcomes.
+4. Enable the composer only when the send dependency and CSRF token provider are present; otherwise keep Phase B disabled copy.
+5. Update the owner cookie proxy to forward authenticated POSTs to the upstream endpoint with small body limits and no request logging.
+6. Verify with unit tests, proxy self-test, `npm run check`, and a local Ubuntu smoke through the managed preview chain before any PR-ready claim.

--- a/docs/plans/2026-04-26-web-chat-platform-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-chat-platform-pm-ledger.md
@@ -86,11 +86,11 @@ Goal: restart managed preview, smoke public URL, capture proof, update PR, mark 
 
 ## Active processes
 
-None at ledger creation.
+- Phase B implementation: `proc_3a89c065bbf3` launched 2026-04-26 after Phase A contract commit `6cac234`.
 
 ## Next action
 
-Launch Phase A Codex high audit/contract run. Then controller triages and launches Phase B/C implementation slices.
+Monitor Phase B Codex high implementation run. On completion, review diff, run targeted tests plus `npm run check` and `git diff --check`, then commit/push if accepted and launch Phase C send-path tests/implementation.
 
 ## Phase A findings
 

--- a/docs/plans/2026-04-26-web-chat-platform-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-chat-platform-pm-ledger.md
@@ -86,11 +86,11 @@ Goal: restart managed preview, smoke public URL, capture proof, update PR, mark 
 
 ## Active processes
 
-- Phase C implementation: `proc_99f79c93cc14` launched 2026-04-26 after Phase B chat-first read UI commit `0aaa9e3`.
+- Phase D live wiring: completed and accepted 2026-04-27.
 
 ## Next action
 
-Monitor Phase C Codex high implementation run. On completion, review diff, run targeted tests plus `npm run check` and `git diff --check`, then commit/push if accepted and launch Phase D refresh/live-result observation slice.
+Commit/push Phase D live Web Chat wiring, then execute Phase E: enable live managed preview, smoke owner login/home/conversation/composer/POST behavior, verify no raw internals leak, update PR body, and pause this cron when Web Chat is proven usable.
 
 ## Phase A findings
 

--- a/docs/plans/2026-04-26-web-first-phase-1-closeout.md
+++ b/docs/plans/2026-04-26-web-first-phase-1-closeout.md
@@ -1,0 +1,203 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/plans/README.md
+children: []
+summary: phase-1 closeout for the Codex Console Web-first local read-only prototype, including commits, verification, and next-stage task board
+read_when:
+  - resuming Codex Console Web-first implementation after the first local Web prototype
+  - checking what Web code landed, what was verified, and what remains deferred
+  - planning the next Web Console MVP stage
+skip_when:
+  - the task is only about shipped Telegram or Feishu pack behavior
+  - the task needs only current product support truth
+source_of_truth:
+  - docs/plans/2026-04-26-web-first-phase-1-closeout.md
+  - docs/plans/2026-04-26-web-first-pm-ledger.md
+  - docs/roadmap/codex-console-continuation-brief.md
+-->
+
+# Codex Console Web-First Phase 1 Closeout
+
+Status: phase closeout / next-stage tracker  
+Owner: Hermes/Tuzi controller; Codex runs were implementation and review subagents  
+Last updated: 2026-04-26
+
+## Owner Goal Alignment
+
+The product goal remains: **a browser Web端 that can access the owner’s Bridge and Codex state, then later operate Codex safely**.
+
+Phase 1 deliberately landed the safety and read-only substrate first. It is not the final Web Console. It proves that a local, token-gated browser surface can read Bridge state through Web-safe ViewModels without leaking raw platform IDs, local paths, callbacks, terminal output, or action controls.
+
+## What Landed
+
+Phase 1 commits on `feat/codex-console-phase2`:
+
+1. `61d2f10 feat: add Web-first read-only view-model seam`
+2. `0a590f6 feat: add Web artifact descriptor view models`
+3. `93fa360 feat: add Web read-only live provider seam`
+4. `eee1273 feat: add local read-only Web shell module`
+5. `bceff02 feat: add local Web readonly harness`
+6. `6a77f8d feat: populate Web rows from scoped sessions`
+7. `39f31cb feat: add Web readonly platform binding filter`
+
+Implemented source areas:
+
+- `src/service/web-readonly-view-model.ts` and tests: Web-safe read-only DTO/ViewModel layer for home, workspaces, conversations, results, artifacts, runtime, readiness, and pending interactions.
+- `src/service/web-readonly-live-provider.ts` and tests: composition seam that scopes reads through a resolved operator binding.
+- `src/web/readonly-access.ts`: denied-by-default bearer gate.
+- `src/web/readonly-renderer.ts`: escaped, static, read-only HTML renderer.
+- `src/web/readonly-http-server.ts` and tests: dependency-free local HTTP shell with generic 404/500, no-store/CSP/nosniff.
+- `src/web/readonly-cli.ts` and tests: explicit local harness for `web readonly`, token requirement, localhost default, and platform-only binding filter.
+- `src/cli.ts` and tests: CLI path wiring for the explicit local Web prototype command.
+
+## Current Prototype Behavior
+
+Development command shape:
+
+```bash
+CTB_WEB_READONLY_TOKEN=*** node --import tsx src/cli.ts web readonly --platform feishu --port 45679
+```
+
+Installed command intent after build/install:
+
+```bash
+CTB_WEB_READONLY_TOKEN=*** ctb web readonly --platform feishu
+```
+
+Observed controller smoke on current local state:
+
+- Listened on `127.0.0.1` only.
+- Unauthenticated `/` returned generic 404 with no state data.
+- Authenticated `/` returned 200 HTML for `Codex Console Web prototype`.
+- With `--platform feishu`, operator binding became available and `workspace_data_unavailable` disappeared.
+- Security headers included no-store/CSP/nosniff.
+- Smoke server was killed after proof.
+
+## Verification
+
+Latest controller verification before closeout:
+
+```bash
+node --import tsx --test src/web/readonly-cli.test.ts src/service/web-readonly-live-provider.test.ts src/service/web-readonly-view-model.test.ts src/web/readonly-http-server.test.ts
+npm run check
+git diff --check
+```
+
+Result: all passed; Web-focused test subset passed with 35 tests.
+
+Full-suite verification should be run before PR merge or release:
+
+```bash
+npm test
+npm run check
+npm run build
+git diff --check
+```
+
+## Explicit Non-Claims
+
+Do not claim any of these yet:
+
+- Web is shipped, supported, public, mobile-ready, or service-enabled.
+- Web replaces Telegram/Feishu.
+- Browser users can submit Codex tasks, answer approvals, interrupt, upload/download, switch/resume, or access raw terminal/logs.
+- External URL exposure is safe.
+
+## Scratch Artifact Policy
+
+`.hermes/` status files from Codex runs were process scratch. Their durable conclusions are summarized here and in `docs/plans/2026-04-26-web-first-pm-ledger.md`. They should stay out of product commits and can be removed after closeout.
+
+## Next Stage: Web Console MVP
+
+Next stage should move from local substrate toward an owner-reviewable Web Console experience while preserving gates.
+
+### Phase 2A — Owner-Reviewable Read-Only Web Proof
+
+Goal: produce a visual proof artifact the owner can inspect from chat without opening a public URL.
+
+Tasks:
+
+1. Create a deterministic screenshot/recording harness for the local read-only Web prototype.
+2. Capture phone-width and desktop-width proof of:
+   - Web Home;
+   - workspace list;
+   - workspace conversations;
+   - conversation result metadata;
+   - runtime/readiness/degraded states.
+3. Add a small proof runbook under docs or operations if the command sequence becomes non-trivial.
+4. Verify proof contains no raw IDs, tokens, local paths, callback data, terminal/log output, or action controls.
+
+Acceptance:
+
+- Owner can visually judge whether this looks like the intended Web Console direction.
+- No URL exposure is required.
+- No new write/action capability is introduced.
+
+### Phase 2B — Useful Read-Only Data Depth
+
+Goal: make the read-only pages genuinely useful before external exposure.
+
+Candidate tasks:
+
+1. Persist or derive Web-safe final-answer bodies separately from Telegram/Feishu delivery HTML.
+2. Improve conversation detail so completed results are readable without exposing raw delivery artifacts.
+3. Improve runtime/readiness labels for owner comprehension.
+4. Preserve artifact descriptors as handles only; defer preview/download until separate gates.
+
+Acceptance:
+
+- Owner can open a conversation and understand the final result and status.
+- No raw protocol/message/platform payloads leak.
+
+### Phase 2C — Protected Owner URL Gate
+
+Goal: design and implement temporary protected access for owner phone validation.
+
+Prerequisites:
+
+- Phase 2A screenshots/recordings accepted.
+- Read-only pages have useful data depth.
+- Explicit auth/session design is approved.
+
+Non-goals until approved:
+
+- public unauthenticated URL;
+- service autostart as default;
+- multi-user/team access;
+- actions or task submission.
+
+### Phase 2D — Controlled Actions Later
+
+Only after the read-only owner flow is accepted:
+
+1. Submit a simple text task.
+2. Observe lifecycle and final result.
+3. Answer one approval/question class.
+4. Interrupt with clear outcome.
+
+Each action requires CSRF/action protection, audit trail, stale/duplicate/failure handling, and owner-visible recovery state.
+
+## Tracking Board
+
+| Lane | Status | Next artifact | Gate |
+|---|---|---|---|
+| Local read-only substrate | Done | This closeout + commits | Pushed branch / PR-ready |
+| Screenshot/recording proof | Next | Media proof + optional runbook | Owner visual acceptance |
+| Final-answer readable body | Next after proof or parallel | Web-safe body storage/display slice | No raw delivery artifact leak |
+| Protected owner URL | Deferred | access design + reversible exposure plan | Auth/session approved |
+| Controlled Codex actions | Deferred | separate action package | Security/audit gates approved |
+
+## Recovery Commands
+
+```bash
+cd /tmp/codex-console-phase2
+git status --short --branch
+git log --oneline --max-count=8
+npm test
+npm run check
+npm run build
+git diff --check
+```
+
+Use this closeout plus the continuation brief before starting the next implementation run.

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -48,19 +48,23 @@ Routine Codex launches, audits, doc cleanup, and passing intermediate tests shou
 
 ## Current Checkpoint
 
-Committed checkpoint:
+Latest committed Phase 1 Web-first checkpoints:
 
 - `61d2f10 feat: add Web-first read-only view-model seam`
+- `0a590f6 feat: add Web artifact descriptor view models`
+- `93fa360 feat: add Web read-only live provider seam`
+- `eee1273 feat: add local read-only Web shell module`
+- `bceff02 feat: add local Web readonly harness`
+- `6a77f8d feat: populate Web rows from scoped sessions`
+- `39f31cb feat: add Web readonly platform binding filter`
 
-That commit includes:
+These commits include:
 
-- Web/App pre-implementation contract.
-- Web MVP scope/readiness docs.
+- Web/App pre-implementation contract and MVP/readiness docs.
 - VPS/mobile access/security plan.
-- Web read-only prototype implementation plan.
-- Web view-model inventory.
-- Initial read-only Web view-model adapter and tests.
-- Closeout wording updates after Gap2.
+- Web read-only prototype implementation plan and view-model inventory.
+- Read-only Web ViewModel/provider seams with redaction, final-answer metadata, pending interactions, artifacts, runtime, and readiness surfaces.
+- Dependency-free local-only HTTP shell, explicit token-gated CLI harness, scoped session-backed rows, and platform-only binding filter.
 
 Scratch/status artifacts under `.hermes/` are not product artifacts and should stay out of product commits unless intentionally promoted.
 

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -230,9 +230,26 @@ Gated Web actions design completed as a docs-only gate:
 - Required gates now include protected owner access passed first, explicit owner auth/session, single resolved binding/platform, CSRF or equivalent replay protection, action audit log, idempotency/action nonce, confirmation for destructive or interruptive actions, rollback path, opaque server-scoped handles, generic stale/duplicate denial, and kill-switch verification.
 - Still not implemented: no-op action capability display, approval-answer, interrupt, task submit, uploads/downloads, artifact download, raw terminal, arbitrary command execution, public/mobile URL exposure, multi-user semantics, or Web support claim.
 
+## Handoff Checkpoint: Product Web Console MVP
+
+Owner correction: the current Portal is not a user-facing Web product; it is only an owner-visible read-only debug/admin preview. This correction is accepted as the next-phase framing.
+
+Current temporary owner preview is live at `https://codex.guicheng.xyz` through Cloudflare Tunnel, form-login cookie proxy, and local Web readonly origin. It is not a supported/public service. Secrets live under `/tmp/ctb-web-access/` and must not be copied into docs or chat summaries.
+
+Handoff note written to `/tmp/codex-console-handoff-2026-04-26.md`.
+
+Next phase should be Phase 3 Product Web Console MVP:
+
+1. Define real product IA and core flows: home, conversations/tasks, detail, pending, settings.
+2. Replace table-like debug views with a readable mobile-friendly Console shell.
+3. Add safe final-answer body rendering from a Web-neutral source.
+4. Add useful live state: running turn, pending question/approval, readiness/runtime in user language.
+5. Only after read UX works, add the first gated action lane with auth/session, CSRF/replay protection, audit, idempotency, kill-switch, and rollback.
+6. Convert temporary preview into managed owner preview service.
+
 ## Guardrails
 
-Do not claim Web is shipped, supported, enabled, public, or browser-usable yet.
+Do not claim Web is shipped, supported, public, or product-complete. Current browser access is a temporary owner preview only.
 
 Still not implemented for the Web prototype:
 
@@ -281,3 +298,31 @@ The explicit local read-only Web harness now accepts a narrow operator binding f
 This does not expose raw chat/user/message IDs, does not auto-select across platforms, and does not add an operator selector UI, public/mobile exposure, service startup wiring, actions, uploads/downloads, logs/terminal/protocol rendering, or final-answer body rendering.
 
 Controller smoke proof showed `--platform feishu` can make the local authenticated page data-bearing on the current local state without exposing raw IDs: operator binding became available, `workspace_data_unavailable` disappeared, and the instance was shut down after proof.
+
+## Phase 3 Current State: Product Web Console MVP
+
+Phase 3 has started as a docs/planning landing, not runtime implementation.
+
+Durable MVP spec:
+
+- `docs/plans/2026-04-26-product-web-console-mvp.md`
+
+Current accepted scope:
+
+- Web-first, App-later.
+- Current browser preview remains an owner-visible temporary read-only debug/admin preview, not a user-facing Web product.
+- First lane remains single-operator, owner/private, denied-by-default, and read-mostly.
+- Phase 3 product direction is a real Web Console information architecture: Home, Workspaces/Projects, Conversations/Tasks, Conversation/Task Detail, Pending/Approvals, and Runtime/Readiness/Settings.
+- The MVP must make conversation/task status and final results readable from phone/desktop without raw IDs, paths, tokens, platform internals, Telegram-shaped copy, or table-only debug pages.
+- Final-answer body rendering may use only sanitized Web-neutral sources. If none exists, the UI must show an explicit unavailable/degraded state and must not scrape Telegram/Feishu/debug HTML.
+- Action controls remain deferred. The later action lane must be separately gated, with approval/question answer or submit draft chosen explicitly after the read UX is useful.
+
+Next implementation slices, in order:
+
+1. Build the first real Console shell and readable conversation/task detail UI using existing safe read-only data; this is the immediate next code slice and should not drift back into substrate-only work.
+2. Refine final-answer body rendering from sanitized Web-neutral sources, with explicit unavailable/degraded copy when absent.
+3. Add conversation/task list grouping and user-language states for running, blocked, pending question, pending approval, done, failed, degraded, and unavailable.
+4. Add a Pending/Approvals read-only page or section, with no active action controls.
+5. Add Runtime/Readiness/Settings read page in safe owner language.
+6. Produce owner-reviewable screenshot/HTML proof after readable UI lands.
+7. Decide the first gated action lane only after the read UX and proof pass.

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -142,11 +142,23 @@ Verification after the local shell:
 - `npm run check` passed.
 - `git diff --check` passed.
 
+## Local Harness Smoke Proof
+
+The explicit local harness was smoke-tested by the controller:
+
+- Command shape: `CTB_WEB_READONLY_TOKEN=<token> node --import tsx src/cli.ts web readonly --port 0`
+- Listener observed on `127.0.0.1:<ephemeral-port>`.
+- Unauthenticated `/` returned generic 404 with no state data.
+- Authenticated `/` returned escaped read-only HTML for `Codex Console Web prototype` with no-store/CSP/nosniff headers.
+- The smoke instance was killed after proof.
+
+This is an owner-visible local proof path, but still not public, not mobile-exposed, not installed into service startup, and not a Web support claim.
+
 ## Next Gates
 
-1. Checkpoint the module-only local read-only HTTP shell plus this PM ledger.
-2. Continue toward an owner-visible Web milestone only through explicit protected/local gates.
-3. Next possible coding lanes may include CLI-local harness wiring guarded by disabled-by-default token config, screenshot harness for controller-owned proof, persisted neutral final-answer bodies, or readiness model refinement; do not add publicly reachable routes, owner/mobile URL exposure, action controls, uploads/downloads, or support claims without an explicit controller gate.
+1. Checkpoint the explicit local harness plus this PM ledger.
+2. Prepare a controller-owned screenshot/proof artifact from the local harness when needed.
+3. Next possible coding lanes may include safer visible data population for the local harness, persisted neutral final-answer bodies, readiness model refinement, or protected owner-review exposure planning; do not add publicly reachable routes, owner/mobile URL exposure, action controls, uploads/downloads, or support claims without an explicit controller gate.
 
 ## Guardrails
 
@@ -168,3 +180,20 @@ Still not implemented beyond the unintegrated module-only local shell:
 - Multi-user/team features.
 - Native App.
 
+
+## Explicit Local Read-only Harness
+
+A first explicitly invoked local-only CLI harness completed cleanly:
+
+- Status artifact: `.hermes/web-local-harness-status.md`
+- Result: `ctb web readonly` starts the existing dependency-free read-only shell with the live provider seam only when an explicit bearer token is supplied by `CTB_WEB_READONLY_TOKEN` or `--token`.
+
+The harness remains disabled by default and is not integrated into normal service startup/install/systemd. It binds to `127.0.0.1` by default, rejects CLI host binding, prints only the localhost URL plus prototype/token warning, and never prints the token.
+
+Verification after the local harness:
+
+- `node --import tsx --test src/web/readonly-cli.test.ts src/cli.test.ts src/web/readonly-http-server.test.ts src/service/web-readonly-live-provider.test.ts src/service/web-readonly-view-model.test.ts` passed with 29 tests.
+- `npm run check` passed.
+- `git diff --check` passed.
+
+Still not implemented: public/mobile URL exposure, reverse proxy/tunnel/HTTPS/DNS, service autostart, browser support claim, action controls, writes, uploads/downloads, previews, raw logs/terminal/protocol rendering, or Web support status.

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -395,3 +395,16 @@ Verification passed:
 - `node --import tsx --test src/web/readonly-http-server.test.ts src/web/readonly-cli.test.ts src/service/web-readonly-live-provider.test.ts src/service/web-readonly-view-model.test.ts`
 - `npm run check`
 - `git diff --check`
+
+## Phase 3 Pending/Approvals Read-only Slice
+
+Completed on 2026-04-26 as Product Web Console MVP code slice 4.
+
+Result:
+
+- Pending/Approvals now renders owner-readable read-only cards grouped by attention, resolved/duplicate, stale/expired, and unavailable/failed states.
+- Pending cards use user-language labels/copy for question, approval, resolved, expired, stale, duplicate, failed, and unavailable-like states, with explicit response-disabled posture.
+- Conversation/task detail reuses the same pending card rendering for its pending panel.
+- No action controls, forms, POST method hints, submit/approval/question/interrupt URLs, callback payloads, raw pending IDs, platform message IDs, tokens, or local paths were added.
+
+TDD/verification evidence is recorded in `.hermes/phase3-pending-approvals-status.md`.

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -26,12 +26,15 @@ Last updated: 2026-04-26
 
 ## Mission
 
-Push Codex Console toward a real Web-first control surface without drifting into fake support claims.
+Push Codex Console toward a real Web-first personal control surface without drifting into fake support claims.
+
+**Owner direction, reinforced 2026-04-26:** this is a personal project. The Web UI should feel like an app the owner can actually use, not a security/readiness/admin dashboard. Future agents should prioritize product workflows — dashboard, continue-working list, workspace/conversation/task browsing, readable results, and attention cards — while keeping only right-sized safety guardrails in the background.
 
 Web-first means:
 
 - Web before native App.
 - First lane is single-operator, non-public, read-mostly/prototype-only.
+- Security/readiness/access posture is secondary utility context, not the main product surface.
 - Web should be workspace/session/conversation/result centered, not a fake Telegram/Feishu chat shell.
 - Shared Codex Bridge Core semantics must remain the source of product meaning.
 

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -168,6 +168,51 @@ This is an owner-visible local proof path, but still not public, not mobile-expo
 6. Controller smoke proof: `CTB_WEB_READONLY_TOKEN=*** node --import tsx src/cli.ts web readonly --platform feishu --port 45679` listened on `127.0.0.1`, authenticated `/` returned 200 with operator binding available and no `workspace_data_unavailable`; smoke instance was killed.
 7. Later lanes may include persisted neutral final-answer bodies, readiness model refinement, screenshot/proof artifacts, or protected owner-review exposure planning; do not add publicly reachable routes, owner/mobile URL exposure, action controls, uploads/downloads, or support claims without an explicit controller gate.
 
+## Phase 2 Web Console MVP Todo
+
+Controller direction: move from local read-only substrate to an owner-visible Web Console MVP while preserving denied-by-default, read-only-first guardrails.
+
+Active todo list:
+
+1. PR #16 review/merge path: keep the Draft PR tracked, keep Ubuntu-pass/Windows-baseline context documented, and do not let existing Windows baseline failures block Web-specific progress unless a new Web regression appears.
+2. Owner-visible proof artifact: run the local token-gated Web prototype with `--platform feishu`, capture a safe screenshot/recording or HTML proof that can be reviewed without exposing token, raw IDs, local paths, terminal logs, or platform internals.
+3. More useful read-only dashboard: add safe conversation detail, sanitized final-answer body where a safe source exists, runtime/readiness panels, and pending-interaction read-only visibility.
+4. Protected owner access plan: design the narrow path from localhost-only to owner phone/browser preview, including auth/session, binding, threat model, and rollback; no public/mobile exposure until this gate is explicit.
+5. Gated actions design: separately design submit/approval/interrupt with audit and scope controls; do not implement actions in the read-only MVP lane.
+
+Phase 2B investigation completed:
+
+- Process: `proc_a1293acfebc9` exited 0.
+- Monitor: `f9c6382df17c` paused.
+- Prompt: `/tmp/codex-web-dashboard-data-investigation.md`
+- Report: `/tmp/codex-web-dashboard-data-investigation-report.md`
+- Accepted controller direction: implement a safe conversation detail slice with Web-only opaque `cv_...` handles and same-origin links; keep final-answer body unavailable unless supplied through the existing sanitizer seam; keep runtime degraded in the local harness unless a live runtime reader is injected; no public exposure or actions.
+
+Phase 2B implementation completed and controller-verified:
+
+- Process: `proc_3ff3c8824320` exited 0.
+- Monitor: `e7de34953605` paused.
+- Status: `.hermes/web-conversation-detail-status.md`
+- Result: Web rows now expose `cv_...` opaque conversation handles; local HTTP shell supports token-gated `GET /conversations/:handle`; renderer links use only same-origin opaque handles; raw `/sessions/:id` routes are not linked and unsafe route parts return generic 404.
+- Controller verification passed:
+  - `node --import tsx --test src/service/web-readonly-view-model.test.ts src/service/web-readonly-live-provider.test.ts src/web/readonly-http-server.test.ts src/web/readonly-cli.test.ts` passed with 38 tests.
+  - `npm run check` passed.
+  - `git diff --check` passed.
+- Controller smoke proof on current local state passed with command shape `CTB_WEB_READONLY_TOKEN=*** node --import tsx src/cli.ts web readonly --platform feishu --port 45681`: authenticated home returned 200 with `cv_...` conversation links, no `/sessions/` links, no token leak; authenticated first `/conversations/:handle` returned 200, no `/sessions/` links and no token leak; smoke server was killed and token file removed.
+
+Current first execution item: owner-visible proof artifact, because it most directly validates the user's original goal: a Web end that can access Bridge/Codex state in a browser.
+
+Owner-visible proof artifact completed by controller:
+
+- Started local prototype with command shape `CTB_WEB_READONLY_TOKEN=*** node --import tsx src/cli.ts web readonly --platform feishu --port 45680`.
+- Authenticated `/` returned 200 and contained `Codex Console Web prototype` with operator binding available, readiness ready, workspace rows, and recent conversation rows.
+- Raw proof HTML was sanitized for owner review: workspace labels and conversation text were redacted.
+- Sanitized artifacts:
+  - `/tmp/ctb-web-proof-safe.html`
+  - `/tmp/codex-console-web-proof-safe.png`
+- Vision verification confirmed the sanitized screenshot shows title/workspace/recent-conversation tables and does not show bearer token, raw paths, raw IDs, or conversation text.
+- The local server was killed after proof and the temporary token file was removed.
+
 ## Guardrails
 
 Do not claim Web is shipped, supported, enabled, public, or browser-usable yet.

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -110,11 +110,27 @@ Controller verification after Gap3:
 - `npm run check` passed.
 - `node --import tsx --test src/service/web-readonly-view-model.test.ts` passed with 11 tests.
 
+## Live Provider Seam
+
+A follow-up live provider composition seam completed cleanly and was controller-verified:
+
+- Process: `proc_2c4cb3d1ca51`
+- Status artifact: `.hermes/web-live-provider-status.md`
+- Result: `createWebReadonlyLiveProvider(deps)` resolves one operator binding internally and feeds safe scoped readers into the pure Web view-model provider.
+
+The seam keeps chat IDs/platform details inside the adapter boundary and does not add routes, UI, server, auth middleware, URLs, screenshots, action controls, writes, downloads, uploads, or runtime service wiring.
+
+Controller verification after the live provider seam:
+
+- `node --import tsx --test src/service/web-readonly-live-provider.test.ts src/service/web-readonly-view-model.test.ts` passed with 16 tests.
+- `npm run check` passed.
+- `git diff --check` passed.
+
 ## Next Gates
 
-1. Checkpoint Gap3 code plus this PM ledger.
-2. Continue with narrow read-only groundwork only until an owner-visible Web shell milestone is intentionally started.
-3. Next possible coding lanes may include persisted neutral final-answer bodies, readiness model refinement, or minimal denied/login shell planning; do not add routes/UI/auth/action controls without an explicit controller gate.
+1. Checkpoint the live provider seam plus this PM ledger.
+2. Continue with narrow groundwork only until an owner-visible Web shell milestone is intentionally started.
+3. Next possible coding lanes may include minimal denied-by-default local shell planning/implementation, persisted neutral final-answer bodies, or readiness model refinement; do not add publicly reachable routes, owner URL, action controls, uploads/downloads, or support claims without an explicit controller gate.
 
 ## Guardrails
 

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -126,22 +126,39 @@ Controller verification after the live provider seam:
 - `npm run check` passed.
 - `git diff --check` passed.
 
+
+## Local Read-only HTTP Shell
+
+A first minimal local-only Web shell module completed cleanly:
+
+- Status artifact: `.hermes/web-readonly-shell-status.md`
+- Result: dependency-free Node HTTP server factory with injected Web read-only provider, denied-by-default bearer access gate, escaped read-only HTML renderer, and generic denied/error responses.
+
+The shell remains module-only and unintegrated from CLI/service startup. It does not add public URLs, owner/mobile URL exposure, reverse proxy, HTTPS/DNS/tunnel setup, cookies/session login, actions, writes, uploads/downloads, previews, logs, raw terminal, or app-server protocol payload rendering.
+
+Verification after the local shell:
+
+- `node --import tsx --test src/web/readonly-http-server.test.ts src/service/web-readonly-live-provider.test.ts src/service/web-readonly-view-model.test.ts` passed with 22 tests.
+- `npm run check` passed.
+- `git diff --check` passed.
+
 ## Next Gates
 
-1. Checkpoint the live provider seam plus this PM ledger.
-2. Continue with narrow groundwork only until an owner-visible Web shell milestone is intentionally started.
-3. Next possible coding lanes may include minimal denied-by-default local shell planning/implementation, persisted neutral final-answer bodies, or readiness model refinement; do not add publicly reachable routes, owner URL, action controls, uploads/downloads, or support claims without an explicit controller gate.
+1. Checkpoint the module-only local read-only HTTP shell plus this PM ledger.
+2. Continue toward an owner-visible Web milestone only through explicit protected/local gates.
+3. Next possible coding lanes may include CLI-local harness wiring guarded by disabled-by-default token config, screenshot harness for controller-owned proof, persisted neutral final-answer bodies, or readiness model refinement; do not add publicly reachable routes, owner/mobile URL exposure, action controls, uploads/downloads, or support claims without an explicit controller gate.
 
 ## Guardrails
 
 Do not claim Web is shipped, supported, enabled, public, or browser-usable yet.
 
-Still not implemented:
+Still not implemented beyond the unintegrated module-only local shell:
 
-- Web routes.
-- UI/pages/components.
-- Auth/session binding.
-- Server or protected URL.
+- CLI/service startup wiring for Web.
+- Public or owner/mobile URL exposure.
+- Browser support claim.
+- Cookie/session login flow.
+- Auth/session binding beyond the injected bearer gate.
 - Screenshot harness/mobile evidence.
 - Task submission.
 - Approval/question answering.

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -14,7 +14,7 @@ skip_when:
 source_of_truth:
   - docs/plans/2026-04-26-web-first-pm-ledger.md
   - docs/roadmap/codex-console-continuation-brief.md
-  - docs/plans/2026-04-26-web-viewmodel-inventory.md
+  - docs/plans/2026-04-26-product-web-console-mvp.md
   - docs/plans/2026-04-26-web-gated-actions-design.md
 -->
 
@@ -301,7 +301,7 @@ Controller smoke proof showed `--platform feishu` can make the local authenticat
 
 ## Phase 3 Current State: Product Web Console MVP
 
-Phase 3 has started as a docs/planning landing, not runtime implementation.
+Phase 3 has landed the first product-shaped read-only Web Console MVP slices on PR #16 through `d66ff3d`.
 
 Durable MVP spec:
 
@@ -408,3 +408,39 @@ Result:
 - No action controls, forms, POST method hints, submit/approval/question/interrupt URLs, callback payloads, raw pending IDs, platform message IDs, tokens, or local paths were added.
 
 TDD/verification evidence is recorded in `.hermes/phase3-pending-approvals-status.md`.
+
+Verification passed:
+
+- `node --import tsx --test src/web/readonly-http-server.test.ts src/service/web-readonly-view-model.test.ts`
+- `node --import tsx --test src/web/readonly-http-server.test.ts src/web/readonly-cli.test.ts src/service/web-readonly-live-provider.test.ts src/service/web-readonly-view-model.test.ts`
+- `npm run check`
+- `git diff --check`
+
+## Session Closeout: Phase 3 Read-only MVP Slices
+
+Closeout state on 2026-04-26:
+
+- Latest pushed PR #16 commit: `d66ff3d feat: add Web pending approvals read view`.
+- Hermes cron monitors for this workstream: none enabled after closeout checks.
+- GitHub checks at closeout: latest Ubuntu jobs were running/passing in the expected pattern; Windows jobs remain the documented baseline risk unless a new Web-specific failure appears.
+- Temporary owner preview was restarted on the latest branch and verified through `https://codex.guicheng.xyz/owner-login` with cookie proxy and localhost Web origin.
+- Public owner preview verification passed: login page 200, authenticated Home 200, authenticated conversation detail 200, shared Console shell/nav present, result panel present, and no bearer token, `/sessions/`, local path, callback payload label, or message-id label in captured HTML.
+- Scratch `.hermes/` status artifacts remain uncommitted intentionally.
+
+Archived/demoted during closeout:
+
+- Phase 2 plan and release note.
+- Web-first project command board.
+- Web MVP controller triage.
+- Web view-model inventory.
+- Web read-only prototype implementation plan.
+- Web-first Phase 1 closeout.
+
+Next recommended queue:
+
+1. Finish PR #16 checks/merge path, treating Windows failures as baseline only if they match prior non-Web failures.
+2. Implement Runtime/Readiness/Settings read-only page in safe owner language.
+3. Produce owner-reviewable screenshot/HTML proof from the protected preview.
+4. Harden managed owner preview start/stop/rotate workflow; do not make Web default service startup.
+5. Run independent overclaim/security review before any MVP-support wording.
+6. Decide first gated action lane only after read UX + protected access gates pass.

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -354,3 +354,24 @@ Controller smoke proof after the code slice:
 - Authenticated `/` returned 200, included the shared Console shell/nav, and did not contain the temporary bearer token, raw `/sessions/` links, local absolute paths, callback payload labels, or message-id labels.
 - Authenticated first `/conversations/:handle` returned 200, included the result panel, and passed the same leak checks.
 - Smoke HTML files were deleted and the local harness process was killed after proof.
+
+## Phase 3 Final Answer Body Source Refinement
+
+Completed on 2026-04-26 as Product Web Console MVP code slice 2.
+
+Result:
+
+- Conversation/task detail continues to render only existing sanitized Web-neutral final-answer body data from the optional sanitizer seam.
+- Available final-answer text is rendered as escaped readable result body content.
+- Missing body sources keep explicit unavailable copy; rejected bodies now show explicit Web safety-filter unavailable copy.
+- Injected bodies containing local paths or tokenized URLs are rejected instead of being redacted into visible body text.
+- `previewHtml` and `pages` remain forbidden as body sources; no platform preview/page scraping, routes, actions, downloads, uploads, raw terminal/protocol output, or auth/service wiring were added.
+
+TDD/verification evidence is recorded in `.hermes/phase3-final-answer-body-status.md`.
+
+Verification passed:
+
+- `node --import tsx --test src/service/web-readonly-view-model.test.ts src/web/readonly-http-server.test.ts`
+- `node --import tsx --test src/web/readonly-http-server.test.ts src/web/readonly-cli.test.ts src/service/web-readonly-live-provider.test.ts src/service/web-readonly-view-model.test.ts`
+- `npm run check`
+- `git diff --check`

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -444,3 +444,23 @@ Next recommended queue:
 4. Harden managed owner preview start/stop/rotate workflow; do not make Web default service startup.
 5. Run independent overclaim/security review before any MVP-support wording.
 6. Decide first gated action lane only after read UX + protected access gates pass.
+
+## Phase 3 Runtime / Readiness / Settings Read-only Slice
+
+Completed on 2026-04-26 as Product Web Console MVP code slice 5 after the Product Web Console phase closeout baseline.
+
+Result:
+
+- Runtime now presents owner-language product panels for current operating state, active conversation/task turns, degraded/unavailable guidance, and Settings / access posture.
+- Readiness now presents a baseline capability/readiness matrix with owner-language observed-state labels, setup/access posture, setup-needed gaps, and explicit support-claim guardrail copy.
+- The slice stayed read-only: no forms, POST routes, submit/approval/question/answer/interrupt controls, uploads/downloads, raw terminal/log views, route changes, auth/proxy/service startup changes, or action affordances were added.
+- Renderer scrubbing now also hides `/sessions/...` fragments and session-like labels in rendered text/warnings.
+
+TDD/verification evidence is recorded in `.hermes/phase3-runtime-readiness-settings-status.md`.
+
+Verification passed:
+
+- `node --import tsx --test src/web/readonly-http-server.test.ts src/service/web-readonly-view-model.test.ts`
+- `node --import tsx --test src/web/readonly-http-server.test.ts src/web/readonly-cli.test.ts src/service/web-readonly-live-provider.test.ts src/service/web-readonly-view-model.test.ts`
+- `npm run check`
+- `git diff --check`

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -177,7 +177,7 @@ Active todo list:
 1. PR #16 review/merge path: keep the Draft PR tracked, keep Ubuntu-pass/Windows-baseline context documented, and do not let existing Windows baseline failures block Web-specific progress unless a new Web regression appears.
 2. Owner-visible proof artifact: run the local token-gated Web prototype with `--platform feishu`, capture a safe screenshot/recording or HTML proof that can be reviewed without exposing token, raw IDs, local paths, terminal logs, or platform internals.
 3. More useful read-only dashboard: add safe conversation detail, sanitized final-answer body where a safe source exists, runtime/readiness panels, and pending-interaction read-only visibility.
-4. Protected owner access plan: design the narrow path from localhost-only to owner phone/browser preview, including auth/session, binding, threat model, and rollback; no public/mobile exposure until this gate is explicit.
+4. Protected owner access plan: completed as a docs-only design gate; use the protected owner access plan before any owner phone/browser URL exposure. No public/mobile exposure is implemented.
 5. Gated actions design: separately design submit/approval/interrupt with audit and scope controls; do not implement actions in the read-only MVP lane.
 
 Phase 2B investigation completed:
@@ -212,6 +212,14 @@ Owner-visible proof artifact completed by controller:
   - `/tmp/codex-console-web-proof-safe.png`
 - Vision verification confirmed the sanitized screenshot shows title/workspace/recent-conversation tables and does not show bearer token, raw paths, raw IDs, or conversation text.
 - The local server was killed after proof and the temporary token file was removed.
+
+Protected owner access design completed as a docs-only gate:
+
+- Status artifact: `.hermes/protected-owner-access-status.md`
+- Durable artifact: `docs/plans/2026-04-26-web-protected-owner-access-plan.md`
+- Result: owner-only protected access is specified as a future preview path, not shipped support. The recommended first path is a WireGuard/Tailscale/VPN-style private network plus app-level auth/session gates, with SSH forwarding kept for controller-only proof and public reverse proxy/tunnel paths deferred or fallback-only.
+- Required gates now include short-lived non-URL secrets, localhost default, explicit enable flag/env, platform binding filter, audit trail, rate/lockout or ingress allowlist, rollback/shutdown drill, and acceptance proof before any real protected URL.
+- Still not implemented: public URL, owner/mobile URL, reverse proxy, tunnel, VPN wrapper, HTTPS/DNS, service auto-start, browser session login, actions, uploads/downloads, raw terminal/logs, or support claim.
 
 ## Guardrails
 

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -1,0 +1,137 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/plans/README.md
+children: []
+summary: PM-owned live ledger for Codex Console Web-first execution state, corrections, and next gates
+read_when:
+  - resuming Codex Console Web-first execution
+  - checking current PM/controller state after delegated Codex work
+  - deciding whether to report to the owner or continue silently
+skip_when:
+  - the task is only about shipped Telegram or Feishu behavior
+  - the task needs historical reconstruction older than this Web-first lane
+source_of_truth:
+  - docs/plans/2026-04-26-web-first-pm-ledger.md
+  - docs/roadmap/codex-console-continuation-brief.md
+  - docs/plans/2026-04-26-web-viewmodel-inventory.md
+-->
+
+# Codex Console Web-First PM Ledger
+
+Status: active PM/controller ledger  
+Owner: Hermes/Tuzi as project PM; Codex runs are implementation/review subagents  
+Last updated: 2026-04-26
+
+## Mission
+
+Push Codex Console toward a real Web-first control surface without drifting into fake support claims.
+
+Web-first means:
+
+- Web before native App.
+- First lane is single-operator, non-public, read-mostly/prototype-only.
+- Web should be workspace/session/conversation/result centered, not a fake Telegram/Feishu chat shell.
+- Shared Codex Bridge Core semantics must remain the source of product meaning.
+
+## Owner Reporting Rule
+
+Do not interrupt the owner with every sub-step.
+
+Report only when one of these happens:
+
+1. Web actually lands as a usable milestone, such as a real protected page/shell or owner-reviewable screenshot/URL gate.
+2. A clear crash/blocker happens, such as failing verification, broken build, lost worktree, or Codex/provider failure that changes the plan.
+3. Direction/scope mismatch appears, such as Web support overclaim, action controls entering too early, auth/security disagreement, or need for owner decision.
+
+Routine Codex launches, audits, doc cleanup, and passing intermediate tests should stay in this ledger and controller notes, not chat spam.
+
+## Current Checkpoint
+
+Committed checkpoint:
+
+- `61d2f10 feat: add Web-first read-only view-model seam`
+
+That commit includes:
+
+- Web/App pre-implementation contract.
+- Web MVP scope/readiness docs.
+- VPS/mobile access/security plan.
+- Web read-only prototype implementation plan.
+- Web view-model inventory.
+- Initial read-only Web view-model adapter and tests.
+- Closeout wording updates after Gap2.
+
+Scratch/status artifacts under `.hermes/` are not product artifacts and should stay out of product commits unless intentionally promoted.
+
+## Implemented Surface So Far
+
+Implemented code is limited to:
+
+- `src/service/web-readonly-view-model.ts`
+- `src/service/web-readonly-view-model.test.ts`
+
+Current read-only adapter capabilities:
+
+- Web home summary.
+- Workspace list.
+- Workspace conversation list.
+- Conversation result / final-answer availability.
+- Runtime context.
+- Pending interactions read model.
+- Readiness guardrails.
+
+Completed gaps:
+
+- Gap1: safe injected final-answer body exposure and workspace opaque labels/path redaction.
+- Gap2: pending-interactions read model with unavailable/degraded handling and redaction.
+
+Current verified baseline before Gap3:
+
+- `git diff --check` passed.
+- `npm run check` passed.
+- `node --import tsx --test src/service/web-readonly-view-model.test.ts` passed with 9 tests.
+
+## Active Work
+
+Gap3 completed cleanly and was controller-verified:
+
+- Process: `proc_1bae009f0f5a`
+- Status artifact: `.hermes/web-viewmodel-gap3-status.md`
+- Result: neutral read-only artifact catalog/descriptors added to the Web view-model seam.
+
+Gap3 kept descriptor-only scope:
+
+- no downloads, previews, file reads, routes, UI, auth, server, actions, uploads, raw paths, URLs, platform IDs, raw terminal, or raw protocol payloads.
+
+Controller verification after Gap3:
+
+- `git diff --check` passed.
+- `npm run check` passed.
+- `node --import tsx --test src/service/web-readonly-view-model.test.ts` passed with 11 tests.
+
+## Next Gates
+
+1. Checkpoint Gap3 code plus this PM ledger.
+2. Continue with narrow read-only groundwork only until an owner-visible Web shell milestone is intentionally started.
+3. Next possible coding lanes may include persisted neutral final-answer bodies, readiness model refinement, or minimal denied/login shell planning; do not add routes/UI/auth/action controls without an explicit controller gate.
+
+## Guardrails
+
+Do not claim Web is shipped, supported, enabled, public, or browser-usable yet.
+
+Still not implemented:
+
+- Web routes.
+- UI/pages/components.
+- Auth/session binding.
+- Server or protected URL.
+- Screenshot harness/mobile evidence.
+- Task submission.
+- Approval/question answering.
+- Interrupt.
+- Uploads/downloads.
+- Switch/resume controls.
+- Multi-user/team features.
+- Native App.
+

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -160,7 +160,9 @@ This is an owner-visible local proof path, but still not public, not mobile-expo
 2. Read-only data-population investigation completed: `proc_6e331d9a80a3`, monitor `78fe54afe14e` paused, report `/tmp/codex-web-data-population-investigation.md`. Decision: next safest slice is scoped session-backed workspace/home rows, not final-answer bodies or public exposure.
 3. Scoped session-backed rows implementation completed: `proc_ae673303a7c8`, monitor `a3767f8b9cf0` paused, status `.hermes/web-scoped-session-rows-status.md`. Controller verification passed with 29 Web tests, `npm run check`, and `git diff --check`.
 4. Prepare a controller-owned screenshot/proof artifact from the local harness when needed.
-5. Later lanes may include persisted neutral final-answer bodies, readiness model refinement, safe operator-binding UX, or protected owner-review exposure planning; do not add publicly reachable routes, owner/mobile URL exposure, action controls, uploads/downloads, or support claims without an explicit controller gate.
+5. Platform binding filter implementation completed: `proc_652eabc7a7ee`, monitor `cfb49e7e5205` paused, status `.hermes/web-platform-binding-filter-status.md`. Controller verification passed with 35 Web tests, `npm run check`, and `git diff --check`.
+6. Controller smoke proof: `CTB_WEB_READONLY_TOKEN=*** node --import tsx src/cli.ts web readonly --platform feishu --port 45679` listened on `127.0.0.1`, authenticated `/` returned 200 with operator binding available and no `workspace_data_unavailable`; smoke instance was killed.
+7. Later lanes may include persisted neutral final-answer bodies, readiness model refinement, screenshot/proof artifacts, or protected owner-review exposure planning; do not add publicly reachable routes, owner/mobile URL exposure, action controls, uploads/downloads, or support claims without an explicit controller gate.
 
 ## Guardrails
 
@@ -205,3 +207,11 @@ Still not implemented: public/mobile URL exposure, reverse proxy/tunnel/HTTPS/DN
 The local read-only Web harness now has a narrower safe data-population path: when exactly one operator binding resolves, workspace/home rows can be derived from that binding's scoped, non-archived sessions. The live Web provider no longer forwards global recent-project or project-stat readers into the Web view-model path, so unscoped project fixtures cannot populate Web workspace rows.
 
 This remains local read-only prototype plumbing only. It does not add final-answer body rendering, public/mobile exposure, auth redesign, operator selection, screenshot flow, or action controls.
+
+## Platform Binding Filter Checkpoint
+
+The explicit local read-only Web harness now accepts a narrow operator binding filter by platform only: `CTB_WEB_READONLY_PLATFORM=telegram|feishu` or local `--platform telegram|feishu`. Invalid platform values fail before the server starts. With no platform filter, the previous safe default remains: all bindings are considered and the live provider only scopes data when exactly one binding resolves.
+
+This does not expose raw chat/user/message IDs, does not auto-select across platforms, and does not add an operator selector UI, public/mobile exposure, service startup wiring, actions, uploads/downloads, logs/terminal/protocol rendering, or final-answer body rendering.
+
+Controller smoke proof showed `--platform feishu` can make the local authenticated page data-bearing on the current local state without exposing raw IDs: operator binding became available, `workspace_data_unavailable` disappeared, and the instance was shut down after proof.

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -375,3 +375,23 @@ Verification passed:
 - `node --import tsx --test src/web/readonly-http-server.test.ts src/web/readonly-cli.test.ts src/service/web-readonly-live-provider.test.ts src/service/web-readonly-view-model.test.ts`
 - `npm run check`
 - `git diff --check`
+
+## Phase 3 Conversation/Task State Grouping
+
+Completed on 2026-04-26 as Product Web Console MVP code slice 3.
+
+Result:
+
+- Home recent conversations and workspace conversation/task lists now group rows into owner-visible buckets: Needs attention, Running now, Recently completed, and Other/Older when row state supports it.
+- Conversation/task cards render user-language state labels and short copy for running, pending question, pending approval, blocked, done/completed, failed, degraded, and unavailable/unknown states.
+- Conversation/task detail status now uses the same user-language label/copy rather than raw row status text.
+- Opaque links, escaping/scrubbing, read-only posture, and forbidden action/control constraints were preserved; no routes, auth, proxy, service wiring, schema, stores, or action endpoints were changed.
+
+TDD/verification evidence is recorded in `.hermes/phase3-conversation-state-status.md`.
+
+Verification passed:
+
+- `node --import tsx --test src/web/readonly-http-server.test.ts src/service/web-readonly-view-model.test.ts`
+- `node --import tsx --test src/web/readonly-http-server.test.ts src/web/readonly-cli.test.ts src/service/web-readonly-live-provider.test.ts src/service/web-readonly-view-model.test.ts`
+- `npm run check`
+- `git diff --check`

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -326,3 +326,31 @@ Next implementation slices, in order:
 5. Add Runtime/Readiness/Settings read page in safe owner language.
 6. Produce owner-reviewable screenshot/HTML proof after readable UI lands.
 7. Decide the first gated action lane only after the read UX and proof pass.
+
+## Phase 3 Console Shell Code Slice 1
+
+Completed on 2026-04-26 as the first Product Web Console MVP implementation slice after `f2f6050`.
+
+Result:
+
+- Replaced the read-only renderer's table-first debug feel with a shared `Codex Console` owner-preview/read-only shell.
+- Home now uses orientation cards plus workspace, recent conversation/task, and active-turn card lists.
+- Conversation/task detail now separates status, final answer/result, pending interactions, runtime, readiness, and warnings.
+- Missing Web-safe final-answer bodies now render explicit unavailable copy instead of an empty table.
+- Existing token-gated HTTP routes, opaque `wk_...` / `cv_...` links, escaping/scrubbing, generic unauthenticated 404 denial, and security headers were preserved.
+
+TDD/verification evidence is recorded in `.hermes/phase3-console-shell-status.md`.
+
+Verification passed:
+
+- `node --import tsx --test src/web/readonly-http-server.test.ts src/web/readonly-cli.test.ts src/service/web-readonly-live-provider.test.ts src/service/web-readonly-view-model.test.ts`
+- `npm run check`
+- `git diff --check`
+
+Controller smoke proof after the code slice:
+
+- Started local harness with command shape `CTB_WEB_READONLY_TOKEN=*** node --import tsx src/cli.ts web readonly --platform feishu --port 45684`.
+- Unauthenticated `/` returned 404.
+- Authenticated `/` returned 200, included the shared Console shell/nav, and did not contain the temporary bearer token, raw `/sessions/` links, local absolute paths, callback payload labels, or message-id labels.
+- Authenticated first `/conversations/:handle` returned 200, included the result panel, and passed the same leak checks.
+- Smoke HTML files were deleted and the local harness process was killed after proof.

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -156,17 +156,19 @@ This is an owner-visible local proof path, but still not public, not mobile-expo
 
 ## Next Gates
 
-1. Checkpoint the explicit local harness plus this PM ledger.
-2. Prepare a controller-owned screenshot/proof artifact from the local harness when needed.
-3. Next possible coding lanes may include safer visible data population for the local harness, persisted neutral final-answer bodies, readiness model refinement, or protected owner-review exposure planning; do not add publicly reachable routes, owner/mobile URL exposure, action controls, uploads/downloads, or support claims without an explicit controller gate.
+1. Checkpoint the explicit local harness plus this PM ledger. Completed in `bceff02 feat: add local Web readonly harness`.
+2. Read-only data-population investigation completed: `proc_6e331d9a80a3`, monitor `78fe54afe14e` paused, report `/tmp/codex-web-data-population-investigation.md`. Decision: next safest slice is scoped session-backed workspace/home rows, not final-answer bodies or public exposure.
+3. Scoped session-backed rows implementation completed: `proc_ae673303a7c8`, monitor `a3767f8b9cf0` paused, status `.hermes/web-scoped-session-rows-status.md`. Controller verification passed with 29 Web tests, `npm run check`, and `git diff --check`.
+4. Prepare a controller-owned screenshot/proof artifact from the local harness when needed.
+5. Later lanes may include persisted neutral final-answer bodies, readiness model refinement, safe operator-binding UX, or protected owner-review exposure planning; do not add publicly reachable routes, owner/mobile URL exposure, action controls, uploads/downloads, or support claims without an explicit controller gate.
 
 ## Guardrails
 
 Do not claim Web is shipped, supported, enabled, public, or browser-usable yet.
 
-Still not implemented beyond the unintegrated module-only local shell:
+Still not implemented for the Web prototype:
 
-- CLI/service startup wiring for Web.
+- Normal service startup/systemd wiring for Web.
 - Public or owner/mobile URL exposure.
 - Browser support claim.
 - Cookie/session login flow.
@@ -197,3 +199,9 @@ Verification after the local harness:
 - `git diff --check` passed.
 
 Still not implemented: public/mobile URL exposure, reverse proxy/tunnel/HTTPS/DNS, service autostart, browser support claim, action controls, writes, uploads/downloads, previews, raw logs/terminal/protocol rendering, or Web support status.
+
+## Scoped Session-backed Rows Checkpoint
+
+The local read-only Web harness now has a narrower safe data-population path: when exactly one operator binding resolves, workspace/home rows can be derived from that binding's scoped, non-archived sessions. The live Web provider no longer forwards global recent-project or project-stat readers into the Web view-model path, so unscoped project fixtures cannot populate Web workspace rows.
+
+This remains local read-only prototype plumbing only. It does not add final-answer body rendering, public/mobile exposure, auth redesign, operator selection, screenshot flow, or action controls.

--- a/docs/plans/2026-04-26-web-first-pm-ledger.md
+++ b/docs/plans/2026-04-26-web-first-pm-ledger.md
@@ -15,6 +15,7 @@ source_of_truth:
   - docs/plans/2026-04-26-web-first-pm-ledger.md
   - docs/roadmap/codex-console-continuation-brief.md
   - docs/plans/2026-04-26-web-viewmodel-inventory.md
+  - docs/plans/2026-04-26-web-gated-actions-design.md
 -->
 
 # Codex Console Web-First PM Ledger
@@ -178,7 +179,7 @@ Active todo list:
 2. Owner-visible proof artifact: run the local token-gated Web prototype with `--platform feishu`, capture a safe screenshot/recording or HTML proof that can be reviewed without exposing token, raw IDs, local paths, terminal logs, or platform internals.
 3. More useful read-only dashboard: add safe conversation detail, sanitized final-answer body where a safe source exists, runtime/readiness panels, and pending-interaction read-only visibility.
 4. Protected owner access plan: completed as a docs-only design gate; use the protected owner access plan before any owner phone/browser URL exposure. No public/mobile exposure is implemented.
-5. Gated actions design: separately design submit/approval/interrupt with audit and scope controls; do not implement actions in the read-only MVP lane.
+5. Gated actions design: completed as a docs-only gate; use the gated-actions design before any Web submit, approval-answer, or interrupt implementation. Do not implement actions in the read-only MVP lane.
 
 Phase 2B investigation completed:
 
@@ -220,6 +221,14 @@ Protected owner access design completed as a docs-only gate:
 - Result: owner-only protected access is specified as a future preview path, not shipped support. The recommended first path is a WireGuard/Tailscale/VPN-style private network plus app-level auth/session gates, with SSH forwarding kept for controller-only proof and public reverse proxy/tunnel paths deferred or fallback-only.
 - Required gates now include short-lived non-URL secrets, localhost default, explicit enable flag/env, platform binding filter, audit trail, rate/lockout or ingress allowlist, rollback/shutdown drill, and acceptance proof before any real protected URL.
 - Still not implemented: public URL, owner/mobile URL, reverse proxy, tunnel, VPN wrapper, HTTPS/DNS, service auto-start, browser session login, actions, uploads/downloads, raw terminal/logs, or support claim.
+
+Gated Web actions design completed as a docs-only gate:
+
+- Status artifact: `.hermes/gated-actions-design-status.md`
+- Durable artifact: `docs/plans/2026-04-26-web-gated-actions-design.md`
+- Result: future Web actions are explicitly sequenced as action 0 no-op/readiness capability display, action 1 allowlisted approval/question answer, action 2 confirmed interrupt/stop, and action 3 submit-new-task only after workspace/binding/session semantics and audit are proven.
+- Required gates now include protected owner access passed first, explicit owner auth/session, single resolved binding/platform, CSRF or equivalent replay protection, action audit log, idempotency/action nonce, confirmation for destructive or interruptive actions, rollback path, opaque server-scoped handles, generic stale/duplicate denial, and kill-switch verification.
+- Still not implemented: no-op action capability display, approval-answer, interrupt, task submit, uploads/downloads, artifact download, raw terminal, arbitrary command execution, public/mobile URL exposure, multi-user semantics, or Web support claim.
 
 ## Guardrails
 

--- a/docs/plans/2026-04-26-web-first-project-command-board.md
+++ b/docs/plans/2026-04-26-web-first-project-command-board.md
@@ -1,0 +1,200 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/plans/README.md
+children: []
+summary: PM-facing command board for Web-first Codex Console continuation, covering scope, owners, gates, reporting, and VPS/mobile validation
+read_when:
+  - coordinating Web-first Codex Console work as a project manager
+  - reviewing what should happen before Web prototype implementation
+  - preparing status reports for owner review
+skip_when:
+  - the request is about current Telegram or Feishu shipped behavior
+  - the request is asking for implementation details after the current Web MVP scope is already approved
+source_of_truth:
+  - docs/plans/2026-04-26-web-first-project-command-board.md
+  - docs/architecture/web-app-preimplementation-contract.md
+  - docs/roadmap/codex-console-continuation-brief.md
+-->
+
+# Web-First Project Command Board
+
+Status: active PM command board
+Owner: Product / Project Lead
+Last updated: 2026-04-26
+
+## Executive Decision
+
+Codex Console should proceed **Web first, App later**.
+
+This does not cancel App. It keeps App out of the first implementation lane so the team can validate shared Core contracts, readiness reporting, and a browser-based control surface before paying the extra cost of app packaging, updates, device permissions, and native notification models.
+
+## Current Position
+
+- Current shipped/default surface remains Telegram.
+- Feishu is a serious current pack with setup/readiness caveats.
+- Web is future work and must not be claimed as currently supported.
+- App is a later product lane that should reuse the same backend/Core contracts proven by Web.
+- The current environment is VPS/Linux-first; owner validation is usually by mobile browser, not by opening a browser on the server.
+
+## Management Goal
+
+Create a safe, staged path from chat-based Codex Console toward a Web control console.
+
+The first outcome is not a polished product. The first outcome is decision-quality evidence:
+
+1. the Web surface can consume Core project/session, runtime, interaction, final-answer, artifact, and readiness state;
+2. the user can eventually access it from a phone through an exposed URL with login/access control;
+3. the team can say exactly which readiness gates passed before making any public support claim.
+
+## Non-Negotiable Boundaries
+
+- Web-only for the current lane; App stays later.
+- Documentation and planning before implementation.
+- No public Web support claim until readiness gates pass.
+- No unauthenticated public URL.
+- No raw terminal exposure in the first Web lane.
+- No arbitrary project writes in the first Web lane.
+- No multi-user/team collaboration in the first Web lane.
+- No repo/package/CLI/service/env-var rename as part of Web prototype work.
+- Current Telegram/Feishu truth must remain separate from future Web direction.
+
+## Work Packages
+
+| ID | Work package | Lead | Support | Output | Acceptance |
+|---|---|---|---|---|---|
+| W1 | PM command board | Project lead | None | This board | Owner can review route, boundaries, and reporting shape. |
+| W2 | Web MVP/readiness draft | Codex high | Project lead | Independent PM-facing report | Defines MVP pages, readiness levels, risks, and phased gates without writing code. |
+| W3 | Controller triage | Project lead | Codex report | Approved scope cut | Removes overdesign, fixes Web-only first lane, marks deferred App/team/raw-terminal items. |
+| W4 | Formal docs landing | Codex high + project lead | Existing docs | Web MVP scope + readiness model docs | Linked from continuation brief/routers; no overclaim; checks pass. |
+| W5 | VPS/mobile access plan | Codex high + project lead | Ops docs | URL/login/security plan | Supports early screenshots and later phone-access URL with auth. |
+| W6 | Independent review | Codex high | Project lead | Blocker-focused review | Checks overclaim, safety, routing consistency, and mobile/VPS validation assumptions. |
+| W7 | Progress ledger and status reports | Project lead | None | Maintained phase notes | Owner can ask anytime and get current state, last verification, blockers, and next action. |
+
+## Phase Plan
+
+### Phase A — Decide Scope Before Coding
+
+Goal: make the first Web lane small enough to execute safely.
+
+Deliverables:
+
+- Web MVP scope draft.
+- Readiness model draft.
+- VPS/mobile validation plan.
+- Owner-readable status summary.
+
+Exit criteria:
+
+- First Web MVP pages are named.
+- First Web MVP explicitly excludes App, raw terminal, multi-user, project writes, and public unauthenticated access.
+- The readiness model defines declared/configured/observed/UX-exposed for each baseline journey.
+- Owner can review the plan without reading code.
+
+### Phase B — Prepare Prototype Implementation Plan
+
+Goal: prepare a non-public Web prototype plan only after readiness is clear.
+
+Deliverables:
+
+- implementation plan for read-only Web prototype;
+- exact Core/state surfaces to read;
+- security/access model;
+- screenshot-first validation flow;
+- external URL validation flow for mobile.
+
+Exit criteria:
+
+- prototype plan names allowed files and forbidden areas;
+- security model is approved before exposing any URL;
+- no public support claim is introduced.
+
+### Phase C — Build Non-Public Web Prototype
+
+Goal: validate feasibility, not launch product.
+
+Initial page candidates:
+
+1. Web Home: workspace list, active workspace/session, recent conversations, contextual health/degraded state.
+2. Workspace Sessions: per-workspace session/conversation list and read-only selection state.
+3. Conversation Detail/Results: completed answer and generated file/image references.
+4. Runtime: running/blocked/done/failed and recent output summary as supporting context.
+5. Interactions: pending approval/question display, initially protected or read-only if needed.
+
+Exit criteria:
+
+- can run on VPS;
+- project lead can capture screenshots for owner review;
+- later exposes an authenticated URL for phone validation;
+- no dangerous actions are available before approval.
+
+## Readiness Model To Formalize
+
+Each Web capability should be tracked at four levels:
+
+1. **Declared** — the system says the capability exists.
+2. **Configured** — required config, server process, auth, storage, and paths are present.
+3. **Observed** — a real run exercised the capability successfully.
+4. **UX-exposed** — the owner can use it through UI, not just internal APIs.
+
+Baseline capabilities:
+
+- operator login/access control;
+- project/session visibility;
+- task/runtime status visibility;
+- blocked interaction visibility;
+- final answer visibility;
+- artifact/file visibility;
+- degraded/failure visibility;
+- mobile-access URL validation;
+- screenshot/recording evidence path.
+
+## VPS And Mobile Validation Strategy
+
+Early validation:
+
+- run locally on VPS;
+- project lead captures screenshots or short recordings;
+- owner reviews layout, wording, and information architecture from media.
+
+Later validation:
+
+- expose a controlled URL;
+- require login/access token or equivalent access control;
+- owner opens from phone;
+- validate real read-only flows before enabling actions.
+
+Security notes:
+
+- never expose a raw unauthenticated server;
+- use screenshots/recordings as the early validation path;
+- expose a temporary or allowlisted URL only after login/access control is ready;
+- keep secrets, local paths, raw logs, and terminal-like output behind explicit controls;
+- do not enable write actions until reviewed.
+
+## Reporting Format
+
+Use this short status format for owner updates:
+
+```text
+Phase: <A/B/C>
+Status: green/yellow/red
+Done: <1-3 bullets>
+Now: <current work>
+Next: <next work>
+Blockers: <none or concrete blocker>
+Verification: <commands/evidence>
+Decision needed: <yes/no + question>
+```
+
+## Current Closeout State
+
+The initial command-board sequence has moved beyond W2. Current accepted outputs are:
+
+- W2 independent Web MVP/readiness report: complete.
+- W3 controller triage: complete.
+- W4 formal Web MVP scope/readiness docs: complete.
+- W5 VPS/mobile access and security plan: complete.
+- W6 independent review: completed with one action-control wording blocker, now tracked for closeout.
+
+Next work after closeout is Web prototype implementation planning, not coding: define the read-only Core/state surfaces, auth/access model, forbidden-data redaction, screenshot evidence path, and protected-URL rollback path.

--- a/docs/plans/2026-04-26-web-gated-actions-design.md
+++ b/docs/plans/2026-04-26-web-gated-actions-design.md
@@ -1,0 +1,275 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/plans/README.md
+children: []
+summary: docs-only design gate for future gated Web submit, approval-answer, and interrupt actions after the read-only owner-visible MVP
+read_when:
+  - designing future Web action controls after the read-only owner-visible MVP
+  - checking action preconditions, safety model, audit requirements, acceptance checklists, or rollback gates
+  - deciding whether Web submit, approval-answer, or interrupt may be implemented
+skip_when:
+  - the task is only about current Telegram or Feishu shipped behavior
+  - the task is only about current read-only Web prototype behavior
+  - the task needs source implementation details for Web routes, auth middleware, or app-server calls
+source_of_truth:
+  - docs/plans/2026-04-26-web-gated-actions-design.md
+  - docs/plans/2026-04-26-web-protected-owner-access-plan.md
+  - docs/plans/2026-04-26-web-first-phase-1-closeout.md
+  - docs/plans/2026-04-26-web-first-pm-ledger.md
+-->
+
+# Web Gated Actions Design
+
+Status: design gate complete; docs-only phase; no Web actions implemented or enabled  
+Owner: Hermes/Tuzi controller; Codex runs are implementation/review subagents  
+Last updated: 2026-04-26
+
+## Decision Summary
+
+Web actions are **not implemented, enabled, safe, or supported now**.
+
+The current Web prototype remains read-only, local-only by default, and token-gated. It exposes owner-safe
+workspace rows, recent conversations, and opaque `cv_...` conversation detail handles. Protected owner
+access must pass first, and the read-only owner-visible MVP must be accepted before any action work starts.
+
+The action path is intentionally sequenced so future implementation cannot jump straight to task
+submission. Each lane must prove owner auth, binding, anti-replay, audit, and rollback before the next lane
+is considered.
+
+## Action Taxonomy And Required Sequence
+
+Actions must land in this order. Skipping a lane is a no-go.
+
+| Lane | Action | Purpose | Required posture |
+|---|---|---|---|
+| 0 | No-op readiness check or action capability display | Show whether the current session could ever accept actions, and why an action is disabled. | Read-only, no state mutation, no app-server write, no platform callback. |
+| 1 | Answer an already-pending approval/question | Let the owner choose one allowlisted answer for an existing pending interaction. | Opaque action handle, allowlisted choices only, preview, CSRF/replay/idempotency, audit. |
+| 2 | Interrupt/stop current turn | Let the owner stop the current Codex turn when a running turn is clearly active. | Explicit confirmation, interrupt-specific audit, generic stale/duplicate denial, recovery state. |
+| 3 | Submit a new task | Start a new Codex task from Web. | Only after workspace, binding, session semantics, lifecycle visibility, and audit are proven. |
+
+Lane 0 is the first implementation candidate because it is a safe diagnostic surface. It may explain that
+actions are unavailable, but it must not create action handles that can mutate state.
+
+## Hard Preconditions Before Any Web Action
+
+No Web action lane may be implemented until all of these are true and evidenced:
+
+1. **Protected owner access gate passed.** Owner-only protected access has passed its auth/session,
+   ingress, denial, and shutdown checklist.
+2. **Read-only MVP accepted.** Owner can inspect useful read-only workspace/conversation state without
+   public exposure, action controls, raw IDs, local paths, terminal output, or payload leaks.
+3. **Explicit owner auth/session.** The request is tied to a revocable owner session, not a bearer token in
+   a URL and not an unauthenticated local page.
+4. **Single resolved binding/platform.** The server resolves exactly one owner/operator binding and one
+   platform scope before rendering or accepting an action.
+5. **CSRF/replay protection or equivalent.** Browser-origin action posts include anti-CSRF protection or an
+   equivalent same-origin/session-bound proof.
+6. **Action audit log.** The server records action attempts, denials, accepted decisions, and outcomes
+   without secrets or raw platform identifiers.
+7. **Idempotency/action nonce.** Every action attempt uses a one-time server-issued nonce or idempotency key
+   scoped to the owner session and action handle.
+8. **Confirmation for destructive or interruptive actions.** Interrupt and any action that may discard work,
+   stop a turn, or approve risky behavior requires an explicit confirmation step.
+9. **Rollback path.** Operators can disable all Web actions, revoke sessions, expire nonces, and verify
+   read-only Web still works.
+10. **Generic stale/duplicate denial.** Stale, duplicate, replayed, unknown, cross-session, or cross-binding
+    action attempts fail with the same safe denial shape.
+
+If any precondition regresses, the correct behavior is to disable all Web actions and preserve read-only
+access only.
+
+## Safety Model
+
+The first action lanes are narrow owner decisions, not a Web terminal.
+
+Required safety boundaries:
+
+- no raw terminal, shell prompt, arbitrary command runner, or raw command execution UI;
+- no uploads, downloads, file writes, previews, artifact retrieval, or file picker in the first action lane;
+- no free-form approval payloads initially; owner choices must come from a server-provided allowlist;
+- no raw callback data, app-server payloads, platform IDs, chat IDs, user IDs, session IDs, or local paths in
+  the UI, URLs, action forms, logs, or errors;
+- action handles are opaque, server-scoped, owner-session-scoped, binding-scoped, and short-lived;
+- stale, duplicate, replayed, expired, unknown, wrong-session, or wrong-binding actions are denied
+  generically;
+- action rendering must be derived from Web-safe ViewModels, not raw platform callbacks or app-server
+  payload dumps;
+- action controls must fail closed when runtime/readiness state is degraded or ambiguous;
+- action failure must leave owner-visible recovery state instead of silently hiding the pending interaction.
+
+Approval answering has an additional constraint: the Web UI may only submit the opaque pending-interaction
+handle plus one allowlisted choice token. It must not let the browser construct arbitrary approval payloads,
+commands, arguments, file paths, or protocol fields.
+
+## Per-Action Acceptance Checklists
+
+### Action 0: Readiness Check / Capability Display
+
+Acceptance before merging lane 0:
+
+- displays action capability as disabled by default until all hard preconditions are true;
+- explains unavailable actions with owner-readable reasons such as `protected_access_not_ready`,
+  `binding_ambiguous`, `runtime_degraded`, or `action_lane_disabled`;
+- does not expose raw IDs, platform payloads, callback data, tokens, file paths, or terminal output;
+- creates no mutation-capable nonce or action handle;
+- covered by view-model and HTTP/auth tests for ready, degraded, unauthenticated, stale, and ambiguous
+  states.
+
+### Action 1: Approval / Question Answer
+
+Acceptance before enabling approval-answer:
+
+- only answers a pending interaction that already exists in the resolved owner binding/session scope;
+- pending interaction is rendered through a Web-safe summary and opaque action handle;
+- available answers are server-provided allowlisted choices; no free-form browser-supplied payload is
+  accepted;
+- owner sees a preview of the exact decision label and consequence class before submit;
+- POST requires owner session, same-origin/CSRF proof, action nonce, and idempotency key;
+- stale, duplicate, replayed, expired, wrong-choice, wrong-binding, wrong-session, and already-answered
+  attempts are denied generically;
+- accepted decision is auditable with actor/session label, binding/platform label, action handle hash,
+  decision label, timestamp, and outcome;
+- UI refreshes to a clear post-action state: accepted, denied, stale, already handled, or runtime unavailable;
+- negative tests prove no raw callback data, protocol fields, platform IDs, local paths, token, or free-form
+  choice text leaks into HTML, URL, logs, or errors;
+- global Web-action kill switch disables the control without disabling read-only pages.
+
+### Action 2: Interrupt / Stop Current Turn
+
+Acceptance before enabling interrupt:
+
+- only appears when a running turn is clearly active for the single resolved owner binding/session scope;
+- disabled state is explicit when no turn is running, runtime state is ambiguous, or protected access/action
+  gates are incomplete;
+- owner must confirm the interrupt with an explicit preview that says the current turn may stop and partial
+  work may remain unresolved;
+- POST requires owner session, same-origin/CSRF proof, action nonce, and idempotency key;
+- stale, duplicate, replayed, expired, wrong-binding, wrong-session, already-stopped, and no-active-turn
+  attempts are denied generically;
+- accepted interrupt is auditable with actor/session label, binding/platform label, target turn handle hash,
+  confirmation result, timestamp, and outcome;
+- UI shows clear recovery state after the action: stopping, stopped, already stopped, failed generically, or
+  runtime unavailable;
+- tests prove duplicate interrupts do not send duplicate stop requests;
+- rollback can disable interrupt alone or all Web actions globally while keeping read-only pages available.
+
+### Action 3: Submit New Task
+
+Submit-new-task is last because it creates new Codex work rather than answering existing state.
+
+Acceptance before enabling submit:
+
+- workspace, binding, session, and conversation ownership semantics are documented and implemented;
+- owner can see where the new task will land before submit: workspace label, platform/binding label,
+  conversation/session target, model/profile if relevant, and audit destination;
+- task body handling is intentionally scoped; no uploads, downloads, file paths, artifact references, raw
+  terminal input, or arbitrary command launcher are included in the first submit lane;
+- optional fields are allowlisted and rendered from server-owned capabilities, not arbitrary browser payloads;
+- POST requires owner session, same-origin/CSRF proof, action nonce, and idempotency key;
+- duplicate or replayed submits cannot create duplicate tasks;
+- accepted submit creates owner-visible lifecycle state immediately: queued, running, blocked, failed, or
+  completed reference;
+- audit records the safe task summary hash/length, target handles, actor/session label, binding/platform
+  label, timestamp, idempotency key hash, and outcome;
+- negative tests prove no raw platform IDs, local paths, tokens, callback payloads, terminal logs, or hidden
+  file-write controls appear in UI, URL, logs, or errors;
+- rollback can disable submit alone, expire submit nonces, and leave already-created tasks visible as normal
+  read-only conversation state.
+
+## Audit And Logging Requirements
+
+Audit is mandatory before actions, and audit must be safe to retain.
+
+Log for each action attempt:
+
+- timestamp and monotonic sequence if available;
+- action lane and action type;
+- safe actor/session label or hash;
+- safe platform/binding label or hash;
+- opaque action handle hash, never the raw handle when avoidable;
+- action nonce/idempotency key hash;
+- route family and result class: accepted, denied, stale, duplicate, replay, expired, wrong scope, failed,
+  or killed by switch;
+- decision label for allowlisted approval choices, not raw payload contents;
+- confirmation result for interruptive actions;
+- lifecycle outcome if known, or follow-up correlation handle hash if outcome is asynchronous.
+
+Never log:
+
+- real secrets, tokens, cookies, Authorization headers, CSRF tokens, session secrets, or nonce raw values;
+- raw platform IDs, chat IDs, user IDs, message IDs, callback data, app-server payloads, local paths, config
+  paths, artifact backing paths, env values, stack traces, terminal output, or command stdout/stderr;
+- full task body, full conversation text, uploaded file contents, approval payload JSON, or arbitrary browser
+  form bodies;
+- real protected URLs, hostnames, public IPs, or tunnel names in durable docs or committed fixtures.
+
+## UX Requirements
+
+The Web surface must remain a Console, not a fake chat shell.
+
+Required UX behavior:
+
+- show actions beside the relevant workspace/conversation/runtime state, not as a generic chat input;
+- unavailable actions are visible only when useful and are disabled with clear owner-readable reasons;
+- every mutating action has an explicit preview; interruptive/destructive actions require confirmation;
+- pending, submitting, accepted, denied, stale, duplicate, failed, and recovered states are visually distinct;
+- browser refresh/back/duplicate-click behavior is safe and idempotent;
+- errors are generic where needed for safety but still tell the owner what safe recovery is available;
+- no raw callback strings, protocol payloads, platform IDs, local paths, terminal output, or debug panels are
+  rendered;
+- forms use opaque handles and server-owned choices only;
+- action controls disappear or disable immediately when the action lane kill switch is active.
+
+## Test Plan
+
+Minimum verification before any implementation PR may claim an action lane is ready:
+
+1. **Service/view-model tests** for action capability, disabled reasons, pending interaction summaries,
+   confirmation models, opaque handles, stale states, and redaction.
+2. **HTTP/auth tests** for unauthenticated denial, wrong owner session, wrong binding, wrong platform,
+   missing session, generic unsafe routes, and no-store/security headers.
+3. **CSRF/replay/idempotency tests** for missing CSRF, wrong CSRF, reused nonce, expired nonce, duplicate
+   POST, replay after session revoke, and idempotent retry of accepted actions.
+4. **Integration smoke** for the full owner flow of each lane using safe local state: render, preview,
+   submit/confirm, refresh, observe lifecycle, then shut down.
+5. **Negative leak tests** that assert HTML, URLs, headers, logs, errors, snapshots, and status output do not
+   contain tokens, raw IDs, callback data, local paths, terminal text, command output, or protocol JSON.
+6. **Action wording tests** or fixtures that verify labels do not overclaim public support, service support,
+   mobile readiness, arbitrary command execution, upload/download support, or safety beyond the passed lane.
+7. **Kill-switch tests** proving all Web actions can be disabled globally and individually while read-only
+   pages still return expected authenticated state.
+8. **Rollback smoke** proving sessions can be revoked, nonces expired, the action lane disabled, and stale
+   browser tabs denied generically.
+
+## Rollback And Kill Switch
+
+Before enabling any lane, operators need a practiced rollback:
+
+1. Disable all Web actions globally through a single config/env/flag or equivalent runtime switch.
+2. Optionally disable one lane independently, starting with submit and interrupt.
+3. Revoke owner Web sessions.
+4. Expire all outstanding action handles, CSRF proofs, idempotency keys, and nonces.
+5. Stop protected exposure if the incident involves owner-access risk.
+6. Verify stale browser tabs and duplicate posts receive only generic denial.
+7. Verify authenticated read-only Web Home and `cv_...` conversation detail still work.
+8. Record safe audit proof of disablement, session revocation, nonce expiry, and read-only recovery without
+   secrets, real URLs, hostnames, raw IDs, or tokens.
+
+Rollback success means the owner can still inspect read-only state while no Web action can mutate Codex,
+platform, session, or file state.
+
+## Non-Goals
+
+This design does not authorize or implement:
+
+- public exposure, public support, mobile support, service support claims, or service availability claims;
+- multi-user, team, organization, shared-browser, or delegated-access semantics;
+- uploads, downloads, artifact download, previews, file picker, paste-to-upload, or write-back flows;
+- raw terminal, shell prompt, arbitrary command execution, command stdout/stderr panels, or debug logs;
+- raw app-server payload, callback-data, platform-ID, local-path, or config-path rendering;
+- free-form approval payloads or browser-constructed protocol fields;
+- task submission before protected owner access, binding/session semantics, lifecycle visibility, and audit are
+  proven;
+- combining action work with protected public exposure, reverse proxy/DNS/tunnel setup, service startup,
+  native App work, or support-claim wording.

--- a/docs/plans/2026-04-26-web-mvp-controller-triage.md
+++ b/docs/plans/2026-04-26-web-mvp-controller-triage.md
@@ -1,0 +1,131 @@
+# Web MVP Readiness Controller Triage
+
+Status: controller-approved scope cut
+Last updated: 2026-04-26
+
+## Verdict
+
+Accept the Codex high report with scope reduction.
+
+Proceed with a **read-mostly Web MVP** as the first implementation target. The product shape is a
+workspace/session/conversation Web app, not a generic management dashboard: start from workspaces,
+inspect workspace conversations, and open conversation results. Do not implement App, public support
+claims, raw terminal, multi-user collaboration, arbitrary project writes, uploads, or unauthenticated
+public access in the first lane.
+
+## Approved First Lane
+
+| Area | Decision |
+|---|---|
+| Product direction | Web first, App later |
+| Product claim | Prototype only; no current Web support claim |
+| Deployment assumption | VPS Linux server |
+| Owner validation | Screenshots/recordings first; later protected mobile-access URL |
+| User model | Single high-trust operator |
+| First implementation posture | Read-mostly |
+| URL exposure | Only after login/access control exists |
+
+## Approved MVP Pages
+
+1. Web Home
+   - workspace list and active workspace/session summary
+   - recent conversations
+   - compact runtime/readiness badges
+   - degraded warnings
+
+2. Workspace Sessions
+   - active workspace/session
+   - per-workspace conversation/session list
+   - empty/error/unavailable states
+   - read-only first
+
+3. Conversation Detail / Results
+   - conversation/session detail
+   - final answer separated from progress
+   - artifact descriptors and availability
+   - preview/download only where safe and configured
+
+4. Runtime
+   - idle/queued/running/blocked/done/failed/degraded/unhealthy/recovered
+   - compact and detailed status as contextual information
+   - recent output summary, not raw terminal
+
+5. Interactions
+   - pending/resolved/expired/stale/duplicate/failed states
+   - read-only first
+   - response actions later behind explicit gate
+
+6. Setup / Readiness
+   - declared/configured/observed/UX-exposed matrix
+   - auth/access status
+   - capability gaps as a setup gate, not the main product experience
+
+## Deferred Until Later
+
+- App implementation.
+- Public Web support claim.
+- Multi-user/team collaboration.
+- Raw terminal access.
+- Arbitrary project writes/file editing.
+- Full upload flow.
+- Browser/mobile push notifications.
+- Hosted/SaaS control plane.
+- Repo/package/CLI/service/env-var renames.
+
+## Action Gates
+
+| Action | First lane decision | Gate before enabling |
+|---|---|---|
+| View Web Home/workspace sessions/conversation results/status | Approved after auth | Login/access control works |
+| Switch/resume project/session | Deferred | owner approves action audit/recovery semantics |
+| Submit text task | Deferred | CSRF/action protection, lifecycle visibility, failure visibility |
+| Answer approval/question | Deferred | stale/duplicate/expiry handling visible |
+| Interrupt | Deferred | action audit trail and recovery state visible |
+| Upload files | Deferred | attachment validation/storage/retention plan |
+
+## Readiness Model To Land Next
+
+Each baseline capability must report four levels:
+
+1. Declared — included in MVP target.
+2. Configured — required config/process/storage/auth exists.
+3. Observed — real run exercised the path.
+4. UX-exposed — owner can use/inspect it in UI.
+
+Baseline capabilities:
+
+- login/access control
+- operator binding
+- workspace/session/conversation visibility
+- runtime status visibility
+- final answer visibility
+- artifact/file visibility
+- interaction visibility
+- delivery/degraded outcome visibility
+- mobile URL validation
+- screenshot/recording evidence path
+
+## VPS / Mobile Validation Rule
+
+The project must validate in this order:
+
+1. Local VPS run with screenshots/recordings.
+2. Protected URL only after login/access control exists.
+3. Owner phone validation of read-only flows.
+4. Controlled actions only after security/readiness approval.
+
+## Next Execution Package
+
+Delegate Codex high to turn this triage into formal docs:
+
+- Web MVP scope doc.
+- Web readiness model doc or section.
+- VPS/mobile validation and URL exposure gate.
+- Router/catalog updates.
+
+Controller must then verify:
+
+- no Web support overclaim;
+- App remains later but alive;
+- first lane is Web-only/read-mostly;
+- `git diff --check` and `npm run check` pass.

--- a/docs/plans/2026-04-26-web-protected-owner-access-plan.md
+++ b/docs/plans/2026-04-26-web-protected-owner-access-plan.md
@@ -1,0 +1,186 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/plans/README.md
+children: []
+summary: protected owner-only access design gate for the local token-gated read-only Web prototype, including threat model, auth/session requirements, rollback drill, and acceptance checklist
+read_when:
+  - planning the first owner phone/browser access trial for the Web read-only prototype
+  - deciding whether localhost-only Web may be exposed beyond the controller machine
+  - checking protected-access threat model, auth/session gates, rollback, or acceptance criteria
+skip_when:
+  - the task is only about current Telegram or Feishu shipped behavior
+  - the task needs source implementation details for Web server, auth middleware, proxy, tunnel, or networking
+source_of_truth:
+  - docs/plans/2026-04-26-web-protected-owner-access-plan.md
+  - docs/operations/web-vps-mobile-access-and-security.md
+  - docs/plans/2026-04-26-web-first-pm-ledger.md
+-->
+
+# Web Protected Owner Access Plan
+
+Status: design gate complete; docs-only phase; not runtime exposure  
+Owner: Hermes/Tuzi controller; Codex runs are implementation/review subagents  
+Last updated: 2026-04-26
+
+## Decision Summary
+
+This phase defines a future safe path from the current localhost-only Web prototype to an owner-only
+phone/browser preview. It does **not** make Web public, shipped, generally supported, mobile-ready, or
+action-capable.
+
+Current ground truth stays unchanged:
+
+- the Web prototype is explicit, local-only by default, token-gated, and read-only;
+- it has workspace rows, recent conversations, and opaque `cv_...` conversation detail handles;
+- it must not be exposed by normal service startup, install flow, systemd, reverse proxy, tunnel, or
+  public DNS until a later implementation gate passes;
+- owner access is a preview/trial lane, not a support claim.
+
+## Recommended First Protected Path
+
+Recommended first owner-phone path: **VPN/private-network access using an owner-only
+WireGuard/Tailscale-style network, plus the existing app-level auth/session gate**.
+
+Why this is the safest first candidate:
+
+- it avoids an unauthenticated public URL and keeps ingress limited to enrolled owner/controller
+  devices before the Web app even sees a request;
+- it is more suitable for phone validation than plain SSH local port forwarding, which is best for
+  controller-only screenshots but awkward as the owner’s normal phone-browser path;
+- it is easier to make owner-only than a reverse proxy or Cloudflare Tunnel, both of which can create
+  a broadly reachable hostname if misconfigured;
+- it supports a fast rollback by disabling the Web process and removing the private-network route or
+  device access;
+- it remains compatible with later HTTPS/session hardening without making public exposure the first
+  milestone.
+
+Pattern ranking for the first real protected URL:
+
+| Candidate | First-use decision | Why |
+|---|---|---|
+| SSH local port forwarding | Use for controller-only smoke, screenshot, or emergency admin proof. | Narrowest exposure, but not the preferred owner phone UX unless the owner explicitly wants SSH from phone. |
+| WireGuard/Tailscale/VPN-style private network | **Recommended first owner-phone path.** | Device-level private ingress plus app auth; no public hostname required. |
+| Reverse proxy with HTTPS/auth | Later repeat-trial path after auth/session, logs, headers, and rollback are proven. | Stable, but public-facing mistakes have higher blast radius. |
+| Cloudflare Tunnel/ngrok-style tunnel | Short one-off fallback only after auth and expiry controls are proven. | Convenient, but accidental public reachability and stale tunnel risk are higher. |
+| Public DNS/HTTPS without private ingress | No for this phase. | Too easy to overclaim or expose state beyond the owner. |
+
+## Explicit Non-Goals
+
+This phase does not authorize or implement:
+
+- unauthenticated public URL exposure;
+- public Web support, mobile support, or service availability claims;
+- raw terminal, shell prompt, app-server payloads, debug logs, stack traces, or raw command output;
+- task submission, approval/question responses, interrupt, switch/resume controls, or other actions;
+- multi-user, team, shared browser, or organization access;
+- uploads, downloads, previews, file picker, paste-to-upload, or write-back flows;
+- service auto-start, install-time exposure, systemd Web wiring, reverse proxy config, DNS, TLS, or
+  tunnel scripts unless a later gate explicitly adds them;
+- exposing raw platform IDs, chat IDs, user IDs, session IDs, callback payloads, local paths, config
+  paths, artifact backing paths, env values, credentials, or tokens.
+
+## Threat Model
+
+| Threat | Risk | Required posture before exposure |
+|---|---|---|
+| Token leakage | Bearer token copied into screenshots, shell history, logs, browser storage, or referrers can open state. | Short-lived secret; never place token in URL; never print token; rotate after trial or suspected leak. |
+| Browser history/referrer | URLs, paths, or query strings can persist or be sent to another origin. | No token or raw IDs in URL; same-origin links only; `Referrer-Policy: no-referrer`; no third-party assets. |
+| Tunnel exposure | Tunnel or proxy may remain running or become reachable beyond the owner. | Explicit enable flag; owner-only ingress; expiry; shutdown proof; no default service exposure. |
+| DNS/HTTPS mistakes | Public hostname, wrong certificate route, or cached DNS may outlive trial. | Prefer private network first; if public TLS is later used, require reversible DNS/proxy ownership and post-shutdown negative proof. |
+| Origin/CSP gaps | Third-party scripts, mixed content, or permissive framing can leak state. | Strict CSP; no inline external dependencies unless reviewed; frame denied; no cross-origin reads. |
+| Brute force | Exposed auth endpoint can be guessed or sprayed. | Rate limit/lockout or ingress allowlist; generic failures; audit denials. |
+| Binding ambiguity | Browser could show the wrong platform/operator state when multiple bindings exist. | Require explicit platform binding filter and exactly one owner binding before state renders. |
+| Stale session links | Old `cv_...` handles or browser tabs may keep opening state after a trial. | Server-side session expiry; handle invalidation on restart/token rotation; generic 404 for stale/unknown handles. |
+| Local file/path leak | UI, errors, artifacts, or readiness may reveal home/temp/config paths. | Redacted labels and opaque handles only; generic errors; no raw artifact backing paths. |
+| Operational rollback failure | Exposure cannot be stopped quickly during a leak or confusion. | Rollback drill must be known, tested, and recorded before any owner URL is shared. |
+
+## Auth And Session Gate Requirements
+
+Minimum gate before any owner-accessible URL:
+
+1. **Localhost remains default.** External access requires an explicit flag/env and cannot happen through
+   normal service startup.
+2. **Short-lived secret.** Generate a trial-only secret, rotate after the trial, and never reuse the
+   local smoke token for protected owner access.
+3. **No token in URL.** Use a login/session exchange, Authorization header, or equivalent non-URL
+   mechanism; do not use query strings, fragments, or path segments for secrets.
+4. **Server-side or revocable session.** Phone access can expire or be revoked without code changes.
+5. **Platform binding filter.** Require an explicit platform and exactly one resolved owner/operator
+   binding before rendering state.
+6. **Owner-only ingress.** Prefer private-network device membership; otherwise require an ingress
+   allowlist in addition to app auth.
+7. **Generic denial.** Unauthorized, stale, unbound, or invalid-handle requests return the same safe
+   denial shape and reveal no project, path, platform, or binding details.
+8. **Audit trail.** Record start/stop time, enabled exposure mode, successful auth, denied auth,
+   binding selected, shutdown result, and token rotation event without logging secrets or raw IDs.
+9. **Rate/lockout.** Add request rate limiting, auth lockout, or equivalent ingress throttling before
+   any network-reachable auth endpoint.
+10. **Headers/origin.** Keep no-store, nosniff, strict CSP, frame denial, and no-referrer behavior;
+    avoid third-party scripts, fonts, or analytics.
+
+## Rollback And Shutdown Drill
+
+Before sharing any protected owner URL, the controller must know the exact stop path for the chosen
+server and exposure mechanism. Use placeholders only in docs and logs; do not record real URLs or
+secrets.
+
+Required drill:
+
+1. **Stop the Web server.** Terminate the explicitly started Web readonly process using the recorded
+   process handle or supervisor stop command for the trial.
+2. **Stop the exposure layer.** Disable the VPN share/route, remove the owner device from the trial
+   policy, stop the SSH forward, stop the tunnel process, or disable the reverse-proxy route used for
+   the trial.
+3. **Rotate the trial secret.** Invalidate the short-lived secret or session store before restarting
+   any Web process.
+4. **Verify local port closed.** Confirm the selected local port is no longer listening on localhost or
+   any non-loopback interface.
+5. **Verify no process left.** Confirm no Web readonly, tunnel, proxy wrapper, or trial supervisor
+   process remains from the exposure run.
+6. **Verify endpoint denial.** From a non-authenticated client and, when applicable, from outside the
+   private network, confirm the protected endpoint is unreachable or returns only the generic denial.
+7. **Record proof.** Add a dated readiness/security note with exposure mode, start/stop result,
+   token/session rotation result, port-closed proof, and public/private endpoint denial proof.
+
+If any step fails, treat the trial as no-go until rollback is fixed and re-tested.
+
+## Acceptance Checklist Before Any Real Protected URL
+
+A protected owner URL is no-go until every item below has explicit evidence:
+
+- local smoke: localhost-only run still passes unauthenticated generic denial and authenticated read-only
+  `200` for Web Home and at least one `cv_...` conversation detail;
+- sanitized screenshot: owner-reviewable screenshot or HTML proof shows useful workspace/conversation
+  state and no token, raw ID, path, logs, terminal, or conversation-sensitive leak;
+- unauthorized generic `404` or equivalent safe denial for `/`, conversation handles, stale handles,
+  and unsafe route shapes;
+- authenticated `200` only after the owner auth/session gate and owner binding filter pass;
+- no token in URL, browser-visible path, rendered HTML, headers, screenshots, or logs;
+- no raw session ID, chat/user/platform ID, callback payload, local path, config path, artifact backing
+  path, env value, stack trace, terminal output, or app-server payload in default UI/error paths;
+- owner-only ingress proof: private-network membership, allowlist, or equivalent proof exists before
+  network exposure;
+- brute-force control proof: rate/lockout or ingress throttle exists for auth attempts;
+- shutdown proof: Web server stopped, exposure layer stopped, token/session rotated, local port closed,
+  no leftover process, and protected endpoint unreachable or generically denied.
+
+## Next Implementation Slices
+
+This phase is docs-only. Later slices should remain narrow and independently reversible:
+
+1. **Config seam.** Add typed config for protected access mode, token/session lifetime, binding filter,
+   ingress mode label, and audit destination; default disabled.
+2. **Explicit command flag.** Add a guarded command flag/env that must be present before non-local
+   exposure is even attempted; localhost remains default.
+3. **Auth/session hardening.** Replace or wrap the local bearer gate with a short-lived, non-URL,
+   revocable browser session suitable for owner phone validation.
+4. **Tunnel/private-network wrapper.** Add one wrapper for the approved first path only; do not add
+   reverse proxy, public DNS, and tunnel variants in one slice.
+5. **Health and shutdown check.** Provide a command or runbook that proves listener state, auth denial,
+   binding status, process identity, and shutdown result without printing secrets.
+6. **Smoke proof.** Capture sanitized proof for local authenticated/unauthenticated paths, owner-only
+   ingress, stale handle denial, and shutdown.
+
+Do not combine these slices with actions, uploads/downloads, raw logs/terminal, service auto-start, or
+support-claim wording.

--- a/docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
+++ b/docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
@@ -1,0 +1,333 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/plans/README.md
+children: []
+summary: guardrail and route-to-future-work package for the read-only Web prototype after the first service view-model seam landed
+read_when:
+  - preparing future read-only Web prototype work after the first service view-model seam
+  - deciding which read-only Core/state surfaces a Web prototype may inspect
+  - validating screenshot-first and protected-phone readiness for the Web prototype
+skip_when:
+  - the request is about current Telegram or Feishu shipped behavior
+  - the request asks to implement Web routes, components, servers, auth middleware, or runtime code now
+source_of_truth:
+  - docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
+  - docs/future/web-mvp-scope-and-readiness.md
+  - docs/operations/web-vps-mobile-access-and-security.md
+  - docs/architecture/web-app-preimplementation-contract.md
+-->
+
+# Web Read-Only Prototype Implementation Plan
+
+Status: guardrails landed; first read-only service adapter seam landed; routes/UI/auth/actions not implemented
+Owner: Product / Architecture / Future implementation controller
+Last updated: 2026-04-26
+
+This is the guardrail and route-to-future-work package for a future **read-only Web prototype** of
+Codex Console. The first service-level read-only view-model adapter seam has landed, including Gap1
+final-answer/workspace redaction and the Gap2 pending-interactions read model. Web remains
+future/prototype only; Telegram remains the current stable/default surface; Feishu remains a serious
+current pack with setup and readiness caveats. No Web routes, UI, auth middleware, server, URL,
+screenshots, or action controls are implemented.
+
+The first lane is strictly read-mostly: it may render redacted state after authentication, but it
+must not submit tasks, answer approvals/questions, interrupt turns, upload files, switch/resume
+sessions, perform arbitrary writes, expose a raw terminal, support multi-user/team access, expose an
+unauthenticated URL, or claim public Web support.
+
+## Goal And Non-Goals
+
+### Goal
+
+Plan a small, non-public Web shell that lets the owner inspect shared Codex Bridge Core state from a
+phone-sized browser view after login. The product shape is workspace/session/conversation centric,
+closer to T3 Chat, Code Web, or the Codex app than to a generic dashboard: the owner starts from
+workspaces, opens a workspace's sessions/conversations, and reads conversation results. Runtime,
+readiness, and access state support that flow as context and gates before any browser control actions
+are added.
+
+### First-lane success means
+
+- controller can capture mobile-sized screenshots/recordings for owner review without exposing a
+  live owner URL;
+- after auth/access control is ready, the owner can open a protected URL from a phone and inspect the
+  same read-only pages;
+- Web Home, Workspace Sessions, Conversation Detail / Results, Runtime, Interactions, and Setup /
+  Readiness render safe empty, unavailable, degraded, and failure states;
+- final answers are visually separate from progress/recent output;
+- artifacts are represented by safe descriptors and availability states, not raw backing paths;
+- readiness uses declared/configured/observed/UX-exposed levels instead of a single support boolean.
+
+### Non-goals
+
+- Web/App support claim, public release, SaaS or hosted control plane.
+- Native App implementation.
+- Text task submission, approval/question answers, interrupt, upload, switch/resume, archive,
+  unarchive, rename, pin, rollback, compact, model selection, or any other action control.
+- Raw terminal, shell prompt, command entry, or unbounded command output.
+- Arbitrary project file contents, editing, diffs, or writes.
+- Multi-user, team roles, unauthenticated access, or anonymous shared links.
+- Repository/package/CLI/service/config/state/environment-variable renames.
+- Copying Telegram callback ids, Feishu card ids, or Web component ids into Core contracts.
+
+## Approved Page List
+
+All pages are authenticated and read-only. If auth is not implemented or fails closed, the only
+allowed owner review path is screenshots/recordings captured by the controller.
+
+| Page | Route label for planning | What it shows in read-only mode | Must not show |
+|---|---|---|---|
+| Web Home | `/` or `/home` | workspace list, active workspace/session summary, recent conversations, active turn summary, compact runtime/readiness badges, degraded warnings, last update time | task box, action buttons, raw paths, raw logs, public support wording, admin-console framing |
+| Workspace Sessions | `/workspaces` or `/workspaces/:workspaceId/sessions` | active workspace/session, per-workspace conversation/session rows, archived/pinned labels if already known, empty/error/unavailable states, continuation eligibility as text only | switch/resume controls, browse/write controls, raw workspace paths |
+| Conversation Detail / Results | `/sessions/:sessionId` or `/conversations/:conversationId` | conversation/session detail, final answer body or safe summary, progress/result separation, artifact descriptors, availability/expired/unavailable/failure states, safe preview/download eligibility where configured | resume controls, raw artifact paths, unrestricted file reads, upload widgets, project diffs |
+| Runtime | `/runtime` | compact and detailed status; idle/queued/running/blocked/done/failed/degraded/unhealthy/recovered states; recent output summary; app-server health summary | raw terminal, shell controls, verbose logs, protocol dumps, interrupt button |
+| Interactions | `/interactions` | pending/resolved/expired/stale/duplicate/failed interaction cards with redacted title/body/options summaries and source turn/session labels | approve/reject/answer inputs, stale-click replay, raw payloads |
+| Setup / Readiness | `/setup` or `/readiness` | declared/configured/observed/UX-exposed matrix, auth/access status, operator binding status, exposure/shutdown status, missing gate list | secrets, tokens, raw env values, config file paths, provider debug blobs |
+
+## Candidate Core And State Surfaces To Inspect
+
+These paths were verified against the current repo docs and source tree on 2026-04-26. They are
+candidate read/adaptation surfaces for Web prototype work, not a requirement to import all of them.
+The first adapter seam has landed; future work should continue from the narrowest existing owner and
+remain read-only unless separately approved.
+
+| Prototype need | Candidate surfaces to inspect first | Why they matter |
+|---|---|---|
+| Neutral Core terms and ids | `src/core/domain/common.ts`, `src/core/domain/context.ts`, `src/core/domain/records.ts`, `src/core/domain/binding.ts` | project/session/turn/operator vocabulary and persisted-record boundaries |
+| Surface/view semantics | `src/core/interaction-model/surface.ts`, `src/core/interaction-model/runtime.ts`, `src/core/interaction-model/interaction.ts`, `src/core/interaction-model/terminal.ts`, `src/core/interaction-model/media.ts` | neutral runtime, interaction, terminal/progress, and media descriptor meanings |
+| Workflow reduction | `src/core/workflow/runtime-workflow.ts`, `src/core/workflow/interaction-workflow.ts`, `src/core/workflow/terminal-workflow.ts`, `src/core/workflow/interaction-support.ts` | reducers likely closest to reusable Core output for Web view models |
+| SQLite facade and records | `src/state/store.ts`, `src/state/store-records.ts`, `src/state/store-sessions.ts`, `src/state/store-pending-interactions.ts`, `src/state/store-runtime-artifacts.ts`, `src/state/store-auth.ts` | persisted sessions, recent projects, interactions, final-answer/runtime artifacts, readiness snapshots, and operator binding |
+| Project/session orchestration evidence | `src/service/session-project-coordinator.ts`, `src/service/project-browser-coordinator.ts`, `src/service/current-session-card-controller.ts` | current shipped semantics for active/recent sessions and safe project visibility |
+| Runtime and progress evidence | `src/service/runtime-surface-controller.ts`, `src/service/runtime-surface-state.ts`, `src/service/runtime-surface-trace-sink.ts`, `src/activity/tracker.ts`, `src/activity/types.ts` | current runtime status, progress aggregation, inspect fields, and trace boundaries |
+| Interactions evidence | `src/service/interaction-broker.ts`, `src/interactions/normalize.ts` | pending/resolved/expired/stale/failed interaction lifecycle and safe normalized text |
+| Final answers/artifacts evidence | `src/service/turn-coordinator.ts`, `src/service/turn-artifacts.ts`, `src/state/store-runtime-artifacts.ts` | final-answer separation, artifact descriptors, delivery/recovery clues |
+| App-server and health evidence | `src/codex/app-server.ts`, `src/codex/notification-classifier.ts`, `src/service/app-server-health-guard.ts` | health/degraded state and protocol event classification; do not expose raw protocol dumps |
+| Setup/readiness evidence | `src/readiness.ts`, `src/config.ts`, `src/paths.ts`, `src/packs/contract.ts`, `src/packs/registry.ts`, `src/packs/catalog.ts` | configured/observed readiness, active-pack status, and safe setup gaps |
+
+Implementation guidance for future Web prototype work:
+
+- prefer a small read-only view-model layer over direct Web rendering from service coordinators;
+- read through existing public facades where possible, especially the store facade;
+- redact at the adapter boundary, before data reaches page rendering;
+- do not expose local filesystem paths, environment values, raw logs, protocol payloads, or transport
+  identifiers by default;
+- treat Telegram and Feishu UI files as evidence of current presentation, not as Web contracts to copy.
+
+## Data Contract And View-Model Sketches
+
+The sketches below are intentionally neutral field lists, not TypeScript interfaces. Future code may
+rename fields, but it must preserve the safety properties: stable opaque ids, redacted labels,
+summary text, explicit unavailable/failure states, and no secrets/raw paths/raw logs.
+
+### Shared envelope for every page
+
+| Field | Meaning | Safety rule |
+|---|---|---|
+| `page_id` | stable page key such as web_home, workspace_sessions, runtime, or readiness | not user-controlled |
+| `generated_at` | server timestamp for the view model | no local timezone/path leakage |
+| `operator` | authorized operator display label and binding status | no platform credential or chat/tenant secret |
+| `auth_state` | authenticated, denied, expired, or unavailable | denied state reveals no project/runtime details |
+| `environment` | local/protected-url/screenshot phase and active pack label | no hostnames, IPs, tokens, or config paths by default |
+| `warnings` | redacted degraded/failure summaries | no raw stack traces or protocol dumps |
+| `links` | internal page links only | no public unauthenticated links |
+
+### Web Home view model
+
+| Field | Meaning | Empty/unavailable behavior |
+|---|---|---|
+| `active_workspace` | opaque id, display label, optional redacted project label, availability | show unavailable/unknown without raw path |
+| `active_session` | opaque id, title/summary, last activity, archived/pinned labels | show no active session state |
+| `recent_conversations` | bounded rows with opaque ids, titles/summaries, last activity, state, artifact/final-answer hints | show empty state without implying setup failure |
+| `active_turn` | opaque id, lifecycle state, progress summary, active interaction count | show idle when no active turn exists |
+| `runtime_compact` | status, health color/label, last event time, degraded flags | show unknown/unhealthy with next check |
+| `readiness_summary` | counts by readiness level and missing gate labels | show configured/observed gaps explicitly |
+| `recent_final_answer` | answer id, summary, time, artifact count | omit body if not safely available |
+
+### Workspace Sessions view model
+
+| Field | Meaning | Safety rule |
+|---|---|---|
+| `workspaces` | rows with opaque id, display label, availability, recent-session/conversation count | path metadata must be redacted or omitted |
+| `sessions` | rows with opaque id, workspace label, title, last activity, state, archived/pinned text | no resume/switch action target exposed as a control |
+| `active_refs` | active project/session ids for highlighting only | not a write capability |
+| `empty_state` | no workspaces, no sessions, scan unavailable, or permission issue | generic message, no sensitive path |
+| `errors` | redacted scan/store errors | no stack trace or filesystem dump |
+
+### Runtime view model
+
+| Field | Meaning | Safety rule |
+|---|---|---|
+| `compact_status` | idle, queued, running, blocked, done, failed, degraded, unhealthy, recovered | use defined vocabulary only |
+| `detailed_status` | active turn/session labels, app-server health, pending interaction count, delivery warnings | summarize, do not dump protocol payloads |
+| `recent_output` | bounded progress summaries with timestamps and severity | not a raw terminal stream |
+| `recovery` | recovered/degraded notes and next safe observation step | no restart/interrupt controls |
+| `delivery_outcomes` | created, updated, deferred, partially delivered, failed, rate-limited, fallback, degraded | show failed/degraded outcomes visibly |
+
+### Interactions view model
+
+| Field | Meaning | Safety rule |
+|---|---|---|
+| `interactions` | cards with opaque id, family, title, redacted body summary, state, source turn/session | no response form or answer button |
+| `states` | pending, resolved, expired, stale, duplicate, failed, canceled, superseded | terminal outcomes visible even without actions |
+| `expiry` | stale/expiry time or unavailable marker | no raw callback payload |
+| `options_summary` | count and safe labels only where helpful | no secret values, no action submit payload |
+| `failure_summary` | redacted reason and recovery visibility | no stack trace/protocol dump |
+
+### Conversation Detail / Results view model
+
+| Field | Meaning | Safety rule |
+|---|---|---|
+| `conversation` | conversation/session id, workspace label, title, last activity, state, source turn labels | no resume/switch action target exposed as a control |
+| `answers` | answer id, turn/session/workspace labels, created time, summary, body availability | body redacted or unavailable when unsafe |
+| `answer_detail` | long-form final answer separate from progress | never sourced from raw terminal output alone |
+| `artifacts` | artifact id, label, media type, size if known, previewability, retention/availability | no local backing path or temp path |
+| `artifact_state` | pending, available, unavailable, expired, rejected, failed | unavailable is explicit, not a broken link |
+| `delivery_outcomes` | final answer/artifact rendering outcomes | failed/partial/fallback shown plainly |
+
+### Setup / Readiness view model
+
+| Field | Meaning | Safety rule |
+|---|---|---|
+| `capabilities` | rows for auth, operator binding, project/session visibility, runtime, interactions, final answers, artifacts, degraded outcomes, screenshot evidence, protected phone URL | each row reports declared/configured/observed/UX-exposed |
+| `auth_access` | login configured, unauthorized rejected, session revoke/logout observed, operator binding status | no cookies, tokens, session ids, raw env values |
+| `exposure` | screenshot-only, protected URL ready, phone trial observed, shutdown drill status | no public hostname required in screenshots |
+| `forbidden_data_check` | pass/fail/unknown for secrets, paths, raw logs, terminal, uploads/actions | failure blocks URL exposure |
+| `next_gate` | owner-review, auth hardening, screenshot evidence, protected phone trial, or no-go | no support claim wording |
+
+## Auth And Access-Control Assumptions Before URL Exposure
+
+A live URL is not allowed until all assumptions below are true or the owner explicitly rejects the
+coding task as not ready:
+
+1. unauthenticated requests render only a generic denied/login state and no bridge data;
+2. the prototype is bound to one high-trust operator/control surface;
+3. login, logout, expiry, and revocation can be verified without code changes;
+4. session state is server-side or equivalently protected; durable browser secrets are minimized;
+5. CSRF/action protection is present before any future state-changing route exists, even though the
+   first lane renders no action controls;
+6. the Setup / Readiness page can say whether auth/access is declared, configured, observed, and
+   UX-exposed without printing secrets;
+7. the exposure mechanism is temporary or reversible, and preferably allowlisted, private-networked,
+   or otherwise constrained;
+8. the shutdown path is known before the URL is shared with the owner.
+
+If any of these assumptions fail, validation remains screenshot/recording-only.
+
+## Screenshot-First Validation Plan
+
+Phase 1 validates information architecture and safety before owner URL exposure.
+
+| Step | Evidence to capture | Pass condition |
+|---|---|---|
+| Seed or observe representative states | screenshots for empty, idle, running, blocked, done, failed, degraded/unhealthy, recovered, artifact unavailable/expired, interaction stale/failed | every approved page has at least one meaningful mobile-sized state |
+| Mobile viewport review | phone-width screenshots or recordings of all pages | no horizontal scrolling for core content; final answer readable separately from progress |
+| Forbidden-data review | screenshots of Web Home, runtime, conversation results/artifacts, setup, and error states | no secrets, raw env, raw paths, terminal controls, verbose logs, upload/action controls |
+| Readiness review | setup/readiness screenshots | capability rows show declared/configured/observed/UX-exposed and next gate |
+| Owner async review | controller shares captured evidence, not a live URL | owner can identify missing/confusing states before exposure |
+
+Screenshot evidence should include the date, environment label, page label, and whether the view is a
+synthetic fixture, live observed state, or degraded fallback. Do not include hostnames, tokens,
+private paths, cookies, or raw logs in the evidence bundle.
+
+## Protected Phone-URL Validation Plan
+
+Phase 2/3 starts only after the screenshot-first gate and auth/access-control assumptions pass.
+
+| Step | Pass condition | No-go condition |
+|---|---|---|
+| Pre-exposure auth check | unauthenticated phone/browser access sees no Web Home or state | any state renders before login |
+| Operator login | owner can authenticate from phone and logout/revoke works | access is anonymous, shared, or not revocable |
+| Web Home phone check | workspace list, active session, recent conversations, runtime/readiness badges, and warnings are readable | horizontal scrolling or confusing state labels block use |
+| Runtime phone check | running/blocked/done/failed/degraded/unhealthy/recovered are clear without raw terminal | raw output or interrupt/action affordance appears |
+| Interactions phone check | pending/resolved/expired/stale/duplicate/failed are visible as read-only | any approval/answer submit control appears |
+| Answers/artifacts phone check | final answer is readable; artifact availability/unavailability is understandable | raw artifact path or unsafe download appears |
+| Setup/readiness phone check | auth/access and missing gates are understandable | support claim or secret/config leak appears |
+| Shutdown drill | controller can disable exposure and owner sees denied/unreachable expected state | exposure cannot be quickly stopped |
+
+Protected phone validation is still prototype validation. It does not imply current Web support.
+
+## Explicit Forbidden Implementation Areas For First Lane
+
+The first coding task must not implement or expose:
+
+- task submission or continuation text boxes;
+- approval/question answer controls;
+- interrupt, rollback, compact, model, skills, plugins, apps, MCP, account, or admin action controls;
+- project/session switch, resume, archive, unarchive, rename, pin, browse-write, or file-edit flows;
+- uploads, drag/drop, paste-to-upload, browser file picker, or generated write-back flows;
+- raw terminal, command entry, shell prompt, raw unbounded output, verbose logs, stack traces,
+  protocol payload dumps, or provider debug blobs;
+- unauthenticated Web Home/state pages, public URLs, anonymous sharing, multi-user/team roles, or public support
+  claims;
+- local sensitive paths, home/temp/socket/config paths, raw artifact backing paths, tokens, env vars,
+  cookies, session ids, OAuth secrets, bot tokens, or tunnel credentials;
+- repository/package/CLI/service/config/state/environment-variable renames;
+- native App implementation.
+
+If a future implementer believes one of these is required to make the prototype useful, stop and ask
+for owner approval before expanding scope.
+
+## Bite-Sized Future Coding Milestones
+
+This list is historical sequencing plus gated future work. The first service adapter seam has landed;
+the next safe implementation item after closeout is Gap3 neutral artifact catalog/descriptors, still
+read-only and without routes, UI, auth, servers, writes, downloads, uploads, or action controls.
+
+1. **Read-only view-model inventory and first adapter seam — landed.** The service-level adapter
+   seam, Gap1 final-answer/workspace redaction, and Gap2 pending-interactions read model exist; no
+   Web routes yet.
+2. **Prototype shell and auth-denied skeleton.** Add the minimal Web process/page shell with a generic
+   denied/login placeholder; prove unauthenticated access sees no bridge data.
+3. **Shared redaction helpers.** Implement redaction for paths, env/secrets, protocol/log text, and
+   artifact handles before any page rendering.
+4. **Web Home and Setup / Readiness pages.** Render workspace-oriented compact state and readiness
+   matrix from safe fixtures or read-only adapters; include empty/unavailable/degraded states.
+5. **Workspace Sessions page.** Render workspace list, active/recent conversation rows, and safe
+   empty/error states without switch/resume controls or raw paths.
+6. **Conversation Detail / Results page.** Render conversation/session detail, final-answer history,
+   and safe artifact descriptors without raw paths, unrestricted file reads, or resume controls.
+7. **Runtime page.** Render compact/detailed runtime, recent output summaries, health/degraded states,
+   and delivery outcomes without terminal or interrupt controls.
+8. **Interactions page.** Render read-only interaction cards and terminal outcomes without response
+   forms.
+9. **Screenshot harness.** Add a deterministic way for the controller to capture mobile-sized states
+   for every page, including degraded/failure examples.
+10. **Protected phone trial hardening.** Add or configure reversible exposure, auth verification,
+    logout/revoke check, and shutdown drill evidence.
+
+Do not combine action controls with these tasks. The first action lane requires a separate owner
+approval package.
+
+## Verification Commands And Evidence For Future Implementation
+
+Minimum local checks for read-only Web view-model follow-up work:
+
+| Check | Expected evidence |
+|---|---|
+| `git diff --check` | no whitespace errors |
+| `npm run check` | TypeScript passes |
+| targeted unit tests for new view-model/redaction code | pass output and covered redaction cases |
+| route/page smoke from local controller environment | unauthenticated state denied; authenticated read-only pages render |
+| manual forbidden-data review | screenshots or notes showing no secrets/raw paths/raw logs/terminal/actions |
+| manual relative `.md` link check for any doc changes | every new relative doc link resolves, or note no docs changed |
+| screenshot evidence bundle | mobile-sized screenshots/recordings for all approved pages and required states |
+| protected phone trial evidence, only after auth gate | owner phone login/logout, denied unauthenticated access, shutdown drill result |
+
+Future implementation evidence should include the environment, date, command output summary, and any
+known no-go condition. Do not paste secrets, raw local paths, or hostnames into verification notes.
+
+## Stop/Go Gates Before Expanding Beyond The Landed Seam
+
+| Gate | Go condition | Stop condition |
+|---|---|---|
+| Owner approval | owner approves the next read-only follow-up, currently Gap3 artifact catalog/descriptors | owner has not reviewed/approved the follow-up |
+| Scope lock | first lane remains read-only/read-mostly and prototype-only | any action control, upload, raw terminal, multi-user, or support claim enters scope |
+| Surface inventory | implementer identifies exact read facades and redaction boundary | implementation would scrape Telegram UI output or raw logs as product state |
+| Auth/access design | unauthenticated access denial and single-operator binding are designed before URL exposure | URL would show state before login or binding is unclear |
+| Data safety | redaction strategy covers secrets, raw paths, logs, protocol dumps, and artifacts | view models can carry forbidden data to pages by default |
+| Screenshot path | controller can capture page evidence without owner URL exposure | live URL is needed just to evaluate basic IA |
+| Verification budget | coding task includes `git diff --check`, `npm run check`, targeted tests, and manual screenshot/link checks | no verifiable acceptance path exists |
+
+If a stop condition is hit, keep Web as planning/prototype only and return to owner review rather
+than coding around the gate.

--- a/docs/plans/2026-04-26-web-viewmodel-inventory.md
+++ b/docs/plans/2026-04-26-web-viewmodel-inventory.md
@@ -1,0 +1,369 @@
+<!-- docmeta
+role: leaf
+layer: 3
+parent: docs/plans/README.md
+children: []
+summary: implementation-facing inventory of read-only Core/state/source facades and landed service adapter seam for the future workspace/session-centric Web prototype
+read_when:
+  - understanding the landed first read-only Web view-model adapter and remaining read-only gaps
+  - deciding which current bridge state/runtime surfaces may feed Web Home, workspaces, sessions, conversation results, runtime, or readiness
+  - checking redaction gaps before rendering future Web prototype data
+skip_when:
+  - the request is about current Telegram or Feishu shipped behavior
+  - the request asks to add Web routes, auth middleware, task submission, approval answers, interrupts, uploads, or writes
+source_of_truth:
+  - docs/plans/2026-04-26-web-viewmodel-inventory.md
+  - docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
+  - docs/future/web-mvp-scope-and-readiness.md
+  - docs/operations/web-vps-mobile-access-and-security.md
+-->
+
+# Web Read-Only View-Model Inventory
+
+Status: planning inventory landed; first read-only service adapter seam plus Gap1/Gap2 landed; no Web routes/UI/auth/server
+Owner: Product / Architecture / Future implementation controller
+Last updated: 2026-04-26
+
+This inventory names the current bridge/server Core, state, and service surfaces that a future
+read-only Web prototype should adapt into safe page view models. It is now also a planning/history
+artifact for the landed first service-level read-only adapter seam: the initial adapter exists, Gap1
+final-answer/workspace redaction exists, and Gap2 pending-interactions read model exists. It does not
+authorize Web routes, servers, auth middleware, task submission, approval answers, interrupts,
+uploads, switch/resume controls, arbitrary writes, raw terminal access, public URLs, multi-user
+access, or a Web support claim.
+
+Telegram remains the stable/default shipped surface. Feishu remains a serious current pack with
+setup/readiness caveats. Web remains future/prototype only.
+
+## 1. Executive Summary
+
+The first useful Web slice is a read-only view-model adapter that composes existing bridge
+state and in-memory runtime state into redacted page DTOs. It should not render directly from
+Telegram UI code, Feishu card code, raw app-server payloads, SQLite rows, or local filesystem paths.
+
+Recommended first seam: the small read-only service adapter and unit tests have landed, to be
+consumed later by any Web route/component layer. This seam is narrow enough to use the existing `BridgeStateStore` public facade, current
+`TurnCoordinator`/`ActivityTracker` read getters, readiness snapshots, pack capability metadata, and
+safe Core view semantics without creating a Web server or changing runtime behavior.
+
+The landed adapter should continue to return explicit unavailable/degraded states when data is missing. It should
+prefer persisted bridge rows for workspaces, sessions, interactions, final-answer delivery records,
+notices, and readiness; use active in-memory runtime getters only for live turns; and keep any
+app-server thread reads optional and redacted.
+
+## 2. Product Shape: Home / Workspaces / Sessions-Conversations / Detail-Results
+
+The product shape is workspace/session/conversation-centric, similar in spirit to a chat/workspace
+product rather than a generic admin surface:
+
+1. **Web Home**: recent and active workspaces, active session/conversation, recent conversations,
+   current turn summary, compact contextual runtime/readiness badges, and warnings.
+2. **Workspaces**: workspace rows derived from recent projects, scanned projects, and session stats,
+   with redacted labels and availability.
+3. **Workspace Sessions / Conversations**: per-workspace session/conversation rows, active/highlighted
+   refs, archived/pinned labels where already known, and safe empty/error/unavailable states.
+4. **Conversation Detail / Results**: one session/conversation, final-answer records separate from
+   progress, persisted delivery state, and artifact descriptors where known.
+5. **Contextual Runtime Status**: compact and detailed runtime health/progress as supporting context,
+   not the landing-page purpose.
+6. **Setup / Readiness Guardrails**: declared/configured/observed/UX-exposed capability rows,
+   auth/binding status, exposure posture, and missing gates.
+
+No first-lane page should expose task boxes, approval/answer controls, interrupt controls, upload
+widgets, switch/resume controls, raw terminal output, raw logs, raw payloads, raw paths, or public Web
+support wording.
+
+## 3. Exact Source Surfaces Inspected
+
+### Core vocabulary and semantic view contracts
+
+- `src/core/domain/common.ts`: session status, failure reason, runtime notice type, pending interaction
+  kind/state, terminal result kind, terminal delivery state.
+- `src/core/domain/context.ts`: session display context, session presentation context, interaction ref,
+  terminal result refs.
+- `src/core/domain/records.ts`: persisted interaction and terminal-result record shape.
+- `src/core/domain/binding.ts`: neutral platform user/chat/binding refs and platform resolution.
+- `src/core/interaction-model/runtime.ts`: runtime status card, inspect, hub, command-entry, and
+  controls view fields.
+- `src/core/interaction-model/interaction.ts`: approval/question/resolved/expired card fields.
+- `src/core/interaction-model/terminal.ts`: terminal-result delivery and recent-output entry fields.
+- `src/core/interaction-model/media.ts`: media descriptor and resolved asset fields; includes unsafe
+  `localPath` that must not cross the Web boundary.
+- `src/core/workflow/runtime-workflow.ts`: visible runtime state, blocked reason, status card, inspect,
+  rollback, and preferences reducers.
+- `src/core/workflow/interaction-workflow.ts`: normalized interaction to surface card reducer.
+- `src/core/workflow/terminal-workflow.ts`: final-answer/plan-result delivery and recent-output reducers.
+- `src/core/workflow/interaction-support.ts`: safe summaries for answered interactions and permission
+  prompts.
+
+### Store facade and persisted records
+
+- `src/state/store.ts`: public `BridgeStateStore` facade, including auth, sessions, runtime notices,
+  current session cards, terminal/final-answer views, pending interactions, turn input sources, and
+  readiness snapshot methods.
+- `src/state/store-records.ts`: auth, binding, session, recent project, scan cache, and session-project
+  stat row mappings.
+- `src/state/store-sessions.ts`: session/project read methods and sorting for `listSessions`,
+  `getActiveSession`, `listSessionsWithThreads`, `listRecentProjects`, `listProjectScanCache`, and
+  `listSessionProjectStats`.
+- `src/state/store-pending-interactions.ts`: interaction rows, prompt/response JSON persistence,
+  unresolved/by-chat/by-turn read methods, and terminal states.
+- `src/state/store-runtime-artifacts.ts`: runtime notices, current session cards, terminal/final-answer
+  views, turn input source, and readiness snapshot persistence.
+- `src/state/store-auth.ts`: authorized user, pending authorization, and chat binding reads.
+- `src/types.ts`: row and snapshot field definitions used by the public store facade.
+
+### Current orchestration/runtime evidence
+
+- `src/service/session-project-coordinator.ts`: current active session, status, where, session list,
+  project picker, archive/rename/pin semantics, and path-label rendering evidence. Use as behavior
+  evidence only; do not import Telegram UI methods for Web view models.
+- `src/service/project-browser-coordinator.ts`: current browse and file-preview behavior. Treat as
+  forbidden first-lane evidence because it reads local directories/files and carries absolute paths.
+- `src/service/current-session-card-controller.ts`: current active-session presentation sync evidence.
+- `src/service/runtime-surface-controller.ts`: live runtime hub/status/inspect/final-answer rendering
+  orchestration and public read getters reachable through dependencies.
+- `src/service/runtime-surface-state.ts`: runtime card state, command summaries, throttling, and cleaned
+  error-summary helpers.
+- `src/service/runtime-surface-trace-sink.ts`: trace log shape; not a Web data source because traces
+  may include ids and operational internals.
+- `src/activity/tracker.ts` and `src/activity/types.ts`: `getStatus`, `getInspectSnapshot`,
+  `getStreamSnapshot`, activity status, inspect snapshot, recent transitions, progress summaries,
+  pending/answered interaction summaries, token usage, and collab-agent snapshots.
+- `src/service/interaction-broker.ts`: read helpers for pending/answered summaries and lifecycle
+  evidence; action handlers are forbidden in the first lane.
+- `src/interactions/normalize.ts`: normalized approval, permissions, questionnaire, and elicitation
+  fields; required for safe redaction of stored `promptJson`.
+- `src/service/turn-coordinator.ts`: active-turn and recent-activity read getters; start/interrupt/server
+  request handlers are forbidden in the first lane.
+- `src/service/turn-artifacts.ts`: read-mostly final-answer extraction from app-server history;
+  useful as fallback evidence, but not the first default because it reaches app-server history and raw
+  turns.
+- `src/codex/app-server.ts`: read-capable thread list/read/resume methods and many mutating methods;
+  Web view-model code must avoid mutators and redact `cwd`/raw turns if optional reads are ever used.
+- `src/codex/notification-classifier.ts`: protocol notification classification feeding runtime state;
+  do not expose raw notifications or payloads.
+- `src/service/app-server-health-guard.ts`: app-server health sampling shape for contextual health only.
+- `src/readiness.ts`: readiness probe, persisted snapshot writing, pack checks, shared checks, app-server
+  availability, and issues.
+- `src/config.ts`, `src/paths.ts`: config/path shapes; useful for knowing what not to expose.
+- `src/packs/contract.ts`, `src/packs/registry.ts`, `src/packs/catalog.ts`: active-pack definition,
+  capability snapshots, health checks, and supported-pack metadata.
+
+## 4. View Inventory
+
+### 4.1 Web Home
+
+| Candidate source/facade | Fields to adapt | Redaction needs | Current gaps |
+|---|---|---|---|
+| `BridgeStateStore.listChatBindings()`, `getAuthorizedUser()`, `getChatBinding()` | authorized/bound operator state, active session id per binding | hide platform user ids, chat ids, tenant/resource ids; expose only binding status and optional display label | no Web auth/session binding exists; current binding is platform chat/user oriented |
+| `BridgeStateStore.getActiveSession(chatId)`, `listSessions(chatId, { archived: false, limit })` | active session, recent conversations, session id, display name, project display label, status, failure reason, last activity, last turn id/status, archived flag | redact `projectPath`; avoid selected model/reasoning unless explicitly allowed; expose opaque ids | every read currently needs a chat id/binding; Web needs a single-operator binding resolver |
+| `BridgeStateStore.listRecentProjects()`, `listSessionProjectStats()` | workspace rows, recent workspace count hints, last-used timestamps, pinned/source labels | redact path, scan root, and home-relative details; use alias/project name as label | stable opaque workspace id must be derived without exposing path; dedupe recent/scan/stat rows |
+| `TurnCoordinator.listActiveTurns()`, `getActiveInspectActivity(sessionId)`, `ActivityTracker.getStatus()` | active turn state, latest progress, blocked reason, final-message availability, pending interaction count | summarize progress; no raw command output, terminal stream, or protocol payload | live data is in-memory only; after restart, Web Home must show degraded/unknown for active turn |
+| `BridgeStateStore.listFinalAnswerViews(chatId)` | recent final-answer hint, answer id, kind, delivery state, created time, page/preview availability | sanitize Telegram HTML, do not expose message id or action-consumed semantics as controls | stored final answers are presentation-shaped HTML pages, not neutral answer bodies |
+| `BridgeStateStore.getReadinessSnapshot()`, `countRuntimeNotices()` | compact readiness/status badge, missing gates, notice count | hide paths, env-derived details, pids unless reduced to health labels | no declared/configured/observed/UX-exposed matrix persisted yet |
+
+### 4.2 Workspaces
+
+| Candidate source/facade | Fields to adapt | Redaction needs | Current gaps |
+|---|---|---|---|
+| `BridgeStateStore.listRecentProjects()` | workspace id, label from alias/name, pinned, source, last used, last success | never expose `projectPath`; avoid source roots | path-derived stable ids need a salted/opaque mapping strategy |
+| `BridgeStateStore.listProjectScanCache()` | discovered workspace candidates, exists flag, confidence, detected marker labels | hide `projectPath` and `scanRoot`; marker names should be bounded and non-sensitive | scan cache may contain stale/missing paths; Web must show unavailable/missing states |
+| `BridgeStateStore.listSessionProjectStats()` | session/conversation count and last-used per workspace | hide grouping path; use redacted project labels | grouping by path/name is internal; view model needs dedupe against recent project rows |
+| `SessionProjectCoordinator.projectDisplayName()` evidence | display-name precedence: project alias over project name | no path label | method lives in Telegram-oriented coordinator; copy semantics into adapter instead of importing coordinator UI |
+| `ProjectBrowserCoordinator` evidence | browse roots and file previews | do not use in first coding task | browse/preview reads filesystem and should stay outside first read-only inventory lane |
+
+### 4.3 Workspace Sessions / Conversations
+
+| Candidate source/facade | Fields to adapt | Redaction needs | Current gaps |
+|---|---|---|---|
+| `BridgeStateStore.listSessions(chatId, { archived, limit })` | rows with session id, display name, workspace label, status, failure reason, archived state, created/last-used times, last turn id/status | hide `chatId`, `telegramChatId`, `threadId` by default; redact `projectPath`; selected model/reasoning optional only | no direct list-by-workspace public method; adapter must filter/group by internal path without returning it |
+| `BridgeStateStore.getActiveSession(chatId)` and `getCurrentSessionCard(chatId)` | active/highlighted refs and last current-card update | hide message id; active ref is not a switch capability | current-session card is Telegram presentation state, not a Web contract |
+| `BridgeStateStore.listSessionsWithThreads()` | cross-binding conversation candidates with thread ids | hide thread ids unless needed for internal linking | may cross operator/binding if used blindly; prefer binding-scoped list first |
+| `TurnCoordinator.getRecentActivity(sessionId)` | recent completed/live activity for a row | summarize status and final-message availability | in-memory/recent only, may be absent after restart |
+| `CodexAppServerClient.listThreads({ cwd })` optional future fallback | app-server conversations by cwd, name, preview, created/updated, status | redact `cwd`; avoid raw status; do not call mutators | requires app-server availability and mapping back to bridge sessions; not first default |
+
+### 4.4 Conversation Detail / Results
+
+| Candidate source/facade | Fields to adapt | Redaction needs | Current gaps |
+|---|---|---|---|
+| `BridgeStateStore.getSessionById(sessionId)` | conversation/session title, workspace label, status, timestamps, last turn id/status | hide chat/platform ids, thread id, project path, selected model unless approved | direct session id must be authorized against the operator binding before rendering |
+| `BridgeStateStore.listFinalAnswerViews(chatId)`, `getFinalAnswerView(answerId, chatId)` | answer id, session/thread/turn linkage, kind, delivery state, created time, preview/pages availability | sanitize `previewHtml` and `pages`; do not expose delivery message id; no Telegram action controls | body is Telegram-rendered HTML pages; no neutral markdown/body store yet |
+| `TerminalResultViewRow.pages` and `previewHtml` | final answer body/pages if considered safe | remove links/actions/HTML not allowed by Web sanitizer; mark unavailable if unsafe | no sanitizer/neutral renderer exists for Web |
+| `TurnArtifactsFromHistory` and `extractTurnArtifactsFromHistory()` optional fallback | final message, proposed plan, compaction/review fallback metadata | raw app-server turns must not be rendered; avoid raw protocol details | app-server history access may be unavailable/slow; should be fallback, not first-lane dependency |
+| `BridgeMediaDescriptor` / `ResolvedMediaAsset` evidence | artifact descriptors, media type, size, availability, expiry, failure reason | never expose `localPath`, temp paths, sha unless intentionally approved; platform refs must be opaque | no generated artifact catalog is persisted beyond terminal answer pages and media descriptors |
+| `BridgeStateStore.getTurnInputSource(threadId, turnId)` | voice-input transcript indicator if needed | transcript may be user content; do not show by default on result page | currently only `voice`; not required for first detail/results view |
+
+### 4.5 Contextual Runtime Status
+
+| Candidate source/facade | Fields to adapt | Redaction needs | Current gaps |
+|---|---|---|---|
+| `TurnCoordinator.listActiveTurns()` | active turn refs: session id, chat id, thread id, turn id, tracker | hide chat/thread/turn ids from user-facing display; retain opaque refs internally | active turns disappear after process restart |
+| `TurnCoordinator.getActiveInspectActivity(sessionId)`, `getRecentActivity(sessionId)` | tracker/status card for active/recent sessions | do not expose status-card message id or Telegram reply markup | recent activity is in-memory only |
+| `ActivityTracker.getStatus()` | turn status, runtime state, active item type/label, last activity, blocked reason, final-message availability, error state | summarize labels; no raw terminal chunks; token usage optional and bounded | canonical Web vocabulary must map `idle/starting/running/blocked/interrupted/completed/failed/unknown` to Web status labels |
+| `ActivityTracker.getInspectSnapshot()` | recent transitions, command/file/MCP/web summaries, plan/proposed plan, agents, completed commentary, pending/answered interactions | bounded summaries only; no raw diffs, raw command output, stack traces, protocol payloads, or full token accounting by default | inspect snapshot is rich and easy to overexpose; adapter needs a strict allowlist |
+| `runtime-workflow.ts`, `terminal-workflow.ts` reducers | visible state, blocked reason, recent-output and final-result separation | do not pass HTML directly without Web sanitizer | reducers are surface-oriented but not Web-ready DTOs |
+| `BridgeStateStore.listRuntimeNotices(chatId)`, `countRuntimeNotices()` | restart/app-server/deferred-delivery notices | sanitize HTML/message; hide reply markup | notice messages are presentation-shaped |
+| `AppServerHealthGuard` and readiness snapshot | app-server health/availability label | hide pid/details unless reduced | health guard does not persist rich health history for Web |
+
+### 4.6 Setup / Readiness Guardrails
+
+| Candidate source/facade | Fields to adapt | Redaction needs | Current gaps |
+|---|---|---|---|
+| `BridgeStateStore.getReadinessSnapshot()` | state, checked time, active pack, codex/app-server booleans, pack/shared checks, issues, setup checklist | redact `codexBinResolvedPath`, `voiceFfmpegResolvedPath`, raw pack metadata, env names when sensitive, pids, path-like values | snapshot is operational readiness, not declared/configured/observed/UX-exposed matrix |
+| `readiness.ts` probe output | configured/observed health details and issue categories | expose summaries only | probe can start/probe app-server; Web view model should read persisted snapshot first |
+| `StoreAuth.getAuthorizedUser()`, `listChatBindings()`, `listPendingAuthorizations()` | auth/binding configured and operator binding status | no platform user id, chat id, username unless owner-approved display label | Web auth is not implemented; existing auth is pack-specific |
+| `BridgePackDefinition.capabilities`, `PackHealthReport` | declared pack capabilities, health checks, setup state | missing env names may be sensitive; show capability labels, not secrets | Web itself has no pack definition or capability row yet |
+| `config.ts` and `paths.ts` | know which config/path fields must be blocked | do not render raw env/config/path values | no redaction helper exists yet |
+
+## 5. Recommended First Code Seam
+
+Add the first read-only view-model adapter at the bridge service/read-model boundary, not in Telegram,
+Feishu, or a future route layer.
+
+Recommended file shape for the first coding task:
+
+- `src/service/web-readonly-view-model.ts`
+- `src/service/web-readonly-view-model.test.ts`
+
+Recommended exported seam:
+
+- a pure-ish factory such as `createWebReadonlyViewModelProvider(deps)`;
+- methods such as `getHomeViewModel()`, `listWorkspaceViewModels()`,
+  `listWorkspaceConversationViewModels(workspaceId)`, `getConversationResultViewModel(sessionId)`,
+  `getRuntimeContextViewModel()`, and `getReadinessGuardrailViewModel()`;
+- dependencies injected as read-only facades: `getStore()`, `getReadinessSnapshot()`, optional
+  `listActiveTurns()`, optional `getActiveInspectActivity(sessionId)`, optional
+  `getRecentActivity(sessionId)`, optional pack/capability provider, and clock/id-redaction helpers.
+
+Why this seam:
+
+- it composes persisted store rows plus in-memory runtime state, which neither Core-only types nor Web
+  routes should own;
+- it lets routes/components stay dumb and read-only later;
+- it allows unit tests without starting a Web server, Telegram poller, Feishu runtime, or app-server;
+- it centralizes redaction before page rendering;
+- it avoids copying Telegram UI HTML/button behavior into Web contracts;
+- it can return explicit unavailable/degraded states while the backing runtime source is absent.
+
+Do not add task submission, approval answers, interrupt, upload, switch/resume, archive, rename, pin,
+project browse, file preview, app-server mutators, Web auth, routes, client components, or persistent
+schema changes in this first seam.
+
+## 6. Data That Must Not Be Read Or Exposed
+
+The first Web view-model adapter must not read or expose by default:
+
+- tokens, API keys, OAuth secrets, bot tokens, cookies, session ids, raw env values, tunnel credentials,
+  or provider debug blobs;
+- raw `projectPath`, `scanRoot`, `cwd`, home-directory paths, temp paths, socket paths, config paths,
+  DB paths, log paths, artifact backing paths, or resolved binary paths;
+- `chatId`, `telegramChatId`, Feishu chat/open ids, platform resource ids, callback ids, message ids,
+  reply markup, or tenant identifiers as user-visible fields;
+- raw terminal streams, command-entry controls, shell prompts, unbounded command output, raw diffs,
+  verbose logs, stack traces, request headers, app-server protocol payloads, or notification dumps;
+- raw `promptJson` / `responseJson` without normalized interaction redaction;
+- secret questionnaire answers or hidden answer values;
+- arbitrary project file contents, directory listings, file previews, or upload/download handles unless a
+  later explicit artifact-preview gate approves them;
+- Web support/supportability claims.
+
+The adapter may internally read rows containing paths or ids only when needed for grouping or lookup,
+but it must convert them to opaque ids and redacted labels before returning a view model.
+
+## 7. Remaining Gap List After First Adapter
+
+1. **Web auth/binding is still not implemented.** Existing auth is platform chat/user binding. The
+   adapter uses an injected authorized-operator context and must fail closed when no binding is
+   available.
+2. **Workspace ids are path-backed today.** Recent projects, scan cache, and session stats all key by
+   path. Web needs stable opaque ids and redacted labels.
+3. **No direct list-sessions-by-workspace facade.** The adapter must group/filter sessions internally or
+   a later store read method must be added after review.
+4. **Final answers are stored as Telegram-oriented HTML pages.** Web can render safe availability and
+   sanitized content only after an allowlist/sanitizer decision; otherwise body should be unavailable.
+5. **Gap3 artifact catalog/descriptors is next.** There is no neutral generated-artifact descriptor
+   catalog with retention and availability states; keep the next slice descriptor-only and read-only,
+   with no downloads, uploads, routes, UI, auth, servers, writes, or action controls.
+6. **Runtime live state is in memory.** Active/recent activity from `TurnCoordinator` and
+   `ActivityTracker` is lost after restart; persisted sessions/notices/final answers must carry the
+   degraded fallback.
+7. **Interaction rows store raw JSON.** They need normalization and a strict redaction allowlist before
+   Web display, especially for secret questionnaire fields and permission details.
+8. **Readiness is not yet a four-level matrix.** Persisted readiness describes operational state; the Web
+   setup page needs declared/configured/observed/UX-exposed rows derived by the adapter.
+9. **App-server read methods expose raw cwd/status/turns.** Optional thread reads must be isolated,
+   bounded, timeout-protected, redacted, and kept out of the first default path.
+10. **No Web route/component skeleton exists.** That is intentional; the landed view-model seam and
+    tests do not add routes.
+
+## 8. Landed First Adapter Task And Next Safe Item
+
+The first read-only view-model adapter and tests have landed. Gap1 final-answer/workspace redaction
+and Gap2 pending-interactions read model have also landed. The next safe implementation item after
+closeout is Gap3 neutral artifact catalog/descriptors, still read-only and without routes, UI, auth,
+servers, writes, downloads, uploads, or action controls.
+
+Allowed source files for the landed first adapter task were:
+
+- `src/service/web-readonly-view-model.ts` (new)
+- `src/service/web-readonly-view-model.test.ts` (new)
+- `src/service/AGENTS.md` only if a local router exists and must mention the new owner file
+- `docs/plans/2026-04-26-web-viewmodel-inventory.md` only for follow-up notes
+
+The first slice kept shared type aliases in the adapter file rather than adding a larger architecture.
+
+Forbidden files and areas for the first coding task:
+
+- no `src/telegram/**` or `src/feishu/**` UI changes;
+- no `src/packs/**` runtime changes;
+- no `src/codex/app-server.ts` mutator changes;
+- no `src/state/**` schema or write-method changes;
+- no `src/service/turn-coordinator.ts` action/start/interrupt changes;
+- no project browser/file-preview code;
+- no Web server, route, client component, CSS, auth middleware, proxy, tunnel, upload, task-submit,
+  approval-answer, interrupt, switch/resume, archive, rename, or pin implementation.
+
+Minimum first adapter behavior preserved by tests:
+
+- return safe empty/unavailable states when store, binding, readiness, or runtime data is absent;
+- derive workspace rows from recent projects and session stats without returning paths;
+- derive conversation rows from binding-scoped sessions without returning platform ids or paths;
+- derive conversation detail from session rows and persisted final-answer rows, marking unsafe bodies
+  unavailable until sanitized;
+- derive runtime context from injected active/recent activity getters, with strict allowlisted fields;
+- derive readiness guardrails from persisted snapshot plus injected declared capability rows;
+- include tests that assert raw paths, chat ids, message ids, prompt JSON, and action fields are not
+  present in returned view models.
+
+## 9. Verification Expectations For Follow-Up Work
+
+Read-only Web view-model follow-up work should run at minimum:
+
+```sh
+git diff --check
+npm run check
+node --import tsx --test src/service/web-readonly-view-model.test.ts
+```
+
+Recommended test coverage:
+
+- empty store/unbound operator returns denied or unavailable state without bridge data;
+- workspace rows redact project paths and scan roots;
+- conversation rows redact chat ids, thread ids, and project paths;
+- final-answer rows expose delivery/availability but not Telegram message ids or action controls;
+- runtime rows expose status/progress summaries but not raw command output, terminal text, or reply markup;
+- interaction rows expose normalized state/title/summary only and hide secret answer values;
+- readiness rows hide resolved binary paths, pids, env values, and pack credentials;
+- serialized view models do not contain representative forbidden substrings from fixtures.
+
+Manual review before any later Web UI work:
+
+- inspect the adapter DTO names and ensure they describe Web Home, workspaces, conversations,
+  conversation results, runtime context, and readiness guardrails;
+- confirm there are no imports from Telegram/Feishu UI rendering modules;
+- confirm no app-server mutator method is called;
+- confirm Web remains prototype-only in docs and comments.
+
+Closeout status: the first adapter, Gap1, and Gap2 are landed; Gap3 artifact catalog/descriptors is
+the next safe read-only implementation item after documentation hygiene.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -7,6 +7,7 @@ children:
   - docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
   - docs/plans/2026-04-26-web-first-phase-1-closeout.md
   - docs/plans/2026-04-26-web-first-pm-ledger.md
+  - docs/plans/2026-04-26-web-protected-owner-access-plan.md
   - docs/plans/2026-04-26-web-first-project-command-board.md
   - docs/plans/2026-04-26-web-mvp-controller-triage.md
   - docs/plans/2026-04-26-codex-console-phase2-release-note.md
@@ -43,6 +44,7 @@ For new continuation work, start with `../roadmap/codex-console-continuation-bri
 - `2026-04-26-web-readonly-prototype-implementation-plan.md` - PM-readable guardrails and future-work route for the read-only Web prototype; the first service adapter seam has landed, while routes/UI/auth/actions remain unimplemented.
 - `2026-04-26-web-first-phase-1-closeout.md` - closeout and next-stage tracker for the landed local read-only Web prototype, including commits, verification, smoke proof, and Phase 2A/2B/2C task lanes.
 - `2026-04-26-web-first-pm-ledger.md` - detailed PM/controller ledger for delegated Codex runs, smoke evidence, and guardrails; use after the closeout only when detailed process history is needed.
+- `2026-04-26-web-protected-owner-access-plan.md` - protected owner-only access design gate for the local read-only Web prototype, including recommended private-network path, threat model, auth/session requirements, rollback drill, and acceptance checklist.
 - `2026-04-26-web-first-project-command-board.md` - PM command board for the Web-first continuation; closeout state points to prototype planning, not completed W2/W5 work.
 - `2026-04-26-web-mvp-controller-triage.md` - controller-approved Web MVP scope cut that keeps the first lane read-mostly and Web-only.
 - `2026-04-26-codex-console-phase2-release-note.md` - PR-ready summary of the install path, Feishu audit, metadata cleanup, Web/App sketch, and verification work.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -4,16 +4,9 @@ layer: 2
 parent: docs/INDEX.md
 children:
   - docs/plans/2026-04-26-product-web-console-mvp.md
-  - docs/plans/2026-04-26-web-viewmodel-inventory.md
-  - docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
-  - docs/plans/2026-04-26-web-first-phase-1-closeout.md
   - docs/plans/2026-04-26-web-first-pm-ledger.md
   - docs/plans/2026-04-26-web-protected-owner-access-plan.md
   - docs/plans/2026-04-26-web-gated-actions-design.md
-  - docs/plans/2026-04-26-web-first-project-command-board.md
-  - docs/plans/2026-04-26-web-mvp-controller-triage.md
-  - docs/plans/2026-04-26-codex-console-phase2-release-note.md
-  - docs/plans/2026-04-26-codex-console-phase2-plan.md
   - docs/plans/2026-04-26-feishu-official-capability-audit.md
   - docs/plans/2026-04-09-feishu-pack-setup-capability-and-hardening-plan.md
   - docs/plans/2026-04-08-multi-platform-core-and-feishu-implementation-plan.md
@@ -22,7 +15,7 @@ children:
   - docs/plans/2026-03-30-platform-surface-adapter-and-capability-prep.md
   - docs/plans/2026-03-23-multi-platform-core-phase-1-implementation-plan.md
   - docs/plans/2026-03-23-multi-platform-core-pending-task-tracker.md
-summary: router for active trackers, implementation sequencing, and closeout notes
+summary: router for active trackers, current implementation sequencing, and non-archived deferred work
 read_when:
   - the request is about implementation sequencing, closeout status, or deferred work
   - the request needs historical planning context for the multi-platform Core slice
@@ -36,38 +29,28 @@ source_of_truth:
 
 # Plans Index
 
-Use this directory for active sequencing, closeout status, and deferred-work tracking.
+Use this directory for active sequencing, current closeout state, and deferred-work tracking.
 It is planning context, not current product truth.
-For new continuation work, start with `../roadmap/codex-console-continuation-brief.md` before opening any dated plan.
+For new Codex Console continuation work, start with `../roadmap/codex-console-continuation-brief.md` before opening any dated plan.
 
 ## Active Or Recently Relevant Leaves
 
-- `2026-04-26-product-web-console-mvp.md` - Phase 3 Product Web Console MVP information architecture, core flows, acceptance criteria, guardrails, and next implementation slices; use before coding the first readable Console shell/detail UI.
-- `2026-04-26-web-viewmodel-inventory.md` - implementation-facing inventory of read-only Core/state/source facades, the landed first adapter seam, and remaining read-only gaps for the future Web prototype.
-- `2026-04-26-web-readonly-prototype-implementation-plan.md` - PM-readable guardrails and future-work route for the read-only Web prototype; the first service adapter seam has landed, while routes/UI/auth/actions remain unimplemented.
-- `2026-04-26-web-first-phase-1-closeout.md` - closeout and next-stage tracker for the landed local read-only Web prototype, including commits, verification, smoke proof, and Phase 2A/2B/2C task lanes.
-- `2026-04-26-web-first-pm-ledger.md` - detailed PM/controller ledger for delegated Codex runs, smoke evidence, and guardrails; use after the closeout only when detailed process history is needed.
-- `2026-04-26-web-protected-owner-access-plan.md` - protected owner-only access design gate for the local read-only Web prototype, including recommended private-network path, threat model, auth/session requirements, rollback drill, and acceptance checklist.
-- `2026-04-26-web-gated-actions-design.md` - docs-only design gate for future Web submit, approval-answer, and interrupt actions after read-only MVP and protected owner access pass; includes sequencing, preconditions, audit, tests, and rollback.
-- `2026-04-26-web-first-project-command-board.md` - PM command board for the Web-first continuation; closeout state points to prototype planning, not completed W2/W5 work.
-- `2026-04-26-web-mvp-controller-triage.md` - controller-approved Web MVP scope cut that keeps the first lane read-mostly and Web-only.
-- `2026-04-26-codex-console-phase2-release-note.md` - PR-ready summary of the install path, Feishu audit, metadata cleanup, Web/App sketch, and verification work.
-- `2026-04-26-codex-console-phase2-plan.md` - phase plan for the Phase 2 continuation branch.
+- `2026-04-26-product-web-console-mvp.md` - active Phase 3 Product Web Console MVP source for information architecture, read-only product UX acceptance criteria, final-answer source rules, runtime/pending copy, guardrails, and next implementation slices.
+- `2026-04-26-web-first-pm-ledger.md` - detailed PM/controller ledger for the current PR branch, committed checkpoints, live owner-preview state, verification, monitor cleanup, and recovery details.
+- `2026-04-26-web-protected-owner-access-plan.md` - protected owner-only access design gate for the local read-only Web prototype, including threat model, auth/session requirements, rollback drill, and acceptance checklist.
+- `2026-04-26-web-gated-actions-design.md` - docs-only design gate for future Web submit, approval-answer, and interrupt actions after read-only MVP and protected owner access pass.
 - `2026-04-26-feishu-official-capability-audit.md` - official-API-backed Feishu capability audit and live-smoke caveat.
 - `2026-04-09-feishu-pack-setup-capability-and-hardening-plan.md` - Feishu setup, callback readiness, and first-run binding hardening backlog.
-- `2026-04-08-multi-platform-core-and-feishu-implementation-plan.md` - four-phase backlog that completed platform abstraction and landed Feishu as the second platform.
-- `2026-03-30-binding-model-neutralization-note.md` - neutralizing auth and chat binding model fields without claiming broad multi-platform support.
-- `2026-03-30-platform-binding-boundary-design.md` - platform principal, surface target, and bridge session ownership boundary.
-- `2026-03-30-platform-surface-adapter-and-capability-prep.md` - platform-surface adapter and capability vocabulary predesign.
-- `2026-03-23-multi-platform-core-phase-1-implementation-plan.md` - first abstraction wave closeout and scope boundary.
-- `2026-03-23-multi-platform-core-pending-task-tracker.md` - original Phase-1 deferred-work baseline; historical sequencing context only.
+- `2026-04-08-multi-platform-core-and-feishu-implementation-plan.md` - completed platform abstraction / Feishu implementation plan kept temporarily because it still anchors current-pack follow-up context.
+- March 23 / March 30 multi-platform Core, binding, and surface notes remain here only as short-term sequencing context for Core/platform-boundary follow-up.
 
 ## Archived Plan Material
 
-Older March implementation plans moved to `../archive/plans/`. They are not active task context and should only be opened for historical reconstruction.
+Completed Phase 1/2 Web planning docs, the Phase 2 release note, and older implementation plans live under `../archive/plans/`.
+They are not active task context and should only be opened for historical reconstruction.
 
 ## Skip This Directory When
 
-- you need the shipped behavior right now
-- you need future product direction rather than implementation sequencing
-- the continuation brief plus one current-truth leaf is enough
+- you need shipped behavior right now;
+- the continuation brief plus one current-truth leaf is enough;
+- the task is archaeology only, in which case use `../archive/plans/README.md` directly.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -5,6 +5,8 @@ parent: docs/INDEX.md
 children:
   - docs/plans/2026-04-26-web-viewmodel-inventory.md
   - docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
+  - docs/plans/2026-04-26-web-first-phase-1-closeout.md
+  - docs/plans/2026-04-26-web-first-pm-ledger.md
   - docs/plans/2026-04-26-web-first-project-command-board.md
   - docs/plans/2026-04-26-web-mvp-controller-triage.md
   - docs/plans/2026-04-26-codex-console-phase2-release-note.md
@@ -39,6 +41,8 @@ For new continuation work, start with `../roadmap/codex-console-continuation-bri
 
 - `2026-04-26-web-viewmodel-inventory.md` - implementation-facing inventory of read-only Core/state/source facades, the landed first adapter seam, and remaining read-only gaps for the future Web prototype.
 - `2026-04-26-web-readonly-prototype-implementation-plan.md` - PM-readable guardrails and future-work route for the read-only Web prototype; the first service adapter seam has landed, while routes/UI/auth/actions remain unimplemented.
+- `2026-04-26-web-first-phase-1-closeout.md` - closeout and next-stage tracker for the landed local read-only Web prototype, including commits, verification, smoke proof, and Phase 2A/2B/2C task lanes.
+- `2026-04-26-web-first-pm-ledger.md` - detailed PM/controller ledger for delegated Codex runs, smoke evidence, and guardrails; use after the closeout only when detailed process history is needed.
 - `2026-04-26-web-first-project-command-board.md` - PM command board for the Web-first continuation; closeout state points to prototype planning, not completed W2/W5 work.
 - `2026-04-26-web-mvp-controller-triage.md` - controller-approved Web MVP scope cut that keeps the first lane read-mostly and Web-only.
 - `2026-04-26-codex-console-phase2-release-note.md` - PR-ready summary of the install path, Feishu audit, metadata cleanup, Web/App sketch, and verification work.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -3,6 +3,10 @@ role: domain
 layer: 2
 parent: docs/INDEX.md
 children:
+  - docs/plans/2026-04-26-web-viewmodel-inventory.md
+  - docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
+  - docs/plans/2026-04-26-web-first-project-command-board.md
+  - docs/plans/2026-04-26-web-mvp-controller-triage.md
   - docs/plans/2026-04-26-codex-console-phase2-release-note.md
   - docs/plans/2026-04-26-codex-console-phase2-plan.md
   - docs/plans/2026-04-26-feishu-official-capability-audit.md
@@ -33,6 +37,10 @@ For new continuation work, start with `../roadmap/codex-console-continuation-bri
 
 ## Active Or Recently Relevant Leaves
 
+- `2026-04-26-web-viewmodel-inventory.md` - implementation-facing inventory of read-only Core/state/source facades, the landed first adapter seam, and remaining read-only gaps for the future Web prototype.
+- `2026-04-26-web-readonly-prototype-implementation-plan.md` - PM-readable guardrails and future-work route for the read-only Web prototype; the first service adapter seam has landed, while routes/UI/auth/actions remain unimplemented.
+- `2026-04-26-web-first-project-command-board.md` - PM command board for the Web-first continuation; closeout state points to prototype planning, not completed W2/W5 work.
+- `2026-04-26-web-mvp-controller-triage.md` - controller-approved Web MVP scope cut that keeps the first lane read-mostly and Web-only.
 - `2026-04-26-codex-console-phase2-release-note.md` - PR-ready summary of the install path, Feishu audit, metadata cleanup, Web/App sketch, and verification work.
 - `2026-04-26-codex-console-phase2-plan.md` - phase plan for the Phase 2 continuation branch.
 - `2026-04-26-feishu-official-capability-audit.md` - official-API-backed Feishu capability audit and live-smoke caveat.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -8,6 +8,7 @@ children:
   - docs/plans/2026-04-26-web-first-phase-1-closeout.md
   - docs/plans/2026-04-26-web-first-pm-ledger.md
   - docs/plans/2026-04-26-web-protected-owner-access-plan.md
+  - docs/plans/2026-04-26-web-gated-actions-design.md
   - docs/plans/2026-04-26-web-first-project-command-board.md
   - docs/plans/2026-04-26-web-mvp-controller-triage.md
   - docs/plans/2026-04-26-codex-console-phase2-release-note.md
@@ -45,6 +46,7 @@ For new continuation work, start with `../roadmap/codex-console-continuation-bri
 - `2026-04-26-web-first-phase-1-closeout.md` - closeout and next-stage tracker for the landed local read-only Web prototype, including commits, verification, smoke proof, and Phase 2A/2B/2C task lanes.
 - `2026-04-26-web-first-pm-ledger.md` - detailed PM/controller ledger for delegated Codex runs, smoke evidence, and guardrails; use after the closeout only when detailed process history is needed.
 - `2026-04-26-web-protected-owner-access-plan.md` - protected owner-only access design gate for the local read-only Web prototype, including recommended private-network path, threat model, auth/session requirements, rollback drill, and acceptance checklist.
+- `2026-04-26-web-gated-actions-design.md` - docs-only design gate for future Web submit, approval-answer, and interrupt actions after read-only MVP and protected owner access pass; includes sequencing, preconditions, audit, tests, and rollback.
 - `2026-04-26-web-first-project-command-board.md` - PM command board for the Web-first continuation; closeout state points to prototype planning, not completed W2/W5 work.
 - `2026-04-26-web-mvp-controller-triage.md` - controller-approved Web MVP scope cut that keeps the first lane read-mostly and Web-only.
 - `2026-04-26-codex-console-phase2-release-note.md` - PR-ready summary of the install path, Feishu audit, metadata cleanup, Web/App sketch, and verification work.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -3,6 +3,7 @@ role: domain
 layer: 2
 parent: docs/INDEX.md
 children:
+  - docs/plans/2026-04-26-product-web-console-mvp.md
   - docs/plans/2026-04-26-web-viewmodel-inventory.md
   - docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md
   - docs/plans/2026-04-26-web-first-phase-1-closeout.md
@@ -41,6 +42,7 @@ For new continuation work, start with `../roadmap/codex-console-continuation-bri
 
 ## Active Or Recently Relevant Leaves
 
+- `2026-04-26-product-web-console-mvp.md` - Phase 3 Product Web Console MVP information architecture, core flows, acceptance criteria, guardrails, and next implementation slices; use before coding the first readable Console shell/detail UI.
 - `2026-04-26-web-viewmodel-inventory.md` - implementation-facing inventory of read-only Core/state/source facades, the landed first adapter seam, and remaining read-only gaps for the future Web prototype.
 - `2026-04-26-web-readonly-prototype-implementation-plan.md` - PM-readable guardrails and future-work route for the read-only Web prototype; the first service adapter seam has landed, while routes/UI/auth/actions remain unimplemented.
 - `2026-04-26-web-first-phase-1-closeout.md` - closeout and next-stage tracker for the landed local read-only Web prototype, including commits, verification, smoke proof, and Phase 2A/2B/2C task lanes.

--- a/docs/roadmap/codex-console-continuation-brief.md
+++ b/docs/roadmap/codex-console-continuation-brief.md
@@ -20,6 +20,7 @@ source_of_truth:
   - docs/operations/web-vps-mobile-access-and-security.md
   - docs/architecture/web-app-preimplementation-contract.md
   - docs/plans/2026-04-26-web-first-phase-1-closeout.md
+  - docs/plans/2026-04-26-web-protected-owner-access-plan.md
 -->
 
 # Codex Console Continuation Brief
@@ -36,7 +37,7 @@ Use this as the first task handoff for future Codex Console / multi-platform bri
 - Internal shared direction is **Codex Bridge Core**.
 - Telegram is the stable first/default pack.
 - Feishu is a serious current pack with explicit setup/readiness caveats.
-- Web has a local, explicit, token-gated read-only prototype substrate on this branch; do not claim current support, public availability, mobile readiness, or action capability.
+- Web has a local, explicit, token-gated read-only prototype substrate on this branch with workspace rows, recent conversations, and opaque `cv_...` conversation detail handles; do not claim current support, public availability, mobile readiness, or action capability.
 - App is alive but deferred until Web proves the shared contract path.
 - Recent Phase 2 work is captured in `docs/plans/2026-04-26-codex-console-phase2-release-note.md`.
 
@@ -65,6 +66,7 @@ Do not read the old dated plan archive by default. It is for archaeology, not ac
 | Web/App pre-implementation contract and readiness gates | `docs/architecture/web-app-preimplementation-contract.md` |
 | Web-first Phase 1 local prototype closeout and next-stage tracker | `docs/plans/2026-04-26-web-first-phase-1-closeout.md` |
 | detailed PM/controller ledger for delegated implementation runs | `docs/plans/2026-04-26-web-first-pm-ledger.md` |
+| protected owner-only access design gate, threat model, auth/session requirements, rollback, and acceptance checklist | `docs/plans/2026-04-26-web-protected-owner-access-plan.md` |
 | future read-only Web prototype implementation planning | `docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md` |
 | future read-only Web view-model inventory and first adapter seam | `docs/plans/2026-04-26-web-viewmodel-inventory.md` |
 | official-API-backed Feishu audit and live-smoke caveat | `docs/plans/2026-04-26-feishu-official-capability-audit.md` |
@@ -103,12 +105,13 @@ Kept outside archive because they still help the current direction:
 4. **Web prototype implementation planning — complete/landed.** Use the read-only prototype implementation plan for page skeletons, candidate Core/state surfaces, redacted data contracts, auth assumptions, validation flow, forbidden scope, and future coding milestones.
 5. **W9 read-only Web view-model inventory — complete/landed.** Use the inventory for the service-level adapter seam and remaining read-only gaps, not routes, auth middleware, task submission, or action controls.
 6. **Web-first Phase 1 local read-only prototype — complete/landed on branch.** Use the closeout leaf for the exact commits, source files, smoke proof, verification, and current non-claims.
-7. **Phase 2A owner-reviewable screenshot/recording proof — next.** Capture local Web Home/workspace/conversation/result/runtime/readiness proof without exposing a public URL.
-8. **Phase 2B useful read-only data depth.** Add Web-safe final-answer readability and owner-comprehensible conversation detail while keeping Telegram/Feishu delivery artifacts hidden.
-9. **Phase 2C protected owner URL gate.** Only after screenshot proof and auth/session design are accepted; no unauthenticated URL or service-default Web exposure.
-10. **Live Feishu tenant smoke.** Verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery as a separate current-pack readiness track.
-11. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
-12. **Docs context budget enforcement and PR hygiene.** Keep routers pointing to this brief plus one leaf; archive or demote temporary plan files after closeout, and include verification commands in each continuation PR.
+7. **Phase 2A owner-reviewable proof — complete/landed as sanitized controller evidence.** Use the PM ledger for the local proof notes; do not expose a public URL for proof review.
+8. **Phase 2B useful read-only data depth — partial/landed.** Conversation detail now uses opaque `cv_...` handles; final-answer body readability remains gated on a safe source.
+9. **Phase 2C protected owner access design — complete/landed as docs-only gate.** Use the protected owner access plan before any URL exposure; no unauthenticated URL, action controls, service-default Web exposure, or support claim.
+10. **Protected owner access implementation slices.** Later work should start with config seam, explicit command flag, auth/session hardening, one private-network/tunnel wrapper, health/shutdown check, and smoke proof.
+11. **Live Feishu tenant smoke.** Verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery as a separate current-pack readiness track.
+12. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
+13. **Docs context budget enforcement and PR hygiene.** Keep routers pointing to this brief plus one leaf; archive or demote temporary plan files after closeout, and include verification commands in each continuation PR.
 
 ## Noise Checks Before Adding A New Doc
 

--- a/docs/roadmap/codex-console-continuation-brief.md
+++ b/docs/roadmap/codex-console-continuation-brief.md
@@ -31,6 +31,8 @@ Use this as the first low-context task handoff for future Codex Console / multi-
 
 ## One-Screen Current State
 
+**Owner direction, do not miss:** this is a personal owner project. The Web Console should now move toward a real, useful Web app experience, not a security/admin/readiness dashboard. Keep only right-sized safety guardrails in the background: token gate, no secret/token leaks, no raw local paths or platform IDs by default, and no destructive/write actions until explicitly approved. Product work should prioritize dashboard, workspace/conversation browsing, readable task/detail pages, recent results, and owner attention flows.
+
 - Compatibility names stay unchanged: repo/package `telegram-codex-bridge`, CLI `ctb`, existing service/config/state paths.
 - Product language is **Codex Console**.
 - Internal shared direction is **Codex Bridge Core**.

--- a/docs/roadmap/codex-console-continuation-brief.md
+++ b/docs/roadmap/codex-console-continuation-brief.md
@@ -5,23 +5,21 @@ parent: docs/roadmap/README.md
 children: []
 summary: active continuation brief for the next Codex Console tasks, optimized for low-context agent handoff
 read_when:
-  - starting any new Codex Console platform-abstraction task
+  - starting any new Codex Console platform-abstraction or Web Console task
   - deciding which current docs are relevant and which historical docs to skip
   - preparing future implementation or review prompts after the current continuation baseline
 skip_when:
   - the task is only about shipped install/runtime behavior and a Tier-1 leaf is already known
 source_of_truth:
   - docs/roadmap/codex-console-continuation-brief.md
-  - docs/architecture/platform-capability-matrix.md
-  - docs/architecture/platform-pack-boundary.md
-  - docs/future/multi-platform-core-prd.md
-  - docs/future/web-app-control-surface-sketch.md
-  - docs/future/web-mvp-scope-and-readiness.md
-  - docs/operations/web-vps-mobile-access-and-security.md
-  - docs/architecture/web-app-preimplementation-contract.md
-  - docs/plans/2026-04-26-web-first-phase-1-closeout.md
+  - docs/plans/2026-04-26-product-web-console-mvp.md
+  - docs/plans/2026-04-26-web-first-pm-ledger.md
   - docs/plans/2026-04-26-web-protected-owner-access-plan.md
   - docs/plans/2026-04-26-web-gated-actions-design.md
+  - docs/architecture/platform-capability-matrix.md
+  - docs/architecture/platform-pack-boundary.md
+  - docs/future/web-mvp-scope-and-readiness.md
+  - docs/operations/web-vps-mobile-access-and-security.md
 -->
 
 # Codex Console Continuation Brief
@@ -29,7 +27,7 @@ source_of_truth:
 Status: active continuation entrypoint
 Last updated: 2026-04-26
 
-Use this as the first task handoff for future Codex Console / multi-platform bridge work. It replaces ad-hoc reading of older dated plans.
+Use this as the first low-context task handoff for future Codex Console / multi-platform bridge work. It replaces ad-hoc reading of older dated plans.
 
 ## One-Screen Current State
 
@@ -38,42 +36,45 @@ Use this as the first task handoff for future Codex Console / multi-platform bri
 - Internal shared direction is **Codex Bridge Core**.
 - Telegram is the stable first/default pack.
 - Feishu is a serious current pack with explicit setup/readiness caveats.
-- Web has a local, explicit, token-gated read-only prototype substrate on this branch with workspace rows, recent conversations, and opaque `cv_...` conversation detail handles; do not claim current support, public availability, mobile readiness, or action capability.
-- Future Web actions have a docs-only gated-actions design for sequencing and acceptance criteria; no Web submit, approval-answer, interrupt, upload/download, or raw terminal action is implemented.
+- Web has a temporary owner-only, read-only preview at `https://codex.guicheng.xyz` through Cloudflare Tunnel + local cookie proxy + localhost Web origin. This is **not** shipped/public/supported Web service.
+- PR #16 branch has landed Phase 3 Product Web Console MVP read UX slices through commit `d66ff3d`:
+  - real Product Web Console MVP IA/spec;
+  - mobile-first `Codex Console` shell and readable conversation/task detail;
+  - Web-safe final-answer body rendering only from injected sanitized sources;
+  - conversation/task grouping with user-language state labels;
+  - read-only Pending/Approvals cards with explicit action-disabled copy.
+- Web actions remain unimplemented: no submit, approval-answer, question-answer, interrupt, upload/download, raw terminal, or project/session writes.
 - App is alive but deferred until Web proves the shared contract path.
-- Recent Phase 2 work is captured in `docs/plans/2026-04-26-codex-console-phase2-release-note.md`.
+- Detailed run/verification/smoke state lives in `docs/plans/2026-04-26-web-first-pm-ledger.md`.
 
 ## Default Agent Reading Budget
 
 For a new task, read at most:
 
 1. this brief;
-2. one current-truth leaf from `docs/product/`, `docs/architecture/`, or `docs/operations/`;
-3. one implementation file or one protocol/future doc only if the task genuinely needs it.
+2. one active leaf from the table below;
+3. one implementation file only if the task is coding.
 
-Do not read the old dated plan archive by default. It is for archaeology, not active task context.
+Do not read archived dated plans by default. They are for archaeology, not active task context.
 
 ## Active Source Set
 
 | Need | Open |
 |---|---|
+| current Web Console MVP scope, IA, read UX acceptance, final-answer source rules, ordered next slices | `docs/plans/2026-04-26-product-web-console-mvp.md` |
+| detailed PM/controller ledger, exact commits, smoke proof, monitor cleanup, current branch state | `docs/plans/2026-04-26-web-first-pm-ledger.md` |
+| protected owner-only access design gate, threat model, auth/session requirements, rollback, acceptance checklist | `docs/plans/2026-04-26-web-protected-owner-access-plan.md` |
+| future Web submit, approval-answer, and interrupt action sequencing, safety preconditions, audit, tests, rollback gates | `docs/plans/2026-04-26-web-gated-actions-design.md` |
+| approved Web-first MVP scope/readiness, validation path, and support-claim guardrails | `docs/future/web-mvp-scope-and-readiness.md` |
+| future Web prototype VPS/mobile access, protected URL exposure, forbidden-data defaults, shutdown plan | `docs/operations/web-vps-mobile-access-and-security.md` |
+| Web/App pre-implementation Core/state/API contract and readiness gates | `docs/architecture/web-app-preimplementation-contract.md` |
 | current Telegram/Feishu capability and Web/App target rows | `docs/architecture/platform-capability-matrix.md` |
 | current pack contract and Telegram/Feishu ownership split | `docs/architecture/platform-pack-boundary.md` |
 | current install/admin and pack selection | `docs/operations/install-and-admin.md` |
 | current product scope and compatibility boundary | `docs/product/v1-scope.md` |
 | future Core product/architecture direction | `docs/future/multi-platform-core-prd.md` |
 | future Web/App control surface sketch | `docs/future/web-app-control-surface-sketch.md` |
-| approved Web-first MVP scope/readiness, action gates, VPS/mobile validation, and support-claim guardrails | `docs/future/web-mvp-scope-and-readiness.md` |
-| future Web prototype VPS/mobile access, protected URL exposure, forbidden-data defaults, and shutdown plan | `docs/operations/web-vps-mobile-access-and-security.md` |
-| Web/App pre-implementation contract and readiness gates | `docs/architecture/web-app-preimplementation-contract.md` |
-| Web-first Phase 1 local prototype closeout and next-stage tracker | `docs/plans/2026-04-26-web-first-phase-1-closeout.md` |
-| detailed PM/controller ledger for delegated implementation runs | `docs/plans/2026-04-26-web-first-pm-ledger.md` |
-| protected owner-only access design gate, threat model, auth/session requirements, rollback, and acceptance checklist | `docs/plans/2026-04-26-web-protected-owner-access-plan.md` |
-| future Web submit, approval-answer, and interrupt action sequencing, safety preconditions, audit, tests, and rollback gates | `docs/plans/2026-04-26-web-gated-actions-design.md` |
-| future read-only Web prototype implementation planning | `docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md` |
-| future read-only Web view-model inventory and first adapter seam | `docs/plans/2026-04-26-web-viewmodel-inventory.md` |
 | official-API-backed Feishu audit and live-smoke caveat | `docs/plans/2026-04-26-feishu-official-capability-audit.md` |
-| Phase 2 PR summary and verification | `docs/plans/2026-04-26-codex-console-phase2-release-note.md` |
 
 ## Archive Policy
 
@@ -81,42 +82,52 @@ Move a doc to `docs/archive/` when all are true:
 
 - it describes a closed historical milestone, superseded PRD, or implementation plan;
 - it is not the smallest source for any current or next task;
-- reading it before current docs would likely bias an agent toward stale Telegram-only or pre-Core assumptions.
+- reading it before current docs would likely bias an agent toward stale assumptions.
 
 Archived docs remain searchable for reconstruction, but routers must not send agents there unless the task explicitly asks for history or current sources conflict.
 
 ## Current Archive Decisions
 
-Archived from active routing in this cleanup:
+Archived from active routing in this closeout:
 
-- old V2/V3 future PRDs and engineering-evaluation material;
-- old March implementation plans for V2/V3, runtime-card, project-picker, runtime-hub, systemd, performance, and final-answer recovery work.
+- Phase 2 plan and release note;
+- Web-first project command board;
+- Web MVP controller triage;
+- Web view-model inventory;
+- Web read-only prototype implementation plan;
+- Web-first Phase 1 closeout.
 
-Kept outside archive because they still help the current direction:
+Kept active because they still gate the next work:
 
-- March 23 and March 30 multi-platform Core / binding / surface notes;
-- April 8 multi-platform Core + Feishu implementation plan;
-- April 9 Feishu hardening plan;
-- April 26 Feishu official capability audit;
-- April 26 Phase 2 plan and release note.
+- Product Web Console MVP spec;
+- PM/controller ledger;
+- protected owner access plan;
+- gated actions design;
+- current Feishu audit / hardening context.
+
+## Current Runtime / Monitor State
+
+At closeout:
+
+- Hermes cron monitors for this PR/workstream: none enabled.
+- Temporary owner preview may be running as manual processes:
+  - `node --import tsx src/cli.ts web readonly --platform feishu --port 45682`;
+  - `/tmp/ctb_web_cookie_proxy.py` on `127.0.0.1:45683`;
+  - `cloudflared tunnel --config /home/ubuntu/.cloudflared/codex-console.yml run codex-console`.
+- This preview is intentionally temporary. Use `/tmp/ctb-stop-codex-console-preview.sh` or kill the tracked processes when the owner is done reviewing.
+- Local `.hermes/` status artifacts are scratch evidence and are intentionally uncommitted.
 
 ## Next Sustainable Task Queue
 
-1. **W4 formal Web MVP docs landing — complete/landed.** Use the Web MVP scope/readiness leaf as the owner-readable source for the approved Web-first, App-later, read-mostly first lane.
-2. **W5 VPS/mobile access and security plan — complete/landed.** Use the operations access/security plan as the owner-readable source for screenshot-first validation, protected URL exposure choices, forbidden-data defaults, phone checklist, and shutdown gates.
-3. **Independent scope/readiness/security review — complete/landed.** The action-control wording blocker was fixed; first lane is strictly read-mostly with actions deferred to later lanes.
-4. **Web prototype implementation planning — complete/landed.** Use the read-only prototype implementation plan for page skeletons, candidate Core/state surfaces, redacted data contracts, auth assumptions, validation flow, forbidden scope, and future coding milestones.
-5. **W9 read-only Web view-model inventory — complete/landed.** Use the inventory for the service-level adapter seam and remaining read-only gaps, not routes, auth middleware, task submission, or action controls.
-6. **Web-first Phase 1 local read-only prototype — complete/landed on branch.** Use the closeout leaf for the exact commits, source files, smoke proof, verification, and current non-claims.
-7. **Phase 2A owner-reviewable proof — complete/landed as sanitized controller evidence.** Use the PM ledger for the local proof notes; do not expose a public URL for proof review.
-8. **Phase 2B useful read-only data depth — partial/landed.** Conversation detail now uses opaque `cv_...` handles; final-answer body readability remains gated on a safe source.
-9. **Phase 2C protected owner access design — complete/landed as docs-only gate.** Use the protected owner access plan before any URL exposure; no unauthenticated URL, action controls, service-default Web exposure, or support claim.
-10. **Phase 2D gated actions design — complete/landed as docs-only gate.** Use the gated-actions design before any Web submit, approval-answer, or interrupt implementation; actions remain unimplemented and blocked behind read-only MVP plus protected owner access acceptance.
-11. **Protected owner access implementation slices.** Later work should start with config seam, explicit command flag, auth/session hardening, one private-network/tunnel wrapper, health/shutdown check, and smoke proof.
-12. **Future Web action lane 0 only after access gates pass.** First action-adjacent slice should be no-op readiness/capability display, not submit; approval-answer, interrupt, and submit remain separately gated.
-13. **Live Feishu tenant smoke.** Verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery as a separate current-pack readiness track.
-14. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
-15. **Docs context budget enforcement and PR hygiene.** Keep routers pointing to this brief plus one leaf; archive or demote temporary plan files after closeout, and include verification commands in each continuation PR.
+1. **PR #16 check/merge path.** Confirm latest Ubuntu checks pass; Windows failures are a documented non-Web baseline unless a new Web-specific failure appears. Update PR body if needed before merge.
+2. **Runtime / Readiness / Settings read page.** Next Product Web Console MVP code slice: turn runtime/readiness/settings into safe owner-language panels. No actions.
+3. **Owner proof package.** Capture sanitized mobile-width screenshot/HTML proof from the live owner preview after the Runtime/Readiness slice; verify no tokens, raw paths, raw IDs, conversation text overexposure, callback payloads, or platform internals.
+4. **Managed owner preview hardening.** Convert today’s temporary process chain into an explicit managed preview workflow only after owner approval: stable start/stop/rotate scripts, auth/session hardening, health checks, shutdown drill. Do not make it default service startup.
+5. **Independent overclaim/security review.** Read-only review of Web UI copy, docs routing, forbidden data, and action-disabled boundaries before declaring the MVP reviewable.
+6. **First gated action lane decision.** Only after read UX and protected owner access pass: choose approval/question answer or submit draft. Start with a no-op capability/readiness display before any mutating action.
+7. **Live Feishu tenant smoke.** Separate current-pack readiness track: verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery.
+8. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
+9. **Docs context budget enforcement.** Keep routers pointing to this brief plus one leaf; archive or demote temporary plan files after each closeout.
 
 ## Noise Checks Before Adding A New Doc
 

--- a/docs/roadmap/codex-console-continuation-brief.md
+++ b/docs/roadmap/codex-console-continuation-brief.md
@@ -19,6 +19,7 @@ source_of_truth:
   - docs/future/web-mvp-scope-and-readiness.md
   - docs/operations/web-vps-mobile-access-and-security.md
   - docs/architecture/web-app-preimplementation-contract.md
+  - docs/plans/2026-04-26-web-first-phase-1-closeout.md
 -->
 
 # Codex Console Continuation Brief
@@ -35,7 +36,7 @@ Use this as the first task handoff for future Codex Console / multi-platform bri
 - Internal shared direction is **Codex Bridge Core**.
 - Telegram is the stable first/default pack.
 - Feishu is a serious current pack with explicit setup/readiness caveats.
-- Web has an approved read-mostly future MVP scope/readiness lane; do not claim current support.
+- Web has a local, explicit, token-gated read-only prototype substrate on this branch; do not claim current support, public availability, mobile readiness, or action capability.
 - App is alive but deferred until Web proves the shared contract path.
 - Recent Phase 2 work is captured in `docs/plans/2026-04-26-codex-console-phase2-release-note.md`.
 
@@ -62,6 +63,8 @@ Do not read the old dated plan archive by default. It is for archaeology, not ac
 | approved Web-first MVP scope/readiness, action gates, VPS/mobile validation, and support-claim guardrails | `docs/future/web-mvp-scope-and-readiness.md` |
 | future Web prototype VPS/mobile access, protected URL exposure, forbidden-data defaults, and shutdown plan | `docs/operations/web-vps-mobile-access-and-security.md` |
 | Web/App pre-implementation contract and readiness gates | `docs/architecture/web-app-preimplementation-contract.md` |
+| Web-first Phase 1 local prototype closeout and next-stage tracker | `docs/plans/2026-04-26-web-first-phase-1-closeout.md` |
+| detailed PM/controller ledger for delegated implementation runs | `docs/plans/2026-04-26-web-first-pm-ledger.md` |
 | future read-only Web prototype implementation planning | `docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md` |
 | future read-only Web view-model inventory and first adapter seam | `docs/plans/2026-04-26-web-viewmodel-inventory.md` |
 | official-API-backed Feishu audit and live-smoke caveat | `docs/plans/2026-04-26-feishu-official-capability-audit.md` |
@@ -99,11 +102,13 @@ Kept outside archive because they still help the current direction:
 3. **Independent scope/readiness/security review — complete/landed.** The action-control wording blocker was fixed; first lane is strictly read-mostly with actions deferred to later lanes.
 4. **Web prototype implementation planning — complete/landed.** Use the read-only prototype implementation plan for page skeletons, candidate Core/state surfaces, redacted data contracts, auth assumptions, validation flow, forbidden scope, and future coding milestones.
 5. **W9 read-only Web view-model inventory — complete/landed.** Use the inventory for the service-level adapter seam and remaining read-only gaps, not routes, auth middleware, task submission, or action controls.
-6. **Web service view-model seam closeout/hygiene — current.** The first read-only adapter, Gap1 final-answer/workspace redaction, and Gap2 pending-interactions read model have landed; closeout should keep docs/status wording aligned without claiming Web support.
-7. **Gap3 neutral artifact catalog/descriptors — next implementation after closeout.** Keep this read-only and descriptor-only; do not add routes, UI, auth, servers, writes, downloads, uploads, or action controls.
-8. **Live Feishu tenant smoke.** Verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery as a separate current-pack readiness track.
-9. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
-10. **Docs context budget enforcement and PR hygiene.** Keep routers pointing to this brief plus one leaf; archive or demote temporary plan files after closeout, and include verification commands in each continuation PR.
+6. **Web-first Phase 1 local read-only prototype — complete/landed on branch.** Use the closeout leaf for the exact commits, source files, smoke proof, verification, and current non-claims.
+7. **Phase 2A owner-reviewable screenshot/recording proof — next.** Capture local Web Home/workspace/conversation/result/runtime/readiness proof without exposing a public URL.
+8. **Phase 2B useful read-only data depth.** Add Web-safe final-answer readability and owner-comprehensible conversation detail while keeping Telegram/Feishu delivery artifacts hidden.
+9. **Phase 2C protected owner URL gate.** Only after screenshot proof and auth/session design are accepted; no unauthenticated URL or service-default Web exposure.
+10. **Live Feishu tenant smoke.** Verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery as a separate current-pack readiness track.
+11. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
+12. **Docs context budget enforcement and PR hygiene.** Keep routers pointing to this brief plus one leaf; archive or demote temporary plan files after closeout, and include verification commands in each continuation PR.
 
 ## Noise Checks Before Adding A New Doc
 

--- a/docs/roadmap/codex-console-continuation-brief.md
+++ b/docs/roadmap/codex-console-continuation-brief.md
@@ -21,6 +21,7 @@ source_of_truth:
   - docs/architecture/web-app-preimplementation-contract.md
   - docs/plans/2026-04-26-web-first-phase-1-closeout.md
   - docs/plans/2026-04-26-web-protected-owner-access-plan.md
+  - docs/plans/2026-04-26-web-gated-actions-design.md
 -->
 
 # Codex Console Continuation Brief
@@ -38,6 +39,7 @@ Use this as the first task handoff for future Codex Console / multi-platform bri
 - Telegram is the stable first/default pack.
 - Feishu is a serious current pack with explicit setup/readiness caveats.
 - Web has a local, explicit, token-gated read-only prototype substrate on this branch with workspace rows, recent conversations, and opaque `cv_...` conversation detail handles; do not claim current support, public availability, mobile readiness, or action capability.
+- Future Web actions have a docs-only gated-actions design for sequencing and acceptance criteria; no Web submit, approval-answer, interrupt, upload/download, or raw terminal action is implemented.
 - App is alive but deferred until Web proves the shared contract path.
 - Recent Phase 2 work is captured in `docs/plans/2026-04-26-codex-console-phase2-release-note.md`.
 
@@ -67,6 +69,7 @@ Do not read the old dated plan archive by default. It is for archaeology, not ac
 | Web-first Phase 1 local prototype closeout and next-stage tracker | `docs/plans/2026-04-26-web-first-phase-1-closeout.md` |
 | detailed PM/controller ledger for delegated implementation runs | `docs/plans/2026-04-26-web-first-pm-ledger.md` |
 | protected owner-only access design gate, threat model, auth/session requirements, rollback, and acceptance checklist | `docs/plans/2026-04-26-web-protected-owner-access-plan.md` |
+| future Web submit, approval-answer, and interrupt action sequencing, safety preconditions, audit, tests, and rollback gates | `docs/plans/2026-04-26-web-gated-actions-design.md` |
 | future read-only Web prototype implementation planning | `docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md` |
 | future read-only Web view-model inventory and first adapter seam | `docs/plans/2026-04-26-web-viewmodel-inventory.md` |
 | official-API-backed Feishu audit and live-smoke caveat | `docs/plans/2026-04-26-feishu-official-capability-audit.md` |
@@ -108,10 +111,12 @@ Kept outside archive because they still help the current direction:
 7. **Phase 2A owner-reviewable proof — complete/landed as sanitized controller evidence.** Use the PM ledger for the local proof notes; do not expose a public URL for proof review.
 8. **Phase 2B useful read-only data depth — partial/landed.** Conversation detail now uses opaque `cv_...` handles; final-answer body readability remains gated on a safe source.
 9. **Phase 2C protected owner access design — complete/landed as docs-only gate.** Use the protected owner access plan before any URL exposure; no unauthenticated URL, action controls, service-default Web exposure, or support claim.
-10. **Protected owner access implementation slices.** Later work should start with config seam, explicit command flag, auth/session hardening, one private-network/tunnel wrapper, health/shutdown check, and smoke proof.
-11. **Live Feishu tenant smoke.** Verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery as a separate current-pack readiness track.
-12. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
-13. **Docs context budget enforcement and PR hygiene.** Keep routers pointing to this brief plus one leaf; archive or demote temporary plan files after closeout, and include verification commands in each continuation PR.
+10. **Phase 2D gated actions design — complete/landed as docs-only gate.** Use the gated-actions design before any Web submit, approval-answer, or interrupt implementation; actions remain unimplemented and blocked behind read-only MVP plus protected owner access acceptance.
+11. **Protected owner access implementation slices.** Later work should start with config seam, explicit command flag, auth/session hardening, one private-network/tunnel wrapper, health/shutdown check, and smoke proof.
+12. **Future Web action lane 0 only after access gates pass.** First action-adjacent slice should be no-op readiness/capability display, not submit; approval-answer, interrupt, and submit remain separately gated.
+13. **Live Feishu tenant smoke.** Verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery as a separate current-pack readiness track.
+14. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
+15. **Docs context budget enforcement and PR hygiene.** Keep routers pointing to this brief plus one leaf; archive or demote temporary plan files after closeout, and include verification commands in each continuation PR.
 
 ## Noise Checks Before Adding A New Doc
 

--- a/docs/roadmap/codex-console-continuation-brief.md
+++ b/docs/roadmap/codex-console-continuation-brief.md
@@ -31,10 +31,10 @@ Use this as the first low-context task handoff for future Codex Console / multi-
 
 ## One-Screen Current State
 
-**Owner direction, do not miss:** this is a personal owner project. The Web Console should now move toward a real, useful Web app experience, not a security/admin/readiness dashboard. Keep only right-sized safety guardrails in the background: token gate, no secret/token leaks, no raw local paths or platform IDs by default, and no destructive/write actions until explicitly approved. Product work should prioritize dashboard, workspace/conversation browsing, readable task/detail pages, recent results, and owner attention flows.
+**Owner direction, do not miss:** this is a personal owner project. The Web Console direction has pivoted to **Web Chat Platform**: Web should become a first-class chat surface for Codex Bridge, analogous to Telegram/Feishu. Do not steer future work back to dashboard/status/security/admin pages. Keep right-sized safety guardrails in the background: token gate, no secret/token leaks, no raw local paths or platform IDs by default, and no destructive/write actions beyond the explicitly chosen chat send lane.
 
 - Compatibility names stay unchanged: repo/package `telegram-codex-bridge`, CLI `ctb`, existing service/config/state paths.
-- Product language is **Codex Console**.
+- Product language is **Codex Console**; the primary Web experience is a chat/work conversation surface.
 - Internal shared direction is **Codex Bridge Core**.
 - Telegram is the stable first/default pack.
 - Feishu is a serious current pack with explicit setup/readiness caveats.
@@ -126,7 +126,7 @@ At closeout:
 2. **Owner proof package.** Capture sanitized mobile-width screenshot/HTML proof from the live owner preview now that the Runtime/Readiness slice has landed; verify no tokens, raw paths, raw IDs, conversation text overexposure, callback payloads, or platform internals.
 3. **Independent overclaim/security review.** Read-only review of Web UI copy, docs routing, forbidden data, and action-disabled boundaries before declaring the MVP reviewable.
 4. **Managed owner preview hardening.** Convert today’s temporary process chain into an explicit managed preview workflow only after owner approval: stable start/stop/rotate scripts, auth/session hardening, health checks, shutdown drill. Do not make it default service startup.
-5. **First gated action lane decision.** Only after read UX + protected access + overclaim/security review pass: choose approval/question answer or submit draft. Start with a no-op capability/readiness display before any mutating action.
+5. **First gated action lane decision.** Current pivot chooses text submit as the first Web Chat action lane after Phase B read UI. Start with a no-op/disabled composer in Phase B, then a text-only `POST /conversations/:handle/messages` in Phase C using the live bridge submit path.
 6. **Live Feishu tenant smoke.** Separate current-pack readiness track: verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery.
 7. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
 8. **Docs context budget enforcement.** Keep routers pointing to this brief plus one leaf; archive or demote temporary plan files after each closeout.

--- a/docs/roadmap/codex-console-continuation-brief.md
+++ b/docs/roadmap/codex-console-continuation-brief.md
@@ -37,12 +37,13 @@ Use this as the first low-context task handoff for future Codex Console / multi-
 - Telegram is the stable first/default pack.
 - Feishu is a serious current pack with explicit setup/readiness caveats.
 - Web has a temporary owner-only, read-only preview at `https://codex.guicheng.xyz` through Cloudflare Tunnel + local cookie proxy + localhost Web origin. This is **not** shipped/public/supported Web service.
-- PR #16 branch has landed Phase 3 Product Web Console MVP read UX slices through commit `d66ff3d`:
+- PR #16 branch has landed Phase 3 Product Web Console MVP read UX slices through commit `c8a13fc`:
   - real Product Web Console MVP IA/spec;
   - mobile-first `Codex Console` shell and readable conversation/task detail;
   - Web-safe final-answer body rendering only from injected sanitized sources;
   - conversation/task grouping with user-language state labels;
-  - read-only Pending/Approvals cards with explicit action-disabled copy.
+  - read-only Pending/Approvals cards with explicit action-disabled copy;
+  - Runtime / Readiness / Settings read-only owner-language panels.
 - Web actions remain unimplemented: no submit, approval-answer, question-answer, interrupt, upload/download, raw terminal, or project/session writes.
 - App is alive but deferred until Web proves the shared contract path.
 - Detailed run/verification/smoke state lives in `docs/plans/2026-04-26-web-first-pm-ledger.md`.
@@ -120,14 +121,13 @@ At closeout:
 ## Next Sustainable Task Queue
 
 1. **PR #16 check/merge path.** Confirm latest Ubuntu checks pass; Windows failures are a documented non-Web baseline unless a new Web-specific failure appears. Update PR body if needed before merge.
-2. **Runtime / Readiness / Settings read page.** Next Product Web Console MVP code slice: turn runtime/readiness/settings into safe owner-language panels. No actions.
-3. **Owner proof package.** Capture sanitized mobile-width screenshot/HTML proof from the live owner preview after the Runtime/Readiness slice; verify no tokens, raw paths, raw IDs, conversation text overexposure, callback payloads, or platform internals.
+2. **Owner proof package.** Capture sanitized mobile-width screenshot/HTML proof from the live owner preview now that the Runtime/Readiness slice has landed; verify no tokens, raw paths, raw IDs, conversation text overexposure, callback payloads, or platform internals.
+3. **Independent overclaim/security review.** Read-only review of Web UI copy, docs routing, forbidden data, and action-disabled boundaries before declaring the MVP reviewable.
 4. **Managed owner preview hardening.** Convert today’s temporary process chain into an explicit managed preview workflow only after owner approval: stable start/stop/rotate scripts, auth/session hardening, health checks, shutdown drill. Do not make it default service startup.
-5. **Independent overclaim/security review.** Read-only review of Web UI copy, docs routing, forbidden data, and action-disabled boundaries before declaring the MVP reviewable.
-6. **First gated action lane decision.** Only after read UX and protected owner access pass: choose approval/question answer or submit draft. Start with a no-op capability/readiness display before any mutating action.
-7. **Live Feishu tenant smoke.** Separate current-pack readiness track: verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery.
-8. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
-9. **Docs context budget enforcement.** Keep routers pointing to this brief plus one leaf; archive or demote temporary plan files after each closeout.
+5. **First gated action lane decision.** Only after read UX + protected access + overclaim/security review pass: choose approval/question answer or submit draft. Start with a no-op capability/readiness display before any mutating action.
+6. **Live Feishu tenant smoke.** Separate current-pack readiness track: verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery.
+7. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
+8. **Docs context budget enforcement.** Keep routers pointing to this brief plus one leaf; archive or demote temporary plan files after each closeout.
 
 ## Noise Checks Before Adding A New Doc
 

--- a/docs/roadmap/codex-console-continuation-brief.md
+++ b/docs/roadmap/codex-console-continuation-brief.md
@@ -16,6 +16,9 @@ source_of_truth:
   - docs/architecture/platform-pack-boundary.md
   - docs/future/multi-platform-core-prd.md
   - docs/future/web-app-control-surface-sketch.md
+  - docs/future/web-mvp-scope-and-readiness.md
+  - docs/operations/web-vps-mobile-access-and-security.md
+  - docs/architecture/web-app-preimplementation-contract.md
 -->
 
 # Codex Console Continuation Brief
@@ -32,7 +35,8 @@ Use this as the first task handoff for future Codex Console / multi-platform bri
 - Internal shared direction is **Codex Bridge Core**.
 - Telegram is the stable first/default pack.
 - Feishu is a serious current pack with explicit setup/readiness caveats.
-- Web/App is future design only; do not claim current support.
+- Web has an approved read-mostly future MVP scope/readiness lane; do not claim current support.
+- App is alive but deferred until Web proves the shared contract path.
 - Recent Phase 2 work is captured in `docs/plans/2026-04-26-codex-console-phase2-release-note.md`.
 
 ## Default Agent Reading Budget
@@ -55,6 +59,11 @@ Do not read the old dated plan archive by default. It is for archaeology, not ac
 | current product scope and compatibility boundary | `docs/product/v1-scope.md` |
 | future Core product/architecture direction | `docs/future/multi-platform-core-prd.md` |
 | future Web/App control surface sketch | `docs/future/web-app-control-surface-sketch.md` |
+| approved Web-first MVP scope/readiness, action gates, VPS/mobile validation, and support-claim guardrails | `docs/future/web-mvp-scope-and-readiness.md` |
+| future Web prototype VPS/mobile access, protected URL exposure, forbidden-data defaults, and shutdown plan | `docs/operations/web-vps-mobile-access-and-security.md` |
+| Web/App pre-implementation contract and readiness gates | `docs/architecture/web-app-preimplementation-contract.md` |
+| future read-only Web prototype implementation planning | `docs/plans/2026-04-26-web-readonly-prototype-implementation-plan.md` |
+| future read-only Web view-model inventory and first adapter seam | `docs/plans/2026-04-26-web-viewmodel-inventory.md` |
 | official-API-backed Feishu audit and live-smoke caveat | `docs/plans/2026-04-26-feishu-official-capability-audit.md` |
 | Phase 2 PR summary and verification | `docs/plans/2026-04-26-codex-console-phase2-release-note.md` |
 
@@ -85,11 +94,16 @@ Kept outside archive because they still help the current direction:
 
 ## Next Sustainable Task Queue
 
-1. **Live Feishu tenant smoke.** Verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery.
-2. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
-3. **Docs context budget enforcement.** Keep routers pointing to this brief plus one leaf; archive or demote any new dated plan after closeout.
-4. **Web/App pre-implementation gate.** Before coding Web/App, turn the sketch into stable Core/state/API contracts and readiness criteria.
-5. **PR hygiene.** Each continuation PR should include a short release note, verification commands, and an archive/demotion decision for any temporary plan files.
+1. **W4 formal Web MVP docs landing — complete/landed.** Use the Web MVP scope/readiness leaf as the owner-readable source for the approved Web-first, App-later, read-mostly first lane.
+2. **W5 VPS/mobile access and security plan — complete/landed.** Use the operations access/security plan as the owner-readable source for screenshot-first validation, protected URL exposure choices, forbidden-data defaults, phone checklist, and shutdown gates.
+3. **Independent scope/readiness/security review — complete/landed.** The action-control wording blocker was fixed; first lane is strictly read-mostly with actions deferred to later lanes.
+4. **Web prototype implementation planning — complete/landed.** Use the read-only prototype implementation plan for page skeletons, candidate Core/state surfaces, redacted data contracts, auth assumptions, validation flow, forbidden scope, and future coding milestones.
+5. **W9 read-only Web view-model inventory — complete/landed.** Use the inventory for the service-level adapter seam and remaining read-only gaps, not routes, auth middleware, task submission, or action controls.
+6. **Web service view-model seam closeout/hygiene — current.** The first read-only adapter, Gap1 final-answer/workspace redaction, and Gap2 pending-interactions read model have landed; closeout should keep docs/status wording aligned without claiming Web support.
+7. **Gap3 neutral artifact catalog/descriptors — next implementation after closeout.** Keep this read-only and descriptor-only; do not add routes, UI, auth, servers, writes, downloads, uploads, or action controls.
+8. **Live Feishu tenant smoke.** Verify text, cards, callbacks, file/image upload/download, long output, status/inspect, project/session selection, and degraded recovery as a separate current-pack readiness track.
+9. **Feishu UX hardening.** Convert smoke results into specific pack/readiness fixes; keep non-native pin/menu/audio/image-url limits explicit.
+10. **Docs context budget enforcement and PR hygiene.** Keep routers pointing to this brief plus one leaf; archive or demote temporary plan files after closeout, and include verification commands in each continuation PR.
 
 ## Noise Checks Before Adding A New Doc
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,12 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/cli.ts",
     "check": "tsc -p tsconfig.json --noEmit",
-    "test": "node --import tsx --test \"src/**/*.test.ts\""
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
+    "web:preview:start": "bash scripts/web-preview-start.sh",
+    "web:preview:stop": "bash scripts/web-preview-stop.sh",
+    "web:preview:status": "bash scripts/web-preview-status.sh",
+    "web:preview:rotate": "bash scripts/web-preview-rotate-secrets.sh",
+    "web:preview:smoke": "bash scripts/web-preview-smoke.sh"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/scripts/web-owner-cookie-proxy.py
+++ b/scripts/web-owner-cookie-proxy.py
@@ -3,8 +3,9 @@
 
 This is intentionally small and personal-use oriented. It accepts an owner
 password at /owner-login, sets a signed HttpOnly/Secure/SameSite=Lax cookie,
-and forwards authenticated GET/HEAD traffic to the localhost read-only Web app
-with the bearer token injected from the environment.
+and forwards authenticated GET/HEAD traffic plus the narrow Web message POST
+endpoint to the localhost Web app with the bearer token injected from the
+environment.
 """
 
 from __future__ import annotations
@@ -33,6 +34,7 @@ DEFAULT_SESSION_MAX_AGE = 6 * 60 * 60
 DEFAULT_THROTTLE_LIMIT = 5
 DEFAULT_THROTTLE_SECONDS = 60
 MAX_FORM_BYTES = 4096
+MAX_UPSTREAM_POST_BYTES = 32 * 1024
 
 LOGIN_PAGE = """<!doctype html>
 <html lang="en">
@@ -139,10 +141,21 @@ class OwnerCookieProxyHandler(BaseHTTPRequestHandler):
         self._forward_authenticated(head_only=True)
 
     def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
-        if self.path_only != "/owner-login":
+        if self.path_only == "/owner-login":
+            self._handle_owner_login_post()
+            return
+
+        if not self._authenticated() or not is_conversation_message_path(self.path_only):
             self._send_not_found()
             return
 
+        body = self._read_upstream_post_body()
+        if body is None:
+            self._send_not_found()
+            return
+        self._forward_authenticated(head_only=False, method="POST", body=body)
+
+    def _handle_owner_login_post(self) -> None:
         client_key = self._client_key()
         if self.server.throttle.is_locked(client_key):
             self._send_plain(HTTPStatus.TOO_MANY_REQUESTS, "try again later")
@@ -242,23 +255,53 @@ class OwnerCookieProxyHandler(BaseHTTPRequestHandler):
         self.send_header("Referrer-Policy", "no-referrer")
         self.send_header("X-Content-Type-Options", "nosniff")
 
-    def _forward_authenticated(self, *, head_only: bool) -> None:
+    def _read_upstream_post_body(self) -> Optional[bytes]:
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            return None
+        if length < 0 or length > MAX_UPSTREAM_POST_BYTES:
+            return None
+        return self.rfile.read(length)
+
+    def _forward_authenticated(self, *, head_only: bool, method: str = "GET", body: bytes = b"") -> None:
         upstream = urllib.parse.urlsplit(self.server.config.upstream)
         path = self.path if self.path.startswith("/") else "/"
         connection_cls = http.client.HTTPSConnection if upstream.scheme == "https" else http.client.HTTPConnection
         port = upstream.port or (443 if upstream.scheme == "https" else 80)
         host = upstream.hostname or "127.0.0.1"
+        request_method = "HEAD" if head_only else method
+        headers = {
+            "Authorization": f"Bearer {self.server.config.readonly_token}",
+            "Accept": self.headers.get("Accept", "text/html,application/xhtml+xml"),
+            "User-Agent": "codex-web-owner-cookie-proxy",
+            "Host": upstream.netloc,
+            "X-Forwarded-Host": self.headers.get("Host", ""),
+            "X-Forwarded-Proto": self.headers.get("X-Forwarded-Proto", "https"),
+        }
+        content_type = safe_forward_content_type(self.headers.get("Content-Type", ""))
+        if request_method == "POST":
+            if content_type is None:
+                self._send_not_found()
+                return
+            headers["Content-Type"] = content_type
+            headers["Content-Length"] = str(len(body))
+            csrf_header = self.headers.get("X-CSRF-Token")
+            if csrf_header:
+                headers["X-CSRF-Token"] = csrf_header
+            origin = self.headers.get("Origin")
+            if origin:
+                headers["Origin"] = origin
+            referer = self.headers.get("Referer")
+            if referer:
+                headers["Referer"] = referer
         try:
             connection = connection_cls(host, port, timeout=10)
             connection.request(
-                "HEAD" if head_only else "GET",
+                request_method,
                 path,
-                headers={
-                    "Authorization": f"Bearer {self.server.config.readonly_token}",
-                    "Accept": self.headers.get("Accept", "text/html,application/xhtml+xml"),
-                    "User-Agent": "codex-web-owner-cookie-proxy",
-                    "Host": upstream.netloc,
-                },
+                body=body if request_method == "POST" else None,
+                headers=headers,
             )
             upstream_response = connection.getresponse()
             body = b"" if head_only else upstream_response.read()
@@ -319,6 +362,21 @@ def parse_cookie_header(header: str) -> Dict[str, str]:
         name, value = item.split("=", 1)
         result[name.strip()] = value.strip()
     return result
+
+
+def is_conversation_message_path(path: str) -> bool:
+    parts = path.strip("/").split("/")
+    if len(parts) != 3 or parts[0] != "conversations" or parts[2] != "messages":
+        return False
+    handle = parts[1]
+    return len(handle) == 19 and handle.startswith("cv_") and all(ch in "0123456789abcdef" for ch in handle[3:])
+
+
+def safe_forward_content_type(value: str) -> Optional[str]:
+    content_type = value.split(";", 1)[0].strip().lower()
+    if content_type in {"application/x-www-form-urlencoded", "application/json", "text/plain"}:
+        return value[:200]
+    return None
 
 
 def read_config(env: Mapping[str, str]) -> ProxyConfig:
@@ -410,6 +468,20 @@ def run_self_test() -> int:
             self.send_header("Content-Length", "0")
             self.end_headers()
 
+        def do_POST(self) -> None:  # noqa: N802
+            seen["post_authorization"] = self.headers.get("Authorization", "")
+            seen["post_content_type"] = self.headers.get("Content-Type", "")
+            seen["post_origin"] = self.headers.get("Origin", "")
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length)
+            seen["post_body_len"] = str(len(body))
+            response_body = b'{"status":"accepted"}\n'
+            self.send_response(202)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(response_body)))
+            self.end_headers()
+            self.wfile.write(response_body)
+
         def log_message(self, fmt: str, *args: object) -> None:
             return
 
@@ -450,6 +522,31 @@ def run_self_test() -> int:
         status, _, body = request(proxy_port, "GET", "/interactions", headers={"Cookie": cookie})
         assert status == 200 and body == b"upstream-interactions"
         assert seen["authorization"] == "Bearer readonly-token"
+        status, _, _ = request(
+            proxy_port,
+            "POST",
+            "/conversations/cv_1234567890abcdef/messages",
+            body="_csrf=csrf-token&message=hello",
+            headers={"Content-Type": "application/x-www-form-urlencoded", "Origin": "https://preview.example.test"},
+        )
+        assert status == 404 and "post_authorization" not in seen
+        status, _, body = request(
+            proxy_port,
+            "POST",
+            "/conversations/cv_1234567890abcdef/messages",
+            body="_csrf=csrf-token&message=hello",
+            headers={
+                "Cookie": cookie,
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Origin": "https://preview.example.test",
+                "Host": "preview.example.test",
+            },
+        )
+        assert status == 202 and body == b'{"status":"accepted"}\n'
+        assert seen["post_authorization"] == "Bearer readonly-token"
+        assert seen["post_content_type"].startswith("application/x-www-form-urlencoded")
+        assert seen["post_origin"] == "https://preview.example.test"
+        assert seen["post_body_len"] == str(len("_csrf=csrf-token&message=hello"))
         status, _, _ = request(
             proxy_port,
             "POST",

--- a/scripts/web-owner-cookie-proxy.py
+++ b/scripts/web-owner-cookie-proxy.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Owner-login cookie proxy for the local Codex Console Web preview.
+
+This is intentionally small and personal-use oriented. It accepts an owner
+password at /owner-login, sets a signed HttpOnly/Secure/SameSite=Lax cookie,
+and forwards authenticated GET/HEAD traffic to the localhost read-only Web app
+with the bearer token injected from the environment.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import http.client
+import json
+import os
+import secrets
+import sys
+import threading
+import time
+import urllib.parse
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional, Tuple
+
+COOKIE_NAME = "ctb_web_owner"
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PROXY_PORT = 45683
+DEFAULT_UPSTREAM = "http://127.0.0.1:45682"
+DEFAULT_SESSION_MAX_AGE = 6 * 60 * 60
+DEFAULT_THROTTLE_LIMIT = 5
+DEFAULT_THROTTLE_SECONDS = 60
+MAX_FORM_BYTES = 4096
+
+LOGIN_PAGE = """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Owner preview login</title>
+  <style>
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; font-family: system-ui, sans-serif; background: #0f172a; color: #e2e8f0; }
+    main { width: min(28rem, calc(100vw - 2rem)); padding: 2rem; border: 1px solid #334155; border-radius: 1rem; background: #111827; box-shadow: 0 24px 80px rgb(0 0 0 / 0.35); }
+    h1 { margin: 0 0 0.5rem; font-size: 1.5rem; }
+    p { color: #94a3b8; line-height: 1.5; }
+    label { display: grid; gap: 0.5rem; margin: 1rem 0; color: #cbd5e1; }
+    input { border: 1px solid #475569; border-radius: 0.7rem; padding: 0.8rem 0.9rem; background: #020617; color: #f8fafc; font-size: 1rem; }
+    button { width: 100%; border: 0; border-radius: 0.7rem; padding: 0.85rem 1rem; background: #38bdf8; color: #082f49; font-weight: 700; cursor: pointer; }
+    .error { color: #fecaca; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Owner preview login</h1>
+    <p>Enter the local owner preview password to view the read-only Codex Console.</p>
+    __MESSAGE__
+    <form method="post" action="/owner-login">
+      <label>Preview password<input name="password" type="password" autocomplete="current-password" required autofocus></label>
+      <button type="submit">Open preview</button>
+    </form>
+  </main>
+</body>
+</html>
+"""
+
+
+@dataclass(frozen=True)
+class ProxyConfig:
+    host: str
+    port: int
+    upstream: str
+    readonly_token: str
+    owner_password: str
+    session_secret: str
+    session_max_age: int = DEFAULT_SESSION_MAX_AGE
+    throttle_limit: int = DEFAULT_THROTTLE_LIMIT
+    throttle_seconds: int = DEFAULT_THROTTLE_SECONDS
+
+
+class LoginThrottle:
+    def __init__(self, limit: int, lock_seconds: int) -> None:
+        self._limit = max(1, limit)
+        self._lock_seconds = max(1, lock_seconds)
+        self._failures: Dict[str, Tuple[int, float]] = {}
+        self._lock = threading.Lock()
+
+    def is_locked(self, key: str, now: Optional[float] = None) -> bool:
+        current = time.time() if now is None else now
+        with self._lock:
+            failures, locked_until = self._failures.get(key, (0, 0.0))
+            if locked_until > current:
+                return True
+            if locked_until and locked_until <= current:
+                self._failures[key] = (0, 0.0)
+            return False
+
+    def record_failure(self, key: str, now: Optional[float] = None) -> None:
+        current = time.time() if now is None else now
+        with self._lock:
+            failures, locked_until = self._failures.get(key, (0, 0.0))
+            if locked_until > current:
+                return
+            failures += 1
+            self._failures[key] = (
+                failures,
+                current + self._lock_seconds if failures >= self._limit else 0.0,
+            )
+
+    def record_success(self, key: str) -> None:
+        with self._lock:
+            self._failures.pop(key, None)
+
+
+class OwnerCookieProxyHandler(BaseHTTPRequestHandler):
+    server: "OwnerCookieProxyServer"
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path_only == "/healthz":
+            self._send_json(HTTPStatus.OK, {"ok": True, "service": "web-owner-cookie-proxy"})
+            return
+        if self.path_only == "/owner-login":
+            self._send_login()
+            return
+        if not self._authenticated():
+            self._send_login()
+            return
+        self._forward_authenticated(head_only=False)
+
+    def do_HEAD(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path_only == "/healthz":
+            self._send_json(HTTPStatus.OK, {"ok": True, "service": "web-owner-cookie-proxy"}, head_only=True)
+            return
+        if self.path_only == "/owner-login" or not self._authenticated():
+            self._send_login(head_only=True)
+            return
+        self._forward_authenticated(head_only=True)
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path_only != "/owner-login":
+            self._send_not_found()
+            return
+
+        client_key = self._client_key()
+        if self.server.throttle.is_locked(client_key):
+            self._send_plain(HTTPStatus.TOO_MANY_REQUESTS, "try again later")
+            return
+
+        password = self._read_password_field()
+        if password is not None and hmac.compare_digest(password, self.server.config.owner_password):
+            self.server.throttle.record_success(client_key)
+            cookie = sign_session_cookie(self.server.config, now=int(time.time()))
+            self.send_response(HTTPStatus.SEE_OTHER)
+            self._send_common_headers(content_type="text/plain; charset=utf-8")
+            self.send_header("Location", "/")
+            self.send_header(
+                "Set-Cookie",
+                f"{COOKIE_NAME}={cookie}; Max-Age={self.server.config.session_max_age}; Path=/; HttpOnly; Secure; SameSite=Lax",
+            )
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        self.server.throttle.record_failure(client_key)
+        self._send_login(HTTPStatus.UNAUTHORIZED, message="<p class=\"error\">Login failed.</p>")
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        # Avoid logging paths, headers, cookies, or submitted form data.
+        return
+
+    @property
+    def path_only(self) -> str:
+        try:
+            return urllib.parse.urlsplit(self.path).path or "/"
+        except ValueError:
+            return "/"
+
+    def _authenticated(self) -> bool:
+        cookie_header = self.headers.get("Cookie", "")
+        cookies = parse_cookie_header(cookie_header)
+        value = cookies.get(COOKIE_NAME)
+        return bool(value and verify_session_cookie(value, self.server.config, now=int(time.time())))
+
+    def _client_key(self) -> str:
+        cf_ip = self.headers.get("CF-Connecting-IP", "").split(",", 1)[0].strip()
+        forwarded = self.headers.get("X-Forwarded-For", "").split(",", 1)[0].strip()
+        return cf_ip or forwarded or self.client_address[0]
+
+    def _read_password_field(self) -> Optional[str]:
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            return None
+        if length < 0 or length > MAX_FORM_BYTES:
+            return None
+        body = self.rfile.read(length).decode("utf-8", errors="replace")
+        values = urllib.parse.parse_qs(body, keep_blank_values=True, strict_parsing=False)
+        candidates = values.get("password") or values.get("pass") or []
+        return candidates[0] if candidates else None
+
+    def _send_login(
+        self,
+        status: HTTPStatus = HTTPStatus.OK,
+        *,
+        message: str = "",
+        head_only: bool = False,
+    ) -> None:
+        body = LOGIN_PAGE.replace("__MESSAGE__", message).encode("utf-8")
+        self.send_response(status)
+        self._send_common_headers()
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if not head_only:
+            self.wfile.write(body)
+
+    def _send_json(self, status: HTTPStatus, payload: Mapping[str, object], *, head_only: bool = False) -> None:
+        body = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+        self.send_response(status)
+        self._send_common_headers(content_type="application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if not head_only:
+            self.wfile.write(body)
+
+    def _send_plain(self, status: HTTPStatus, body_text: str) -> None:
+        body = body_text.encode("utf-8")
+        self.send_response(status)
+        self._send_common_headers(content_type="text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_not_found(self) -> None:
+        self._send_plain(HTTPStatus.NOT_FOUND, "not found")
+
+    def _send_common_headers(self, *, content_type: str = "text/html; charset=utf-8") -> None:
+        self.send_header("Content-Type", content_type)
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
+
+    def _forward_authenticated(self, *, head_only: bool) -> None:
+        upstream = urllib.parse.urlsplit(self.server.config.upstream)
+        path = self.path if self.path.startswith("/") else "/"
+        connection_cls = http.client.HTTPSConnection if upstream.scheme == "https" else http.client.HTTPConnection
+        port = upstream.port or (443 if upstream.scheme == "https" else 80)
+        host = upstream.hostname or "127.0.0.1"
+        try:
+            connection = connection_cls(host, port, timeout=10)
+            connection.request(
+                "HEAD" if head_only else "GET",
+                path,
+                headers={
+                    "Authorization": f"Bearer {self.server.config.readonly_token}",
+                    "Accept": self.headers.get("Accept", "text/html,application/xhtml+xml"),
+                    "User-Agent": "codex-web-owner-cookie-proxy",
+                    "Host": upstream.netloc,
+                },
+            )
+            upstream_response = connection.getresponse()
+            body = b"" if head_only else upstream_response.read()
+            self.send_response(upstream_response.status)
+            for name, value in upstream_response.getheaders():
+                lower = name.lower()
+                if lower in {"connection", "keep-alive", "proxy-authenticate", "proxy-authorization", "te", "trailers", "transfer-encoding", "upgrade", "set-cookie", "content-length"}:
+                    continue
+                self.send_header(name, value)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if body:
+                self.wfile.write(body)
+        except Exception:
+            self._send_plain(HTTPStatus.BAD_GATEWAY, "upstream unavailable")
+        finally:
+            try:
+                connection.close()  # type: ignore[possibly-undefined]
+            except Exception:
+                pass
+
+
+class OwnerCookieProxyServer(ThreadingHTTPServer):
+    def __init__(self, server_address: Tuple[str, int], config: ProxyConfig) -> None:
+        super().__init__(server_address, OwnerCookieProxyHandler)
+        self.config = config
+        self.throttle = LoginThrottle(config.throttle_limit, config.throttle_seconds)
+
+
+def sign_session_cookie(config: ProxyConfig, *, now: int) -> str:
+    expires = now + config.session_max_age
+    payload = json.dumps({"exp": expires, "nonce": secrets.token_urlsafe(18)}, separators=(",", ":")).encode("utf-8")
+    payload_b64 = base64.urlsafe_b64encode(payload).rstrip(b"=").decode("ascii")
+    signature = hmac.new(config.session_secret.encode("utf-8"), payload_b64.encode("ascii"), hashlib.sha256).digest()
+    signature_b64 = base64.urlsafe_b64encode(signature).rstrip(b"=").decode("ascii")
+    return f"{payload_b64}.{signature_b64}"
+
+
+def verify_session_cookie(value: str, config: ProxyConfig, *, now: int) -> bool:
+    try:
+        payload_b64, signature_b64 = value.split(".", 1)
+        expected = hmac.new(config.session_secret.encode("utf-8"), payload_b64.encode("ascii"), hashlib.sha256).digest()
+        expected_b64 = base64.urlsafe_b64encode(expected).rstrip(b"=").decode("ascii")
+        if not hmac.compare_digest(signature_b64, expected_b64):
+            return False
+        payload_bytes = base64.urlsafe_b64decode(payload_b64 + "=" * (-len(payload_b64) % 4))
+        payload = json.loads(payload_bytes.decode("utf-8"))
+        return isinstance(payload.get("exp"), int) and payload["exp"] >= now
+    except Exception:
+        return False
+
+
+def parse_cookie_header(header: str) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    for item in header.split(";"):
+        if "=" not in item:
+            continue
+        name, value = item.split("=", 1)
+        result[name.strip()] = value.strip()
+    return result
+
+
+def read_config(env: Mapping[str, str]) -> ProxyConfig:
+    password = env.get("CTB_WEB_PREVIEW_PASS") or env.get("CTB_WEB_BASIC_PASS") or ""
+    token = env.get("CTB_WEB_READONLY_TOKEN", "")
+    session_secret = env.get("CTB_WEB_SESSION_SECRET", "")
+    missing = [
+        name
+        for name, value in (
+            ("CTB_WEB_READONLY_TOKEN", token),
+            ("CTB_WEB_PREVIEW_PASS or CTB_WEB_BASIC_PASS", password),
+            ("CTB_WEB_SESSION_SECRET", session_secret),
+        )
+        if not value.strip()
+    ]
+    if missing:
+        raise SystemExit(f"missing required environment: {', '.join(missing)}")
+
+    return ProxyConfig(
+        host=DEFAULT_HOST,
+        port=parse_int(env.get("PROXY_PORT"), DEFAULT_PROXY_PORT, "PROXY_PORT"),
+        upstream=env.get("UPSTREAM", DEFAULT_UPSTREAM).strip() or DEFAULT_UPSTREAM,
+        readonly_token=token.strip(),
+        owner_password=password,
+        session_secret=session_secret.strip(),
+        session_max_age=parse_int(env.get("CTB_WEB_SESSION_MAX_AGE"), DEFAULT_SESSION_MAX_AGE, "CTB_WEB_SESSION_MAX_AGE"),
+        throttle_limit=parse_int(env.get("CTB_WEB_LOGIN_THROTTLE_LIMIT"), DEFAULT_THROTTLE_LIMIT, "CTB_WEB_LOGIN_THROTTLE_LIMIT"),
+        throttle_seconds=parse_int(env.get("CTB_WEB_LOGIN_THROTTLE_SECONDS"), DEFAULT_THROTTLE_SECONDS, "CTB_WEB_LOGIN_THROTTLE_SECONDS"),
+    )
+
+
+def parse_int(value: Optional[str], default: int, name: str) -> int:
+    if value is None or value == "":
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise SystemExit(f"{name} must be an integer") from None
+    if parsed < 0 or parsed > 65535 and name == "PROXY_PORT":
+        raise SystemExit(f"{name} must be between 0 and 65535")
+    if parsed <= 0 and name != "PROXY_PORT":
+        raise SystemExit(f"{name} must be positive")
+    return parsed
+
+
+def serve(config: ProxyConfig) -> None:
+    httpd = OwnerCookieProxyServer((config.host, config.port), config)
+    print(f"web owner cookie proxy listening on {config.host}:{httpd.server_address[1]}", flush=True)
+    httpd.serve_forever()
+
+
+def main(argv: Iterable[str]) -> int:
+    args = list(argv)
+    if args == ["--self-test"]:
+        return run_self_test()
+    config = read_config(os.environ)
+    serve(config)
+    return 0
+
+
+def request(port: int, method: str, path: str, *, body: str = "", headers: Optional[Mapping[str, str]] = None) -> Tuple[int, Mapping[str, str], bytes]:
+    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    connection.request(method, path, body=body.encode("utf-8"), headers=dict(headers or {}))
+    response = connection.getresponse()
+    data = response.read()
+    result_headers = {name.lower(): value for name, value in response.getheaders()}
+    connection.close()
+    return response.status, result_headers, data
+
+
+def run_self_test() -> int:
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    seen: MutableMapping[str, str] = {}
+
+    class UpstreamHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            seen["authorization"] = self.headers.get("Authorization", "")
+            body = ("upstream-interactions" if self.path == "/interactions" else "upstream-home").encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_HEAD(self) -> None:  # noqa: N802
+            seen["authorization"] = self.headers.get("Authorization", "")
+            self.send_response(200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, fmt: str, *args: object) -> None:
+            return
+
+    upstream = ThreadingHTTPServer((DEFAULT_HOST, 0), UpstreamHandler)
+    upstream_thread = threading.Thread(target=upstream.serve_forever, daemon=True)
+    upstream_thread.start()
+    upstream_port = upstream.server_address[1]
+
+    config = ProxyConfig(
+        host=DEFAULT_HOST,
+        port=0,
+        upstream=f"http://127.0.0.1:{upstream_port}",
+        readonly_token="readonly-token",
+        owner_password="owner-password",
+        session_secret="session-secret",
+        throttle_limit=2,
+        throttle_seconds=1,
+    )
+    proxy = OwnerCookieProxyServer((DEFAULT_HOST, 0), config)
+    proxy_thread = threading.Thread(target=proxy.serve_forever, daemon=True)
+    proxy_thread.start()
+    proxy_port = proxy.server_address[1]
+
+    try:
+        status, _, body = request(proxy_port, "GET", "/healthz")
+        assert status == 200 and b"web-owner-cookie-proxy" in body
+        status, _, body = request(proxy_port, "GET", "/")
+        assert status == 200 and b"Owner preview login" in body and "authorization" not in seen
+        status, headers, _ = request(
+            proxy_port,
+            "POST",
+            "/owner-login",
+            body="password=owner-password",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert status == 303 and COOKIE_NAME in headers.get("set-cookie", "")
+        cookie = headers["set-cookie"].split(";", 1)[0]
+        status, _, body = request(proxy_port, "GET", "/interactions", headers={"Cookie": cookie})
+        assert status == 200 and body == b"upstream-interactions"
+        assert seen["authorization"] == "Bearer readonly-token"
+        status, _, _ = request(
+            proxy_port,
+            "POST",
+            "/owner-login",
+            body="password=wrong",
+            headers={"Content-Type": "application/x-www-form-urlencoded", "X-Forwarded-For": "203.0.113.10"},
+        )
+        assert status == 401
+        status, _, _ = request(
+            proxy_port,
+            "POST",
+            "/owner-login",
+            body="password=wrong",
+            headers={"Content-Type": "application/x-www-form-urlencoded", "X-Forwarded-For": "203.0.113.10"},
+        )
+        assert status == 401
+        status, _, _ = request(
+            proxy_port,
+            "POST",
+            "/owner-login",
+            body="password=owner-password",
+            headers={"Content-Type": "application/x-www-form-urlencoded", "X-Forwarded-For": "203.0.113.10"},
+        )
+        assert status == 429
+    finally:
+        proxy.shutdown()
+        upstream.shutdown()
+        proxy.server_close()
+        upstream.server_close()
+    print("web-owner-cookie-proxy self-test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/web-preview-rotate-secrets.sh
+++ b/scripts/web-preview-rotate-secrets.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE=${CTB_WEB_PREVIEW_ENV:-"$HOME/.config/codex-telegram-bridge/web-preview.env"}
+STATE_DIR=${CTB_WEB_PREVIEW_STATE_DIR:-"$HOME/.local/state/codex-telegram-bridge/web-preview"}
+mkdir -p "$(dirname "$ENV_FILE")"
+umask 077
+touch "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+python3 - "$ENV_FILE" <<'PY'
+from pathlib import Path
+import secrets
+import sys
+
+path = Path(sys.argv[1])
+updates = {
+    "CTB_WEB_READONLY_TOKEN": secrets.token_hex(32),
+    "CTB_WEB_SESSION_SECRET": secrets.token_hex(32),
+    "CTB_WEB_PREVIEW_PASS": secrets.token_hex(32),
+}
+lines = path.read_text().splitlines() if path.exists() else []
+seen = set()
+out = []
+for line in lines:
+    if not line or line.lstrip().startswith("#") or "=" not in line:
+        out.append(line)
+        continue
+    key = line.split("=", 1)[0]
+    if key in updates:
+        out.append(f"{key}={updates[key]}")
+        seen.add(key)
+    else:
+        out.append(line)
+for key, value in updates.items():
+    if key not in seen:
+        out.append(f"{key}={value}")
+path.write_text("\n".join(out) + "\n")
+PY
+chmod 600 "$ENV_FILE"
+
+echo "Rotated CTB_WEB_READONLY_TOKEN, CTB_WEB_SESSION_SECRET, and CTB_WEB_PREVIEW_PASS in $ENV_FILE."
+echo "New secrets were not printed. Restart the preview to apply them:"
+echo "  scripts/web-preview-stop.sh && scripts/web-preview-start.sh"
+if [[ -d "$STATE_DIR" ]] && find "$STATE_DIR" -maxdepth 1 -name '*.pid' -size +0c | grep -q .; then
+  echo "Managed pid files are present under $STATE_DIR; current processes keep old secrets until restart."
+fi

--- a/scripts/web-preview-smoke.sh
+++ b/scripts/web-preview-smoke.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE=${CTB_WEB_PREVIEW_ENV:-"$HOME/.config/codex-telegram-bridge/web-preview.env"}
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "ERROR: env file not found: $ENV_FILE" >&2
+  exit 1
+fi
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+: "${CTB_WEB_READONLY_PORT:=45682}"
+: "${PROXY_PORT:=45683}"
+PASS=${CTB_WEB_PREVIEW_PASS:-${CTB_WEB_BASIC_PASS:-}}
+if [[ -z "${PASS}" || -z "${CTB_WEB_READONLY_TOKEN:-}" || -z "${CTB_WEB_SESSION_SECRET:-}" ]]; then
+  echo "ERROR: missing password, bearer token, or session secret in $ENV_FILE" >&2
+  exit 1
+fi
+BASE="http://127.0.0.1:${PROXY_PORT}"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+curl_code() {
+  local out=$1; shift
+  curl -sS --max-time 10 -o "$out" -w '%{http_code}' "$@"
+}
+
+expect_code() {
+  local expected=$1 actual=$2 label=$3
+  if [[ "$actual" != "$expected" ]]; then
+    echo "ERROR: $label returned HTTP $actual, expected $expected" >&2
+    exit 1
+  fi
+  echo "ok: $label HTTP $actual"
+}
+
+leak_check() {
+  local label=$1; shift
+  local file
+  for file in "$@"; do
+    [[ -f "$file" ]] || continue
+    for secret in "$CTB_WEB_READONLY_TOKEN" "$CTB_WEB_SESSION_SECRET" "$PASS"; do
+      if [[ -n "$secret" ]] && grep -Fq "$secret" "$file"; then
+        echo "ERROR: secret leaked in $label" >&2
+        exit 1
+      fi
+    done
+  done
+}
+
+code=$(curl_code "$TMP_DIR/healthz.body" "$BASE/healthz")
+expect_code 200 "$code" "proxy /healthz"
+grep -q '"ok":true' "$TMP_DIR/healthz.body" || { echo "ERROR: /healthz is not machine-checkable" >&2; exit 1; }
+leak_check healthz "$TMP_DIR/healthz.body"
+
+code=$(curl_code "$TMP_DIR/login.body" "$BASE/owner-login")
+expect_code 200 "$code" "GET /owner-login"
+grep -q 'Owner preview login' "$TMP_DIR/login.body" || { echo "ERROR: login page marker missing" >&2; exit 1; }
+leak_check login "$TMP_DIR/login.body"
+
+code=$(curl_code "$TMP_DIR/unauth-root.body" "$BASE/")
+expect_code 200 "$code" "unauthenticated /"
+grep -q 'Owner preview login' "$TMP_DIR/unauth-root.body" || { echo "ERROR: unauthenticated root did not return login" >&2; exit 1; }
+leak_check unauth-root "$TMP_DIR/unauth-root.body"
+
+# Direct readonly app should not expose state without the bearer token.
+direct_code=$(curl -sS --max-time 5 -o "$TMP_DIR/direct-readonly.body" -w '%{http_code}' "http://127.0.0.1:${CTB_WEB_READONLY_PORT}/" || true)
+if [[ "$direct_code" == "200" ]]; then
+  echo "ERROR: direct readonly app returned public 200 without bearer token" >&2
+  exit 1
+fi
+echo "ok: direct readonly app unauthenticated HTTP $direct_code"
+leak_check direct-readonly "$TMP_DIR/direct-readonly.body"
+
+login_code=$(curl -sS --max-time 10 -D "$TMP_DIR/login.headers" -o "$TMP_DIR/login-post.body" -w '%{http_code}' \
+  -X POST --data-urlencode "password=${PASS}" "$BASE/owner-login")
+expect_code 303 "$login_code" "POST /owner-login"
+COOKIE=$(grep -i '^Set-Cookie:' "$TMP_DIR/login.headers" | head -n1 | sed -E 's/^[Ss]et-[Cc]ookie:[[:space:]]*//; s/;.*$//')
+if [[ -z "$COOKIE" || "$COOKIE" != ctb_web_owner=* ]]; then
+  echo "ERROR: owner session cookie missing" >&2
+  exit 1
+fi
+leak_check login-post "$TMP_DIR/login.headers" "$TMP_DIR/login-post.body"
+
+home_code=$(curl_code "$TMP_DIR/home.body" -H "Cookie: $COOKIE" "$BASE/")
+expect_code 200 "$home_code" "authenticated Home"
+grep -q 'Codex Console' "$TMP_DIR/home.body" || { echo "ERROR: Home marker missing" >&2; exit 1; }
+leak_check home "$TMP_DIR/home.body"
+
+interactions_code=$(curl_code "$TMP_DIR/interactions.body" -H "Cookie: $COOKIE" "$BASE/interactions")
+expect_code 200 "$interactions_code" "authenticated /interactions"
+grep -Eq 'Pending/Approvals|Pending interactions|Codex Console' "$TMP_DIR/interactions.body" || { echo "ERROR: interactions marker missing" >&2; exit 1; }
+leak_check interactions "$TMP_DIR/interactions.body"
+
+DETAIL=$(grep -Eoh '/conversations/cv_[a-f0-9]{16}' "$TMP_DIR/home.body" "$TMP_DIR/interactions.body" | head -n1 || true)
+if [[ -n "$DETAIL" ]]; then
+  detail_code=$(curl_code "$TMP_DIR/detail.body" -H "Cookie: $COOKIE" "$BASE$DETAIL")
+  expect_code 200 "$detail_code" "authenticated detail $DETAIL"
+  leak_check detail "$TMP_DIR/detail.body"
+else
+  echo "ok: no conversation detail route discovered; skipped optional detail smoke"
+fi
+
+echo "Smoke passed for $BASE"

--- a/scripts/web-preview-start.sh
+++ b/scripts/web-preview-start.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ENV_FILE=${CTB_WEB_PREVIEW_ENV:-"$HOME/.config/codex-telegram-bridge/web-preview.env"}
+STATE_DIR=${CTB_WEB_PREVIEW_STATE_DIR:-"$HOME/.local/state/codex-telegram-bridge/web-preview"}
+LOG_DIR="$STATE_DIR/logs"
+
+secret_hex() {
+  python3 - <<'PY'
+import secrets
+print(secrets.token_hex(32))
+PY
+}
+
+ensure_env_file() {
+  mkdir -p "$(dirname "$ENV_FILE")" "$STATE_DIR" "$LOG_DIR"
+  umask 077
+  touch "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+}
+
+has_key() {
+  grep -Eq "^$1=" "$ENV_FILE"
+}
+
+append_key() {
+  printf '%s=%s\n' "$1" "$2" >> "$ENV_FILE"
+}
+
+ensure_key() {
+  local key=$1 value=$2
+  if ! has_key "$key"; then
+    append_key "$key" "$value"
+  fi
+}
+
+load_env() {
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+}
+
+pid_alive() {
+  local pid_file=$1
+  [[ -s "$pid_file" ]] || return 1
+  local pid
+  pid=$(cat "$pid_file")
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+port_busy() {
+  local port=$1
+  ss -ltnH 2>/dev/null | awk '{print $4}' | grep -Eq "(^|:)${port}$"
+}
+
+wait_for_port() {
+  local port=$1 name=$2
+  for _ in {1..60}; do
+    if port_busy "$port"; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "ERROR: $name did not listen on 127.0.0.1:$port in time" >&2
+  return 1
+}
+
+start_readonly() {
+  local pid_file="$STATE_DIR/readonly.pid"
+  if pid_alive "$pid_file"; then
+    echo "readonly app already running (pid $(cat "$pid_file"))"
+    return
+  fi
+  rm -f "$pid_file"
+  if port_busy "$CTB_WEB_READONLY_PORT"; then
+    echo "ERROR: port $CTB_WEB_READONLY_PORT is already in use; not starting readonly app" >&2
+    return 1
+  fi
+  (
+    cd "$REPO_ROOT"
+    set -a
+    # shellcheck disable=SC1090
+    . "$ENV_FILE"
+    set +a
+    if [[ "${CTB_WEB_USE_DIST:-0}" == "1" ]]; then
+      if [[ ! -f dist/cli.js ]]; then
+        echo "ERROR: CTB_WEB_USE_DIST=1 but dist/cli.js is missing" >&2
+        exit 1
+      fi
+      exec node dist/cli.js web readonly --platform "${CTB_WEB_READONLY_PLATFORM:-feishu}" --port "${CTB_WEB_READONLY_PORT:-45682}"
+    fi
+    exec node --import tsx src/cli.ts web readonly --platform "${CTB_WEB_READONLY_PLATFORM:-feishu}" --port "${CTB_WEB_READONLY_PORT:-45682}"
+  ) > "$LOG_DIR/readonly.log" 2>&1 &
+  echo $! > "$pid_file"
+  wait_for_port "$CTB_WEB_READONLY_PORT" "readonly app"
+  echo "started readonly app (pid $(cat "$pid_file"))"
+}
+
+start_proxy() {
+  local pid_file="$STATE_DIR/proxy.pid"
+  if pid_alive "$pid_file"; then
+    echo "cookie proxy already running (pid $(cat "$pid_file"))"
+    return
+  fi
+  rm -f "$pid_file"
+  if port_busy "$PROXY_PORT"; then
+    echo "ERROR: port $PROXY_PORT is already in use; not starting cookie proxy" >&2
+    return 1
+  fi
+  (
+    set -a
+    # shellcheck disable=SC1090
+    . "$ENV_FILE"
+    set +a
+    exec python3 "$REPO_ROOT/scripts/web-owner-cookie-proxy.py"
+  ) > "$LOG_DIR/proxy.log" 2>&1 &
+  echo $! > "$pid_file"
+  wait_for_port "$PROXY_PORT" "cookie proxy"
+  echo "started cookie proxy (pid $(cat "$pid_file"))"
+}
+
+start_cloudflared() {
+  local pid_file="$STATE_DIR/cloudflared.pid"
+  if pid_alive "$pid_file"; then
+    echo "cloudflared tunnel already running (pid $(cat "$pid_file"))"
+    return
+  fi
+  rm -f "$pid_file"
+  if ! command -v cloudflared >/dev/null 2>&1; then
+    echo "ERROR: cloudflared not found in PATH" >&2
+    return 1
+  fi
+  if [[ ! -f "$CTB_WEB_CLOUDFLARED_CONFIG" ]]; then
+    echo "ERROR: cloudflared config not found: $CTB_WEB_CLOUDFLARED_CONFIG" >&2
+    return 1
+  fi
+  (
+    exec cloudflared tunnel --config "$CTB_WEB_CLOUDFLARED_CONFIG" run "$CTB_WEB_CLOUDFLARED_TUNNEL"
+  ) > "$LOG_DIR/cloudflared.log" 2>&1 &
+  echo $! > "$pid_file"
+  echo "started cloudflared tunnel '$CTB_WEB_CLOUDFLARED_TUNNEL' (pid $(cat "$pid_file"))"
+}
+
+ensure_env_file
+ensure_key CTB_WEB_READONLY_PORT 45682
+ensure_key PROXY_PORT 45683
+ensure_key CTB_WEB_READONLY_PLATFORM feishu
+ensure_key CTB_WEB_PUBLIC_URL https://codex.guicheng.xyz
+ensure_key CTB_WEB_CLOUDFLARED_CONFIG "$HOME/.cloudflared/codex-console.yml"
+ensure_key CTB_WEB_CLOUDFLARED_TUNNEL codex-console
+ensure_key CTB_WEB_CLOUDFLARED_READY_URL http://127.0.0.1:20242/ready
+ensure_key CTB_WEB_READONLY_TOKEN "$(secret_hex)"
+ensure_key CTB_WEB_SESSION_SECRET "$(secret_hex)"
+if ! has_key CTB_WEB_PREVIEW_PASS && ! has_key CTB_WEB_BASIC_PASS; then
+  append_key CTB_WEB_PREVIEW_PASS "$(secret_hex)"
+fi
+load_env
+if ! has_key UPSTREAM; then
+  append_key UPSTREAM "http://127.0.0.1:${CTB_WEB_READONLY_PORT:-45682}"
+  load_env
+fi
+chmod 600 "$ENV_FILE"
+
+: "${CTB_WEB_READONLY_PORT:=45682}"
+: "${PROXY_PORT:=45683}"
+: "${CTB_WEB_PUBLIC_URL:=https://codex.guicheng.xyz}"
+: "${CTB_WEB_CLOUDFLARED_CONFIG:=$HOME/.cloudflared/codex-console.yml}"
+: "${CTB_WEB_CLOUDFLARED_TUNNEL:=codex-console}"
+
+start_readonly
+start_proxy
+start_cloudflared
+
+echo
+echo "Owner preview URL: $CTB_WEB_PUBLIC_URL"
+echo "Password location: $ENV_FILE (CTB_WEB_PREVIEW_PASS or CTB_WEB_BASIC_PASS)"
+echo "State/logs: $STATE_DIR"
+echo "Run smoke: $REPO_ROOT/scripts/web-preview-smoke.sh"

--- a/scripts/web-preview-start.sh
+++ b/scripts/web-preview-start.sh
@@ -99,6 +99,16 @@ start_readonly() {
   echo "started readonly app (pid $(cat "$pid_file"))"
 }
 
+use_live_upstream() {
+  if port_busy "$CTB_WEB_LIVE_PORT"; then
+    echo "using live bridge Web Chat upstream on 127.0.0.1:$CTB_WEB_LIVE_PORT"
+    return
+  fi
+  echo "ERROR: live bridge Web Chat is not listening on 127.0.0.1:$CTB_WEB_LIVE_PORT" >&2
+  echo "Start or restart the managed bridge service with CTB_WEB_LIVE_ENABLED=1, CTB_WEB_LIVE_PORT=$CTB_WEB_LIVE_PORT, and CTB_WEB_READONLY_TOKEN set." >&2
+  return 1
+}
+
 start_proxy() {
   local pid_file="$STATE_DIR/proxy.pid"
   if pid_alive "$pid_file"; then
@@ -146,7 +156,10 @@ start_cloudflared() {
 
 ensure_env_file
 ensure_key CTB_WEB_READONLY_PORT 45682
+ensure_key CTB_WEB_LIVE_PORT 45682
+ensure_key CTB_WEB_LIVE_HOST 127.0.0.1
 ensure_key PROXY_PORT 45683
+ensure_key CTB_WEB_PREVIEW_MODE readonly
 ensure_key CTB_WEB_READONLY_PLATFORM feishu
 ensure_key CTB_WEB_PUBLIC_URL https://codex.guicheng.xyz
 ensure_key CTB_WEB_CLOUDFLARED_CONFIG "$HOME/.cloudflared/codex-console.yml"
@@ -157,25 +170,46 @@ ensure_key CTB_WEB_SESSION_SECRET "$(secret_hex)"
 if ! has_key CTB_WEB_PREVIEW_PASS && ! has_key CTB_WEB_BASIC_PASS; then
   append_key CTB_WEB_PREVIEW_PASS "$(secret_hex)"
 fi
+if grep -Eq "^CTB_WEB_PREVIEW_MODE=live$" "$ENV_FILE"; then
+  ensure_key CTB_WEB_LIVE_ENABLED 1
+fi
 load_env
 if ! has_key UPSTREAM; then
-  append_key UPSTREAM "http://127.0.0.1:${CTB_WEB_READONLY_PORT:-45682}"
+  if [[ "${CTB_WEB_PREVIEW_MODE:-readonly}" == "live" ]]; then
+    append_key UPSTREAM "http://127.0.0.1:${CTB_WEB_LIVE_PORT:-${CTB_WEB_READONLY_PORT:-45682}}"
+  else
+    append_key UPSTREAM "http://127.0.0.1:${CTB_WEB_READONLY_PORT:-45682}"
+  fi
   load_env
 fi
 chmod 600 "$ENV_FILE"
 
 : "${CTB_WEB_READONLY_PORT:=45682}"
+: "${CTB_WEB_LIVE_PORT:=$CTB_WEB_READONLY_PORT}"
+: "${CTB_WEB_PREVIEW_MODE:=readonly}"
 : "${PROXY_PORT:=45683}"
 : "${CTB_WEB_PUBLIC_URL:=https://codex.guicheng.xyz}"
 : "${CTB_WEB_CLOUDFLARED_CONFIG:=$HOME/.cloudflared/codex-console.yml}"
 : "${CTB_WEB_CLOUDFLARED_TUNNEL:=codex-console}"
 
-start_readonly
+case "$CTB_WEB_PREVIEW_MODE" in
+  live)
+    use_live_upstream
+    ;;
+  readonly)
+    start_readonly
+    ;;
+  *)
+    echo "ERROR: CTB_WEB_PREVIEW_MODE must be readonly or live" >&2
+    exit 1
+    ;;
+esac
 start_proxy
 start_cloudflared
 
 echo
 echo "Owner preview URL: $CTB_WEB_PUBLIC_URL"
+echo "Preview mode: $CTB_WEB_PREVIEW_MODE"
 echo "Password location: $ENV_FILE (CTB_WEB_PREVIEW_PASS or CTB_WEB_BASIC_PASS)"
 echo "State/logs: $STATE_DIR"
 echo "Run smoke: $REPO_ROOT/scripts/web-preview-smoke.sh"

--- a/scripts/web-preview-status.sh
+++ b/scripts/web-preview-status.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE=${CTB_WEB_PREVIEW_ENV:-"$HOME/.config/codex-telegram-bridge/web-preview.env"}
+STATE_DIR=${CTB_WEB_PREVIEW_STATE_DIR:-"$HOME/.local/state/codex-telegram-bridge/web-preview"}
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+: "${CTB_WEB_READONLY_PORT:=45682}"
+: "${PROXY_PORT:=45683}"
+: "${CTB_WEB_PUBLIC_URL:=https://codex.guicheng.xyz}"
+: "${CTB_WEB_CLOUDFLARED_TUNNEL:=codex-console}"
+: "${CTB_WEB_CLOUDFLARED_READY_URL:=http://127.0.0.1:20242/ready}"
+
+pid_status() {
+  local name=$1 pid_file=$2
+  if [[ -s "$pid_file" ]]; then
+    local pid
+    pid=$(cat "$pid_file")
+    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+      echo "$name: running (pid $pid)"
+      return
+    fi
+    echo "$name: stale pid file ($pid_file)"
+    return
+  fi
+  echo "$name: no managed pid file"
+}
+
+port_status() {
+  local name=$1 port=$2
+  if ss -ltnH 2>/dev/null | awk '{print $4}' | grep -Eq "(^|:)${port}$"; then
+    echo "$name port: listening on $port"
+  else
+    echo "$name port: not listening on $port"
+  fi
+}
+
+echo "Env file: $ENV_FILE"
+echo "State dir: $STATE_DIR"
+echo "Public URL: $CTB_WEB_PUBLIC_URL"
+echo
+pid_status readonly "$STATE_DIR/readonly.pid"
+pid_status proxy "$STATE_DIR/proxy.pid"
+pid_status cloudflared "$STATE_DIR/cloudflared.pid"
+echo
+port_status readonly "$CTB_WEB_READONLY_PORT"
+port_status proxy "$PROXY_PORT"
+echo
+if command -v curl >/dev/null 2>&1; then
+  if curl -fsS --max-time 3 "http://127.0.0.1:${PROXY_PORT}/healthz" >/dev/null; then
+    echo "proxy healthz: ok"
+  else
+    echo "proxy healthz: unavailable"
+  fi
+  if curl -fsS --max-time 3 "$CTB_WEB_CLOUDFLARED_READY_URL" >/dev/null 2>&1; then
+    echo "cloudflared ready endpoint: ok ($CTB_WEB_CLOUDFLARED_READY_URL)"
+  else
+    echo "cloudflared ready endpoint: unavailable ($CTB_WEB_CLOUDFLARED_READY_URL)"
+  fi
+else
+  echo "curl: unavailable"
+fi
+if pgrep -af "[c]loudflared .*run ${CTB_WEB_CLOUDFLARED_TUNNEL}" >/dev/null 2>&1; then
+  echo "cloudflared named tunnel process: present ($CTB_WEB_CLOUDFLARED_TUNNEL)"
+else
+  echo "cloudflared named tunnel process: not found ($CTB_WEB_CLOUDFLARED_TUNNEL)"
+fi

--- a/scripts/web-preview-stop.sh
+++ b/scripts/web-preview-stop.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE_DIR=${CTB_WEB_PREVIEW_STATE_DIR:-"$HOME/.local/state/codex-telegram-bridge/web-preview"}
+ENV_FILE=${CTB_WEB_PREVIEW_ENV:-"$HOME/.config/codex-telegram-bridge/web-preview.env"}
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  set +a
+fi
+: "${CTB_WEB_CLOUDFLARED_TUNNEL:=codex-console}"
+
+stop_pid_file() {
+  local name=$1 pid_file=$2
+  if [[ ! -s "$pid_file" ]]; then
+    echo "$name: no pid file"
+    return
+  fi
+  local pid
+  pid=$(cat "$pid_file")
+  if [[ ! "$pid" =~ ^[0-9]+$ ]] || ! kill -0 "$pid" 2>/dev/null; then
+    echo "$name: not running"
+    rm -f "$pid_file"
+    return
+  fi
+  kill "$pid" 2>/dev/null || true
+  for _ in {1..40}; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      rm -f "$pid_file"
+      echo "$name: stopped"
+      return
+    fi
+    sleep 0.25
+  done
+  kill -KILL "$pid" 2>/dev/null || true
+  rm -f "$pid_file"
+  echo "$name: killed after timeout"
+}
+
+# Stop public ingress first, then proxy, then readonly app.
+stop_pid_file cloudflared "$STATE_DIR/cloudflared.pid"
+stop_pid_file proxy "$STATE_DIR/proxy.pid"
+stop_pid_file readonly "$STATE_DIR/readonly.pid"
+
+echo "Stop complete for managed preview pid files under $STATE_DIR."
+echo "Unrelated cloudflared quick tunnels, including :8088 previews, are not touched."

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -82,5 +82,34 @@ test("cli usage includes app-server guard install flags", async () => {
     assert.match(stdout, /--app-server-guard-mcp-worker-threshold/u);
     assert.match(stdout, /--app-server-guard-consecutive-windows/u);
     assert.match(stdout, /--app-server-guard-cooldown-ms/u);
+    assert.match(stdout, /ctb web readonly \[--token <token>\] \[--port <port>\]/u);
+  }
+});
+
+test("cli web readonly refuses to start without token", async () => {
+  const homeDir = await mkdtemp(join(tmpdir(), "ctb-cli-web-readonly-home-"));
+  const repoRoot = process.cwd();
+
+  try {
+    await execFile(
+      process.execPath,
+      ["--import", "tsx", "src/cli.ts", "web", "readonly"],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          CTB_WEB_READONLY_TOKEN: ""
+        }
+      }
+    );
+    assert.fail("cli should refuse web readonly without token");
+  } catch (error) {
+    const stdout = (error as { stdout?: string }).stdout ?? "";
+    const stderr = (error as { stderr?: string }).stderr ?? "";
+    assert.equal(stdout.includes("http://127.0.0.1"), false);
+    assert.match(stderr, /CTB_WEB_READONLY_TOKEN|--token/u);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
   }
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { loadConfig, parseProjectScanRootsValue, type BridgeInstallOverrides } f
 import { buildPerformanceReport, parseReportWindowMs } from "./perf/report.js";
 import { parseBridgePackName } from "./packs/catalog.js";
 import { parseBooleanLike } from "./util/boolean.js";
+import { startWebReadonlyLocalHarness } from "./web/readonly-cli.js";
 import {
   captureSystemdStopAuditCommand,
   clearAuthorization,
@@ -99,6 +100,7 @@ function printUsage(): void {
   ctb status
   ctb doctor
   ctb perf report [--window <5m|1h|24h|7d>]
+  ctb web readonly [--token <token>] [--port <port>]
   ctb start | stop | restart | update
   ctb uninstall [--purge-state]
   ctb authorize pending [--latest | --select <index> | --user-id <id> | --show-expired]
@@ -248,6 +250,29 @@ async function main(): Promise<void> {
         config,
         windowMs
       })}\n`);
+      return;
+    }
+
+    case "web": {
+      if (subcommand !== "readonly") {
+        printUsage();
+        process.exitCode = 1;
+        return;
+      }
+
+      if (flags.host !== undefined) {
+        process.stderr.write("ctb web readonly is local-only; --host is not supported\n");
+        process.exitCode = 1;
+        return;
+      }
+
+      await startWebReadonlyLocalHarness({
+        paths,
+        logger,
+        token: flags.token,
+        port: flags.port,
+        env: process.env
+      });
       return;
     }
 

--- a/src/service-web-submit.test.ts
+++ b/src/service-web-submit.test.ts
@@ -1,6 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
 
 import { BridgeService } from "./service.js";
 import type { SessionRow } from "./types.js";
@@ -60,6 +62,21 @@ function createHarness(sessions: SessionRow[], bindings = [{ chatId: "chat-1" }]
   return { service, calls };
 }
 
+async function withListeningServer<T>(server: Server, fn: (baseUrl: string) => Promise<T>): Promise<T> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  try {
+    return await fn(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
+  }
+}
+
 test("submitWebTextMessage resolves one owner binding and opaque conversation handle before delegating", async () => {
   const session = sessionFixture();
   const { service, calls } = createHarness([session]);
@@ -95,4 +112,60 @@ test("submitWebTextMessage rejects raw ids, archived sessions, mismatched chat, 
     });
     assert.deepEqual(result, { status: "rejected" });
   }
+});
+
+test("live web chat server renders enabled composer and POST invokes BridgeService submit seam", async () => {
+  const session = sessionFixture();
+  const service = Object.create(BridgeService.prototype) as BridgeService;
+  const rawService = service as any;
+  const submitted: unknown[] = [];
+  rawService.config = { activePack: "feishu" };
+  rawService.snapshot = null;
+  rawService.store = {
+    listChatBindings: () => [{ chatId: "chat-1" }],
+    listRecentProjects: () => [],
+    listSessionProjectStats: () => [],
+    listSessions: (chatId: string, options?: { archived?: boolean }) =>
+      [session].filter((row) => row.chatId === chatId && Boolean(row.archived) === Boolean(options?.archived)),
+    getSessionById: (sessionId: string) => sessionId === session.sessionId ? session : null,
+    listFinalAnswerViews: () => [],
+    getReadinessSnapshot: () => null,
+    listPendingInteractionsByChat: () => []
+  };
+  rawService.listActiveTurns = () => [];
+  rawService.submitWebTextMessage = async (request: unknown) => {
+    submitted.push(request);
+    return { status: "accepted" };
+  };
+
+  const csrfToken = "csrf-safe-token";
+  const server = service.createWebChatHttpServer({ token: "owner-token", csrfToken });
+  await withListeningServer(server, async (baseUrl) => {
+    const handle = conversationHandleForSessionId(session.sessionId);
+    const detail = await fetch(`${baseUrl}/conversations/${handle}`, {
+      headers: { Authorization: "Bearer owner-token" }
+    });
+    const html = await detail.text();
+    assert.equal(detail.status, 200);
+    assert.match(html, new RegExp(`action="/conversations/${handle}/messages"`));
+    assert.match(html, /<button type="submit">Send message<\/button>/);
+
+    const response = await fetch(`${baseUrl}/conversations/${handle}/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer owner-token",
+        "Content-Type": "application/x-www-form-urlencoded",
+        Host: "127.0.0.1"
+      },
+      body: `_csrf=${csrfToken}&message=%20live%20hello%20&nonce=n-1`,
+      redirect: "manual"
+    });
+    assert.equal(response.status, 303);
+    assert.equal(response.headers.get("location"), `/conversations/${handle}?send=accepted`);
+    assert.deepEqual(submitted, [{
+      conversationHandle: handle,
+      text: "live hello",
+      nonce: "n-1"
+    }]);
+  });
 });

--- a/src/service-web-submit.test.ts
+++ b/src/service-web-submit.test.ts
@@ -44,8 +44,11 @@ function createHarness(sessions: SessionRow[], bindings = [{ chatId: "chat-1" }]
   const service = Object.create(BridgeService.prototype) as BridgeService;
   const rawService = service as any;
   const calls: unknown[] = [];
+  rawService.config = { activePack: "feishu" };
   rawService.store = {
-    listChatBindings: () => bindings,
+    listChatBindings: (platform?: string) => platform
+      ? bindings.filter((binding) => !("platform" in binding) || binding.platform === platform)
+      : bindings,
     listSessions: (chatId: string, options?: { archived?: boolean }) => {
       calls.push({ type: "listSessions", chatId, archived: options?.archived });
       return sessions.filter((session) => session.chatId === chatId && Boolean(session.archived) === Boolean(options?.archived));

--- a/src/service-web-submit.test.ts
+++ b/src/service-web-submit.test.ts
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+
+import { BridgeService } from "./service.js";
+import type { SessionRow } from "./types.js";
+
+const idSalt = "web-readonly-view-model:v1";
+
+function conversationHandleForSessionId(sessionId: string): string {
+  return `cv_${createHash("sha256").update(idSalt).update("\0").update(sessionId).digest("hex").slice(0, 16)}`;
+}
+
+function sessionFixture(patch: Partial<SessionRow> = {}): SessionRow {
+  return {
+    sessionId: "session-1",
+    chatId: "chat-1",
+    telegramChatId: "chat-1",
+    threadId: "thread-1",
+    selectedModel: null,
+    selectedReasoningEffort: null,
+    planMode: false,
+    needsDefaultCollaborationModeReset: false,
+    displayName: "Web submit fixture",
+    displayNameSource: "manual",
+    projectName: "project",
+    projectAlias: null,
+    projectPath: "/tmp/project",
+    status: "idle",
+    failureReason: null,
+    archived: false,
+    archivedAt: null,
+    createdAt: "2026-04-26T00:00:00.000Z",
+    lastUsedAt: "2026-04-26T00:00:00.000Z",
+    lastTurnId: null,
+    lastTurnStatus: null,
+    ...patch
+  };
+}
+
+function createHarness(sessions: SessionRow[], bindings = [{ chatId: "chat-1" }]) {
+  const service = Object.create(BridgeService.prototype) as BridgeService;
+  const rawService = service as any;
+  const calls: unknown[] = [];
+  rawService.store = {
+    listChatBindings: () => bindings,
+    listSessions: (chatId: string, options?: { archived?: boolean }) => {
+      calls.push({ type: "listSessions", chatId, archived: options?.archived });
+      return sessions.filter((session) => session.chatId === chatId && Boolean(session.archived) === Boolean(options?.archived));
+    }
+  };
+  rawService.flushRuntimeNotices = async (chatId: string) => {
+    calls.push({ type: "flush", chatId });
+  };
+  rawService.submitNormalTextToSession = async (chatId: string, session: SessionRow, text: string) => {
+    calls.push({ type: "submit", chatId, sessionId: session.sessionId, text });
+    return { status: "accepted" };
+  };
+  rawService.logger = { warn: async () => undefined };
+  return { service, calls };
+}
+
+test("submitWebTextMessage resolves one owner binding and opaque conversation handle before delegating", async () => {
+  const session = sessionFixture();
+  const { service, calls } = createHarness([session]);
+
+  const result = await service.submitWebTextMessage({
+    conversationHandle: conversationHandleForSessionId(session.sessionId),
+    text: "  hello from web  "
+  });
+
+  assert.deepEqual(result, { status: "accepted" });
+  assert.deepEqual(calls, [
+    { type: "listSessions", chatId: "chat-1", archived: false },
+    { type: "listSessions", chatId: "chat-1", archived: true },
+    { type: "flush", chatId: "chat-1" },
+    { type: "submit", chatId: "chat-1", sessionId: "session-1", text: "hello from web" }
+  ]);
+});
+
+test("submitWebTextMessage rejects raw ids, archived sessions, mismatched chat, and ambiguous owner binding", async () => {
+  const active = sessionFixture();
+  const archived = sessionFixture({ sessionId: "archived-session", archived: true, archivedAt: "2026-04-26T00:00:00.000Z" });
+
+  for (const { service, handle, chatId } of [
+    { ...createHarness([active]), handle: "session-1" },
+    { ...createHarness([archived]), handle: conversationHandleForSessionId(archived.sessionId) },
+    { ...createHarness([active], [{ chatId: "chat-1" }, { chatId: "chat-2" }]), handle: conversationHandleForSessionId(active.sessionId) },
+    { ...createHarness([active]), handle: conversationHandleForSessionId(active.sessionId), chatId: "chat-2" }
+  ] as Array<ReturnType<typeof createHarness> & { handle: string; chatId?: string }>) {
+    const result = await service.submitWebTextMessage({
+      conversationHandle: handle,
+      text: "hello",
+      ...(chatId ? { chatId } : {})
+    });
+    assert.deepEqual(result, { status: "rejected" });
+  }
+});

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { basename } from "node:path";
 
 import { createLogger, type Logger } from "./logger.js";
@@ -159,6 +159,21 @@ const VOICE_REALTIME_POLL_INTERVAL_MS = 1_000;
 const VOICE_REALTIME_TRANSCRIPTION_PROMPT = "请逐字转写收到的语音，只返回转写文本，不要解释。";
 const CODEX_CLI_STATUS_LINE_BASELINE_TOKENS = 12_000;
 const FEISHU_ENTRY_SURFACE_COOLDOWN_MS = 60_000;
+const WEB_CONVERSATION_HANDLE_ID_SALT = "web-readonly-view-model:v1";
+
+export interface WebTextMessageSubmitInput {
+  conversationHandle: string;
+  text: string;
+  chatId?: string | null;
+  nonce?: string | null;
+  idSalt?: string;
+}
+
+export type WebTextMessageSubmitResult =
+  | { status: "accepted" }
+  | { status: "blocked" }
+  | { status: "rejected" }
+  | { status: "unavailable" };
 
 interface BridgeServiceDependencies {
   probeReadiness?: typeof probeReadiness;
@@ -218,6 +233,14 @@ function displayName(message: TelegramMessage): string | null {
 
   const parts = [message.from.first_name, message.from.last_name].filter(Boolean);
   return parts.join(" ").trim() || message.from.username || null;
+}
+
+function webConversationHandleForSessionId(idSalt: string, sessionId: string): string {
+  return `cv_${createHash("sha256").update(idSalt).update("\0").update(sessionId).digest("hex").slice(0, 16)}`;
+}
+
+function isSafeWebConversationHandle(value: string): boolean {
+  return /^cv_[a-f0-9]{16}$/.test(value);
 }
 
 export class BridgeService {
@@ -628,6 +651,52 @@ export class BridgeService {
 
   private get activeTurn(): ActiveTurnState | null {
     return this.turnCoordinator.getActiveTurn() as ActiveTurnState | null;
+  }
+
+  async submitWebTextMessage(input: WebTextMessageSubmitInput): Promise<WebTextMessageSubmitResult> {
+    if (!this.store || !isSafeWebConversationHandle(input.conversationHandle)) {
+      return { status: "rejected" };
+    }
+
+    const chatId = input.chatId?.trim() || this.resolveSingleWebOwnerChatId();
+    if (!chatId) {
+      return { status: "rejected" };
+    }
+
+    const text = input.text.trim();
+    if (!text) {
+      return { status: "rejected" };
+    }
+
+    const idSalt = input.idSalt ?? WEB_CONVERSATION_HANDLE_ID_SALT;
+    const sessions = [
+      ...this.store.listSessions(chatId, { archived: false, limit: 100 }),
+      ...this.store.listSessions(chatId, { archived: true, limit: 100 })
+    ];
+    const session = sessions.find((row) => webConversationHandleForSessionId(idSalt, row.sessionId) === input.conversationHandle);
+    if (!session || session.chatId !== chatId || session.archived) {
+      return { status: "rejected" };
+    }
+
+    try {
+      await this.flushRuntimeNotices(chatId);
+      return await this.submitNormalTextToSession(chatId, session, text);
+    } catch (error) {
+      await this.logger.warn("web text submit failed", {
+        chatId,
+        conversationHandle: input.conversationHandle,
+        error: `${error}`
+      });
+      return { status: "unavailable" };
+    }
+  }
+
+  private resolveSingleWebOwnerChatId(): string | null {
+    if (!this.store) {
+      return null;
+    }
+    const bindings = this.store.listChatBindings();
+    return bindings.length === 1 ? bindings[0]?.chatId ?? null : null;
   }
 
   private get pendingThreadArchiveOps(): ReadonlyMap<string, PendingThreadArchiveOp[]> {
@@ -2331,8 +2400,16 @@ export class BridgeService {
       return;
     }
 
-    if (activeSession.status === "running") {
-      const steerAvailability = this.turnCoordinator.getBlockedTurnSteerAvailability(chatId, activeSession);
+    await this.submitNormalTextToSession(chatId, activeSession, text ?? "");
+  }
+
+  private async submitNormalTextToSession(
+    chatId: string,
+    session: SessionRow,
+    text: string
+  ): Promise<WebTextMessageSubmitResult> {
+    if (session.status === "running") {
+      const steerAvailability = this.turnCoordinator.getBlockedTurnSteerAvailability(chatId, session);
       if (text && steerAvailability.kind === "available") {
         try {
           await this.ensureAppServerAvailable();
@@ -2341,28 +2418,29 @@ export class BridgeService {
             expectedTurnId: steerAvailability.activeTurn.turnId,
             input: [{ type: "text", text }]
           });
-          await this.reanchorRuntimeAfterBridgeReply(chatId, "accepted_turn_continue", activeSession.sessionId);
+          await this.reanchorRuntimeAfterBridgeReply(chatId, "accepted_turn_continue", session.sessionId);
         } catch (error) {
           await this.logger.warn("turn steer failed", {
             chatId,
-            sessionId: activeSession.sessionId,
+            sessionId: session.sessionId,
             threadId: steerAvailability.activeTurn.threadId,
             turnId: steerAvailability.activeTurn.turnId,
             error: `${error}`
           });
           await this.safeSendMessage(chatId, "Codex 服务暂时不可用，请稍后重试。");
+          return { status: "unavailable" };
         }
-        return;
+        return { status: "accepted" };
       }
 
       if (steerAvailability.kind === "interaction_pending") {
         await this.interactionBroker.sendPendingInteractionBlockNotice(chatId);
-        return;
+        return { status: "blocked" };
       }
 
       const reminder = this.runtimeSurfaceController.consumeHubCommandReminderForTurn(
         chatId,
-        this.getActiveTurnForSession(activeSession.sessionId)?.turnId ?? null
+        this.getActiveTurnForSession(session.sessionId)?.turnId ?? null
       );
       await this.safeSendMessage(
         chatId,
@@ -2371,15 +2449,16 @@ export class BridgeService {
           : "当前项目仍在执行，请等待完成或发送 /interrupt。",
         this.buildBusyTurnReplyMarkup(Boolean(reminder))
       );
-      return;
+      return { status: "blocked" };
     }
 
     if (!text) {
-      await this.safeSendHtmlMessage(chatId, buildProjectSelectedText(this.projectDisplayName(activeSession)));
-      return;
+      await this.safeSendHtmlMessage(chatId, buildProjectSelectedText(this.projectDisplayName(session)));
+      return { status: "rejected" };
     }
 
-    await this.startRealTurn(chatId, activeSession, text);
+    await this.startRealTurn(chatId, session, text);
+    return { status: "accepted" };
   }
 
   private async showProjectPicker(chatId: string): Promise<void> {

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,4 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { basename } from "node:path";
 
 import { createLogger, type Logger } from "./logger.js";
@@ -123,6 +125,14 @@ import { asRecord, getString, getNumber, getArray } from "./util/untyped.js";
 import { normalizeAndTruncate, summarizeTextPreview, HISTORY_TEXT_LIMIT } from "./util/text.js";
 import { summarizeActivityStatus, summarizeActivityStatusList } from "./activity/serialize.js";
 import { nowIso } from "./util/time.js";
+import { createReadonlyAccessGate } from "./web/readonly-access.js";
+import { createReadonlyHttpServer } from "./web/readonly-http-server.js";
+import { createWebReadonlyLiveProvider } from "./service/web-readonly-live-provider.js";
+import type {
+  WebReadonlyActiveTurn,
+  WebReadonlyPendingInteractionInputRow,
+  WebReadonlyReadinessSnapshot
+} from "./service/web-readonly-view-model.js";
 
 interface RecentActivityEntry {
   tracker: ActivityTracker;
@@ -174,6 +184,16 @@ export type WebTextMessageSubmitResult =
   | { status: "blocked" }
   | { status: "rejected" }
   | { status: "unavailable" };
+
+export interface WebChatHttpServerOptions {
+  token: string;
+  csrfToken?: string | null;
+}
+
+export interface WebChatHttpListenOptions extends WebChatHttpServerOptions {
+  host?: string | null;
+  port: number;
+}
 
 interface BridgeServiceDependencies {
   probeReadiness?: typeof probeReadiness;
@@ -272,6 +292,7 @@ export class BridgeService {
   private performanceRecorder: PerformanceRecorder = noopPerformanceRecorder;
   private performanceSampler: PerformanceSamplerLike | null = null;
   private appServerHealthGuard: AppServerHealthGuardLike | null = null;
+  private webChatServer: Server | null = null;
   private readonly unauthorizedReplyAt = new Map<string, number>();
   private readonly feishuEntrySurfaceAt = new Map<string, number>();
   private readonly commandPanelDrafts = new Map<string, CommandPanelDraftState>();
@@ -699,6 +720,89 @@ export class BridgeService {
     return bindings.length === 1 ? bindings[0]?.chatId ?? null : null;
   }
 
+  createWebChatHttpServer(options: WebChatHttpServerOptions): Server {
+    const token = options.token.trim();
+    if (!token) {
+      throw new Error("web chat token is required");
+    }
+    const csrfToken = options.csrfToken?.trim() || deriveWebChatCsrfToken(token);
+    return createReadonlyHttpServer({
+      provider: this.createWebChatReadonlyProvider(),
+      access: createReadonlyAccessGate({ enabled: true, token }),
+      send: {
+        csrfToken,
+        submitTextMessage: (request) => this.submitWebTextMessage(request)
+      }
+    });
+  }
+
+  async startWebChatHttpServer(options: WebChatHttpListenOptions): Promise<Server> {
+    if (this.webChatServer) {
+      return this.webChatServer;
+    }
+    const host = normalizeWebChatHost(options.host);
+    const server = this.createWebChatHttpServer(options);
+    await listenWebChatServer(server, options.port, host);
+    this.webChatServer = server;
+    const address = server.address() as AddressInfo;
+    await this.bootstrapLogger.info("web chat server started", {
+      host,
+      port: address.port
+    });
+    return server;
+  }
+
+  private async maybeStartWebChatHttpServerFromEnv(): Promise<void> {
+    if (!isTruthyEnv(process.env.CTB_WEB_LIVE_ENABLED ?? process.env.CTB_WEB_CHAT_ENABLED)) {
+      return;
+    }
+
+    const token = process.env.CTB_WEB_LIVE_TOKEN ?? process.env.CTB_WEB_READONLY_TOKEN ?? "";
+    const port = parseWebChatPort(process.env.CTB_WEB_LIVE_PORT ?? process.env.CTB_WEB_READONLY_PORT ?? "45682");
+    const host = process.env.CTB_WEB_LIVE_HOST ?? "127.0.0.1";
+    await this.startWebChatHttpServer({
+      token,
+      csrfToken: process.env.CTB_WEB_CSRF_TOKEN ?? null,
+      host,
+      port
+    });
+  }
+
+  private createWebChatReadonlyProvider() {
+    return createWebReadonlyLiveProvider({
+      auth: {
+        listOperatorBindings: () =>
+          this.store?.listChatBindings(this.config.activePack).map((binding) => ({ chatId: binding.chatId })) ?? []
+      },
+      store: {
+        listRecentProjects: () => this.store?.listRecentProjects() ?? [],
+        listSessionProjectStats: () => this.store?.listSessionProjectStats() ?? [],
+        listSessions: (chatId, listOptions) => this.store?.listSessions(chatId, listOptions) ?? [],
+        getSessionById: (sessionId) => this.store?.getSessionById(sessionId) ?? null,
+        listFinalAnswerViews: (chatId) => this.store?.listFinalAnswerViews(chatId) ?? [],
+        getReadinessSnapshot: () => toWebReadonlyReadinessSnapshot(this.snapshot ?? this.store?.getReadinessSnapshot() ?? null),
+        listPendingInteractions: (chatId) => toWebReadonlyPendingInteractions(this.store?.listPendingInteractionsByChat(chatId) ?? [])
+      },
+      runtime: {
+        listActiveTurns: (chatId) => this.listWebReadonlyActiveTurns(chatId)
+      }
+    });
+  }
+
+  private listWebReadonlyActiveTurns(chatId: string): WebReadonlyActiveTurn[] {
+    return this.listActiveTurns()
+      .filter((turn) => turn.chatId === chatId)
+      .map((turn) => {
+        const status = turn.tracker.getStatus();
+        return {
+          sessionId: turn.sessionId,
+          status: status.turnStatus,
+          summary: status.latestProgress ?? status.lastHighValueTitle ?? status.activeItemLabel ?? turn.latestStatusProgressText,
+          blockedReason: status.threadBlockedReason
+        };
+      });
+  }
+
   private get pendingThreadArchiveOps(): ReadonlyMap<string, PendingThreadArchiveOp[]> {
     return this.threadArchiveReconciler.pendingOps;
   }
@@ -840,6 +944,7 @@ export class BridgeService {
       }
     }
     await this.flushRuntimeNotices();
+    await this.maybeStartWebChatHttpServerFromEnv();
     await this.poller.run();
   }
 
@@ -869,6 +974,8 @@ export class BridgeService {
     this.performanceSampler = null;
     this.appServerHealthGuard?.stop();
     this.appServerHealthGuard = null;
+    await closeWebChatServer(this.webChatServer);
+    this.webChatServer = null;
     this.poller?.stop();
     this.threadArchiveReconciler.clear();
     this.runtimeSurfaceController.disposeAllRuntimeHubs();
@@ -3789,6 +3896,63 @@ export class BridgeService {
     const sleepImpl = this.deps.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
     await sleepImpl(delayMs);
   }
+}
+
+function deriveWebChatCsrfToken(token: string): string {
+  return `csrf_${createHash("sha256").update("web-chat-csrf:v1").update("\0").update(token).digest("hex").slice(0, 32)}`;
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  return /^(1|true|yes|on)$/iu.test(String(value ?? "").trim());
+}
+
+function parseWebChatPort(value: string): number {
+  const port = Number.parseInt(value, 10);
+  if (!Number.isInteger(port) || port < 0 || port > 65535 || String(port) !== value.trim()) {
+    throw new Error("invalid CTB_WEB_LIVE_PORT value");
+  }
+  return port;
+}
+
+function normalizeWebChatHost(value: string | null | undefined): string {
+  const host = String(value ?? "127.0.0.1").trim() || "127.0.0.1";
+  if (host !== "127.0.0.1" && host !== "localhost") {
+    throw new Error("web chat live server is local-only; external host binding is not supported");
+  }
+  return host;
+}
+
+function toWebReadonlyReadinessSnapshot(snapshot: ReadinessSnapshot | null): WebReadonlyReadinessSnapshot | null {
+  return snapshot ? { ...snapshot, details: { ...snapshot.details } } : null;
+}
+
+function toWebReadonlyPendingInteractions(rows: PendingInteractionRow[]): WebReadonlyPendingInteractionInputRow[] {
+  return rows.map((row) => ({ ...row }));
+}
+
+async function listenWebChatServer(server: Server, port: number, host: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, host);
+  });
+}
+
+async function closeWebChatServer(server: Server | null): Promise<void> {
+  if (!server?.listening) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
 }
 
 export async function runBridgeService(importMetaUrl: string): Promise<void> {

--- a/src/service.ts
+++ b/src/service.ts
@@ -716,7 +716,7 @@ export class BridgeService {
     if (!this.store) {
       return null;
     }
-    const bindings = this.store.listChatBindings();
+    const bindings = this.store.listChatBindings(this.config.activePack);
     return bindings.length === 1 ? bindings[0]?.chatId ?? null : null;
   }
 

--- a/src/service/web-readonly-live-provider.test.ts
+++ b/src/service/web-readonly-live-provider.test.ts
@@ -119,9 +119,9 @@ test("one binding scopes sessions and final-answer metadata internally without e
         calls.push(`sessions:${chatId}`);
         return [safeSession];
       },
-      getSessionById: (sessionId) => {
-        calls.push(`session:${sessionId}`);
-        return safeSession;
+      getSessionById: (_sessionId) => {
+        calls.push("session:raw");
+        throw new Error("detail lookup must not use raw session id");
       },
       listFinalAnswerViews: (chatId) => {
         calls.push(`answers:${chatId}`);
@@ -160,13 +160,17 @@ test("one binding scopes sessions and final-answer metadata internally without e
   const workspace = provider.listWorkspaceViewModels().workspaces[0];
   assert.ok(workspace);
   const conversations = provider.listWorkspaceConversationViewModels(workspace.workspaceId);
-  const result = provider.getConversationResultViewModel("session-1");
+  const conversationHandle = conversations.conversations[0]?.conversationHandle ?? "";
+  const result = provider.getConversationResultViewModel(conversationHandle);
+  const rawResult = provider.getConversationResultViewModel("session-1");
   const pending = provider.getPendingInteractionsViewModel();
 
   assert.equal(conversations.state, "available");
-  assert.equal(conversations.conversations[0]?.conversationId, "session-1");
+  assert.match(conversations.conversations[0]?.conversationId ?? "", /^cv_[a-f0-9]{16}$/);
+  assert.equal(conversations.conversations[0]?.conversationId, conversationHandle);
   assert.equal(conversations.conversations[0]?.finalAnswerAvailable, true);
   assert.equal(result.state, "available");
+  assert.equal(rawResult.state, "unavailable");
   assert.equal(result.answers[0]?.answerId, "answer-1");
   assert.deepEqual(result.answers[0]?.body, { state: "unavailable", reason: "sanitized_body_not_provided" });
   assert.equal(pending.state, "available");
@@ -174,6 +178,9 @@ test("one binding scopes sessions and final-answer metadata internally without e
     "answers:chat-secret",
     "answers:chat-secret",
     "pending:chat-secret",
+    "pending:chat-secret",
+    "sessions:chat-secret",
+    "sessions:chat-secret",
     "sessions:chat-secret",
     "sessions:chat-secret"
   ]);
@@ -218,6 +225,49 @@ test("unscoped recent project and stat readers cannot populate live Web workspac
     assert.equal(text.includes(forbidden), false, `live view model leaked ${forbidden}: ${text}`);
   }
   assertNoForbiddenLiveData(vm);
+});
+
+test("conversation detail resolves only through the single binding's opaque handle", () => {
+  const otherSession = {
+    ...safeSession,
+    sessionId: "session-other",
+    chatId: "chat-other",
+    telegramChatId: "telegram-chat-other",
+    displayName: "Other operator conversation",
+    lastTurnId: "turn-other"
+  };
+  const store = {
+    listSessions: () => [safeSession, otherSession],
+    listFinalAnswerViews: () => []
+  };
+  const secretProvider = createWebReadonlyLiveProvider({
+    now: () => fixedNow,
+    auth: { listOperatorBindings: () => [{ chatId: "chat-secret" }] },
+    store
+  });
+  const otherProvider = createWebReadonlyLiveProvider({
+    now: () => fixedNow,
+    auth: { listOperatorBindings: () => [{ chatId: "chat-other" }] },
+    store
+  });
+
+  const secretWorkspace = secretProvider.listWorkspaceViewModels().workspaces[0];
+  assert.ok(secretWorkspace);
+  const secretHandle = secretProvider.listWorkspaceConversationViewModels(secretWorkspace.workspaceId).conversations[0]?.conversationHandle ?? "";
+  const otherWorkspace = otherProvider.listWorkspaceViewModels().workspaces[0];
+  assert.ok(otherWorkspace);
+  const otherHandle = otherProvider.listWorkspaceConversationViewModels(otherWorkspace.workspaceId).conversations[0]?.conversationHandle ?? "";
+
+  assert.match(secretHandle, /^cv_[a-f0-9]{16}$/);
+  assert.match(otherHandle, /^cv_[a-f0-9]{16}$/);
+  assert.notEqual(secretHandle, otherHandle);
+  assert.equal(secretProvider.getConversationResultViewModel(secretHandle).state, "available");
+  assert.equal(secretProvider.getConversationResultViewModel(otherHandle).state, "unavailable");
+  assert.equal(secretProvider.getConversationResultViewModel("session-1").state, "unavailable");
+  assertNoForbiddenLiveData({
+    secret: secretProvider.getConversationResultViewModel(secretHandle),
+    otherAttempt: secretProvider.getConversationResultViewModel(otherHandle)
+  });
 });
 
 test("multiple bindings return safe unavailable/degraded behavior instead of guessing", () => {
@@ -281,7 +331,7 @@ test("store throws surface generic warnings only", () => {
   assert.equal(workspaces.state, "degraded");
   assert.deepEqual(workspaces.warnings, ["sessions_unavailable"]);
   assert.equal(result.state, "unavailable");
-  assert.deepEqual(result.warnings, ["conversation_not_available"]);
+  assert.deepEqual(result.warnings, ["conversation_data_unavailable"]);
   assert.equal(pending.state, "unavailable");
   assert.deepEqual(pending.warnings, ["pending_interactions_unavailable"]);
   assertNoForbiddenLiveData({ workspaces, result, pending });

--- a/src/service/web-readonly-live-provider.test.ts
+++ b/src/service/web-readonly-live-provider.test.ts
@@ -174,9 +174,50 @@ test("one binding scopes sessions and final-answer metadata internally without e
     "answers:chat-secret",
     "answers:chat-secret",
     "pending:chat-secret",
+    "sessions:chat-secret",
     "sessions:chat-secret"
   ]);
   assertNoForbiddenLiveData({ workspace, conversations, result, pending });
+});
+
+test("unscoped recent project and stat readers cannot populate live Web workspace rows", () => {
+  const provider = createWebReadonlyLiveProvider({
+    now: () => fixedNow,
+    auth: { listOperatorBindings: () => [{ chatId: "chat-secret" }] },
+    store: {
+      listRecentProjects: () => [
+        {
+          projectPath: "/home/ubuntu/global-workspace",
+          projectName: "global-workspace",
+          projectAlias: "Global Leak",
+          lastUsedAt: "2026-04-25T14:00:00.000Z",
+          pinned: true
+        }
+      ],
+      listSessionProjectStats: () => [
+        {
+          projectPath: "/home/ubuntu/global-workspace",
+          projectName: "global-workspace",
+          sessionCount: 99,
+          lastUsedAt: "2026-04-25T14:00:00.000Z"
+        }
+      ],
+      listSessions: (chatId) => chatId === "chat-secret" ? [safeSession] : []
+    }
+  });
+
+  const vm = provider.listWorkspaceViewModels();
+
+  assert.equal(vm.state, "available");
+  assert.equal(vm.workspaces.length, 1);
+  assert.equal(vm.workspaces[0]?.label, "Console Core");
+  assert.equal(vm.workspaces[0]?.conversationCount, 1);
+  assert.equal(vm.workspaces[0]?.pinned, false);
+  const text = serialized(vm);
+  for (const forbidden of ["/home/ubuntu/global-workspace", "Global Leak", "global-workspace", "99"]) {
+    assert.equal(text.includes(forbidden), false, `live view model leaked ${forbidden}: ${text}`);
+  }
+  assertNoForbiddenLiveData(vm);
 });
 
 test("multiple bindings return safe unavailable/degraded behavior instead of guessing", () => {
@@ -218,6 +259,9 @@ test("store throws surface generic warnings only", () => {
       listSessionProjectStats: () => {
         throw new Error("stats failed at /home/ubuntu/secret-workspace");
       },
+      listSessions: () => {
+        throw new Error("sessions failed for chat-secret /home/ubuntu/secret-workspace");
+      },
       getSessionById: () => {
         throw new Error("session failed for chat-secret /home/ubuntu/secret-workspace");
       },
@@ -235,7 +279,7 @@ test("store throws surface generic warnings only", () => {
   const pending = provider.getPendingInteractionsViewModel();
 
   assert.equal(workspaces.state, "degraded");
-  assert.deepEqual(workspaces.warnings.sort(), ["recent_projects_unavailable", "workspace_stats_unavailable"]);
+  assert.deepEqual(workspaces.warnings, ["sessions_unavailable"]);
   assert.equal(result.state, "unavailable");
   assert.deepEqual(result.warnings, ["conversation_not_available"]);
   assert.equal(pending.state, "unavailable");

--- a/src/service/web-readonly-live-provider.test.ts
+++ b/src/service/web-readonly-live-provider.test.ts
@@ -1,0 +1,273 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createWebReadonlyLiveProvider } from "./web-readonly-live-provider.js";
+
+const fixedNow = "2026-04-26T00:00:00.000Z";
+
+function serialized(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function assertNoForbiddenLiveData(value: unknown): void {
+  const text = serialized(value);
+  for (const forbidden of [
+    "/home/ubuntu/secret-workspace",
+    "/tmp/secret-store",
+    "chat-secret",
+    "chat-other",
+    "telegramChatId",
+    "feishuChatId",
+    "deliveryMessageId",
+    "messageId",
+    "thread-secret",
+    "callback",
+    "replyMarkup",
+    "localPath",
+    "resourceId",
+    "rawJson",
+    "submit",
+    "approve",
+    "interrupt",
+    "upload",
+    "switch",
+    "resume"
+  ]) {
+    assert.equal(text.includes(forbidden), false, `live view model leaked ${forbidden}: ${text}`);
+  }
+}
+
+const safeSession = {
+  sessionId: "session-1",
+  chatId: "chat-secret",
+  telegramChatId: "telegram-chat-secret",
+  threadId: "thread-secret",
+  displayName: "Readonly seam",
+  projectName: "secret-workspace",
+  projectAlias: "Console Core",
+  projectPath: "/home/ubuntu/secret-workspace",
+  status: "idle",
+  failureReason: null,
+  archived: false,
+  createdAt: "2026-04-25T10:00:00.000Z",
+  lastUsedAt: "2026-04-25T12:00:00.000Z",
+  lastTurnId: "turn-secret",
+  lastTurnStatus: "completed"
+} as const;
+
+test("no binding returns unavailable/degraded public view models without leaking store data", () => {
+  const provider = createWebReadonlyLiveProvider({
+    now: () => fixedNow,
+    auth: { listOperatorBindings: () => [] },
+    store: {
+      listRecentProjects: () => [
+        {
+          projectPath: "/home/ubuntu/secret-workspace",
+          projectName: "secret-workspace",
+          projectAlias: "Secret Alias",
+          lastUsedAt: "2026-04-25T12:00:00.000Z"
+        }
+      ],
+      listSessions: () => [safeSession],
+      listFinalAnswerViews: () => [
+        {
+          answerId: "answer-1",
+          chatId: "chat-secret",
+          deliveryMessageId: 777,
+          sessionId: "session-1",
+          threadId: "thread-secret",
+          turnId: "turn-secret",
+          kind: "final_answer",
+          deliveryState: "delivered",
+          createdAt: "2026-04-25T12:30:00.000Z"
+        }
+      ]
+    }
+  });
+
+  assert.equal(provider.listWorkspaceViewModels().state, "unavailable");
+  assert.equal(provider.listWorkspaceConversationViewModels("wk_missing").state, "unavailable");
+  assert.equal(provider.getConversationResultViewModel("session-1").state, "unavailable");
+  assert.equal(provider.getPendingInteractionsViewModel().state, "unavailable");
+  assert.equal(provider.getRuntimeContextViewModel().state, "degraded");
+  assert.equal(provider.getHomeViewModel().operator.binding, "unavailable");
+  assertNoForbiddenLiveData({
+    home: provider.getHomeViewModel(),
+    workspaces: provider.listWorkspaceViewModels(),
+    conversations: provider.listWorkspaceConversationViewModels("wk_missing"),
+    result: provider.getConversationResultViewModel("session-1")
+  });
+});
+
+test("one binding scopes sessions and final-answer metadata internally without exposing platform ids", () => {
+  const calls: string[] = [];
+  const provider = createWebReadonlyLiveProvider({
+    now: () => fixedNow,
+    auth: {
+      listOperatorBindings: () => [{ chatId: "chat-secret", platform: "telegram", userId: "telegram-user-secret" }]
+    },
+    store: {
+      listSessionProjectStats: () => [
+        {
+          projectPath: "/home/ubuntu/secret-workspace",
+          projectName: "secret-workspace",
+          sessionCount: 1,
+          lastUsedAt: "2026-04-25T12:00:00.000Z"
+        }
+      ],
+      listSessions: (chatId) => {
+        calls.push(`sessions:${chatId}`);
+        return [safeSession];
+      },
+      getSessionById: (sessionId) => {
+        calls.push(`session:${sessionId}`);
+        return safeSession;
+      },
+      listFinalAnswerViews: (chatId) => {
+        calls.push(`answers:${chatId}`);
+        return [
+          {
+            answerId: "answer-1",
+            chatId: "chat-secret",
+            deliveryMessageId: 777,
+            sessionId: "session-1",
+            threadId: "thread-secret",
+            turnId: "turn-secret",
+            kind: "final_answer",
+            deliveryState: "delivered",
+            previewHtml: "<b>Telegram body should stay hidden</b>",
+            pages: ["/home/ubuntu/secret-workspace raw page"],
+            createdAt: "2026-04-25T12:30:00.000Z"
+          }
+        ];
+      },
+      listPendingInteractions: (chatId) => {
+        calls.push(`pending:${chatId}`);
+        return [
+          {
+            id: "pending_safe_1",
+            sessionId: "session-1",
+            status: "awaiting_user_input",
+            kind: "question",
+            createdAt: "2026-04-25T12:40:00.000Z",
+            summary: "Waiting for a short answer."
+          }
+        ];
+      }
+    }
+  });
+
+  const workspace = provider.listWorkspaceViewModels().workspaces[0];
+  assert.ok(workspace);
+  const conversations = provider.listWorkspaceConversationViewModels(workspace.workspaceId);
+  const result = provider.getConversationResultViewModel("session-1");
+  const pending = provider.getPendingInteractionsViewModel();
+
+  assert.equal(conversations.state, "available");
+  assert.equal(conversations.conversations[0]?.conversationId, "session-1");
+  assert.equal(conversations.conversations[0]?.finalAnswerAvailable, true);
+  assert.equal(result.state, "available");
+  assert.equal(result.answers[0]?.answerId, "answer-1");
+  assert.deepEqual(result.answers[0]?.body, { state: "unavailable", reason: "sanitized_body_not_provided" });
+  assert.equal(pending.state, "available");
+  assert.deepEqual(calls.filter((call) => call.includes("chat-secret")).sort(), [
+    "answers:chat-secret",
+    "answers:chat-secret",
+    "pending:chat-secret",
+    "sessions:chat-secret"
+  ]);
+  assertNoForbiddenLiveData({ workspace, conversations, result, pending });
+});
+
+test("multiple bindings return safe unavailable/degraded behavior instead of guessing", () => {
+  const provider = createWebReadonlyLiveProvider({
+    now: () => fixedNow,
+    auth: {
+      listOperatorBindings: () => [
+        { chatId: "chat-secret", platform: "telegram" },
+        { chatId: "chat-other", platform: "feishu" }
+      ]
+    },
+    store: {
+      listSessionProjectStats: () => [
+        {
+          projectPath: "/home/ubuntu/secret-workspace",
+          projectName: "secret-workspace",
+          sessionCount: 1,
+          lastUsedAt: "2026-04-25T12:00:00.000Z"
+        }
+      ],
+      listSessions: () => [safeSession]
+    }
+  });
+
+  assert.equal(provider.getHomeViewModel().operator.binding, "unavailable");
+  assert.equal(provider.listWorkspaceViewModels().state, "unavailable");
+  assert.equal(provider.listWorkspaceConversationViewModels("wk_any").state, "unavailable");
+  assertNoForbiddenLiveData({ home: provider.getHomeViewModel(), workspaces: provider.listWorkspaceViewModels() });
+});
+
+test("store throws surface generic warnings only", () => {
+  const provider = createWebReadonlyLiveProvider({
+    now: () => fixedNow,
+    auth: { listOperatorBindings: () => [{ chatId: "chat-secret" }] },
+    store: {
+      listRecentProjects: () => {
+        throw new Error("database failed for chat-secret at /tmp/secret-store with messageId=999");
+      },
+      listSessionProjectStats: () => {
+        throw new Error("stats failed at /home/ubuntu/secret-workspace");
+      },
+      getSessionById: () => {
+        throw new Error("session failed for chat-secret /home/ubuntu/secret-workspace");
+      },
+      listFinalAnswerViews: () => {
+        throw new Error("answer failed thread-secret messageId=999");
+      },
+      listPendingInteractions: () => {
+        throw new Error("pending failed callback approve /tmp/secret-store");
+      }
+    }
+  });
+
+  const workspaces = provider.listWorkspaceViewModels();
+  const result = provider.getConversationResultViewModel("session-1");
+  const pending = provider.getPendingInteractionsViewModel();
+
+  assert.equal(workspaces.state, "degraded");
+  assert.deepEqual(workspaces.warnings.sort(), ["recent_projects_unavailable", "workspace_stats_unavailable"]);
+  assert.equal(result.state, "unavailable");
+  assert.deepEqual(result.warnings, ["conversation_not_available"]);
+  assert.equal(pending.state, "unavailable");
+  assert.deepEqual(pending.warnings, ["pending_interactions_unavailable"]);
+  assertNoForbiddenLiveData({ workspaces, result, pending });
+});
+
+test("readiness snapshots with path-like issue details are sanitized by the produced view model", () => {
+  const provider = createWebReadonlyLiveProvider({
+    now: () => fixedNow,
+    auth: { listOperatorBindings: () => [{ chatId: "chat-secret" }] },
+    readiness: {
+      getReadinessSnapshot: () => ({
+        state: "degraded",
+        checkedAt: "2026-04-25T13:00:00.000Z",
+        appServerPid: "4242",
+        details: {
+          activePack: "telegram",
+          codexInstalled: false,
+          codexAuthenticated: true,
+          appServerAvailable: false,
+          authorizedUserBound: true,
+          issues: ["Codex binary missing at /home/ubuntu/secret-workspace/bin/codex", "Socket unavailable at /tmp/secret-store/app.sock"]
+        }
+      })
+    }
+  });
+
+  const readiness = provider.getReadinessGuardrailViewModel();
+
+  assert.equal(readiness.state, "degraded");
+  assert.deepEqual(readiness.missingGates, ["Codex binary missing", "Socket unavailable"]);
+  assert.equal(readiness.capabilities.some((row) => row.key === "codex_installed" && row.observed === "missing"), true);
+  assertNoForbiddenLiveData(readiness);
+});

--- a/src/service/web-readonly-live-provider.ts
+++ b/src/service/web-readonly-live-provider.ts
@@ -132,12 +132,6 @@ function createScopedStoreReader(
   }
 
   const scopedStore: WebReadonlyStoreReader = {};
-  if (store.listRecentProjects) {
-    scopedStore.listRecentProjects = store.listRecentProjects;
-  }
-  if (store.listSessionProjectStats) {
-    scopedStore.listSessionProjectStats = store.listSessionProjectStats;
-  }
   if (store.listSessions) {
     scopedStore.listSessions = (_chatId, options) => store.listSessions?.(binding.chatId, options) ?? [];
   }

--- a/src/service/web-readonly-live-provider.ts
+++ b/src/service/web-readonly-live-provider.ts
@@ -133,7 +133,8 @@ function createScopedStoreReader(
 
   const scopedStore: WebReadonlyStoreReader = {};
   if (store.listSessions) {
-    scopedStore.listSessions = (_chatId, options) => store.listSessions?.(binding.chatId, options) ?? [];
+    scopedStore.listSessions = (_chatId, options) =>
+      (store.listSessions?.(binding.chatId, options) ?? []).filter((session) => scopedSession(session, binding));
   }
   if (store.getSessionById) {
     scopedStore.getSessionById = (sessionId) => scopedSession(store.getSessionById?.(sessionId) ?? null, binding);

--- a/src/service/web-readonly-live-provider.ts
+++ b/src/service/web-readonly-live-provider.ts
@@ -1,0 +1,178 @@
+import {
+  createWebReadonlyViewModelProvider,
+  type WebReadonlyActiveTurn,
+  type WebReadonlyArtifactDescriptorInputRow,
+  type WebReadonlyFinalAnswerRow,
+  type WebReadonlyOperatorBinding,
+  type WebReadonlyPendingInteractionInputRow,
+  type WebReadonlyReadinessSnapshot,
+  type WebReadonlyRecentProjectRow,
+  type WebReadonlySessionProjectStatsRow,
+  type WebReadonlySessionRow,
+  type WebReadonlyStoreReader,
+  type WebReadonlyViewModelDeps,
+  type WebReadonlyViewModelProvider
+} from "./web-readonly-view-model.js";
+
+export interface WebReadonlyLiveOperatorBindingCandidate {
+  chatId: string;
+  [key: string]: unknown;
+}
+
+export interface WebReadonlyLiveAuthReader {
+  listOperatorBindings?: () => WebReadonlyLiveOperatorBindingCandidate[] | null | undefined;
+}
+
+export interface WebReadonlyLiveStoreReader {
+  listRecentProjects?: () => WebReadonlyRecentProjectRow[];
+  listSessionProjectStats?: () => WebReadonlySessionProjectStatsRow[];
+  listSessions?: (chatId: string, options?: { archived?: boolean; limit?: number }) => WebReadonlySessionRow[];
+  getSessionById?: (sessionId: string) => WebReadonlySessionRow | null;
+  listFinalAnswerViews?: (chatId: string) => WebReadonlyFinalAnswerRow[];
+  getReadinessSnapshot?: () => WebReadonlyReadinessSnapshot | null;
+  listPendingInteractions?: (chatId: string) => WebReadonlyPendingInteractionInputRow[] | null | undefined;
+}
+
+export interface WebReadonlyLiveReadinessReader {
+  getReadinessSnapshot?: () => WebReadonlyReadinessSnapshot | null | undefined;
+}
+
+export interface WebReadonlyLiveRuntimeReader {
+  listActiveTurns?: (chatId: string) => WebReadonlyActiveTurn[] | null | undefined;
+}
+
+export interface WebReadonlyLiveArtifactReader {
+  listArtifactDescriptors?: (sessionId: string) => WebReadonlyArtifactDescriptorInputRow[] | null | undefined;
+}
+
+export interface WebReadonlyLiveFinalAnswerBodyReader {
+  getSanitizedFinalAnswerBody?: (answer: WebReadonlyFinalAnswerRow) => string | null | undefined;
+}
+
+export interface WebReadonlyLiveProviderDeps {
+  auth?: WebReadonlyLiveAuthReader;
+  store?: WebReadonlyLiveStoreReader;
+  readiness?: WebReadonlyLiveReadinessReader;
+  runtime?: WebReadonlyLiveRuntimeReader;
+  artifacts?: WebReadonlyLiveArtifactReader;
+  finalAnswerBodies?: WebReadonlyLiveFinalAnswerBodyReader;
+  now?: () => string;
+  idSalt?: string;
+}
+
+export function createWebReadonlyLiveProvider(deps: WebReadonlyLiveProviderDeps): WebReadonlyViewModelProvider {
+  const binding = resolveSingleOperatorBinding(deps.auth);
+  if (!binding) {
+    return createWebReadonlyViewModelProvider(baseProviderDeps(deps));
+  }
+
+  const providerDeps = baseProviderDeps(deps);
+  providerDeps.operatorBinding = binding;
+  const scopedStore = createScopedStoreReader(deps.store, binding);
+  if (scopedStore) {
+    providerDeps.store = scopedStore;
+  }
+  if (deps.runtime?.listActiveTurns) {
+    providerDeps.listActiveTurns = () => deps.runtime?.listActiveTurns?.(binding.chatId);
+  }
+  if (deps.store?.listPendingInteractions) {
+    providerDeps.listPendingInteractions = () => deps.store?.listPendingInteractions?.(binding.chatId);
+  }
+  if (deps.artifacts?.listArtifactDescriptors) {
+    providerDeps.listArtifactDescriptors = deps.artifacts.listArtifactDescriptors;
+  }
+  const getReadinessSnapshot = deps.readiness?.getReadinessSnapshot ?? deps.store?.getReadinessSnapshot;
+  if (getReadinessSnapshot) {
+    providerDeps.getReadinessSnapshot = getReadinessSnapshot;
+  }
+  if (deps.finalAnswerBodies?.getSanitizedFinalAnswerBody) {
+    providerDeps.getSanitizedFinalAnswerBody = deps.finalAnswerBodies.getSanitizedFinalAnswerBody;
+  }
+  return createWebReadonlyViewModelProvider(providerDeps);
+}
+
+function baseProviderDeps(deps: WebReadonlyLiveProviderDeps): WebReadonlyViewModelDeps {
+  const providerDeps: WebReadonlyViewModelDeps = {};
+  if (deps.now) {
+    providerDeps.now = deps.now;
+  }
+  if (deps.idSalt) {
+    providerDeps.idSalt = deps.idSalt;
+  }
+  return providerDeps;
+}
+
+function resolveSingleOperatorBinding(auth: WebReadonlyLiveAuthReader | undefined): WebReadonlyOperatorBinding | null {
+  if (!auth?.listOperatorBindings) {
+    return null;
+  }
+
+  let rows: WebReadonlyLiveOperatorBindingCandidate[] | null | undefined;
+  try {
+    rows = auth.listOperatorBindings();
+  } catch {
+    return null;
+  }
+
+  const bindings = (rows ?? [])
+    .map((row) => ({ chatId: normalizeChatId(row.chatId) }))
+    .filter((row): row is WebReadonlyOperatorBinding => Boolean(row.chatId));
+  if (bindings.length !== 1) {
+    return null;
+  }
+  return bindings[0] ?? null;
+}
+
+function createScopedStoreReader(
+  store: WebReadonlyLiveStoreReader | undefined,
+  binding: WebReadonlyOperatorBinding
+): WebReadonlyStoreReader | undefined {
+  if (!store) {
+    return undefined;
+  }
+
+  const scopedStore: WebReadonlyStoreReader = {};
+  if (store.listRecentProjects) {
+    scopedStore.listRecentProjects = store.listRecentProjects;
+  }
+  if (store.listSessionProjectStats) {
+    scopedStore.listSessionProjectStats = store.listSessionProjectStats;
+  }
+  if (store.listSessions) {
+    scopedStore.listSessions = (_chatId, options) => store.listSessions?.(binding.chatId, options) ?? [];
+  }
+  if (store.getSessionById) {
+    scopedStore.getSessionById = (sessionId) => scopedSession(store.getSessionById?.(sessionId) ?? null, binding);
+  }
+  if (store.listFinalAnswerViews) {
+    scopedStore.listFinalAnswerViews = (_chatId) =>
+      (store.listFinalAnswerViews?.(binding.chatId) ?? []).filter((answer) => answerBelongsToBinding(answer, binding));
+  }
+  if (store.getReadinessSnapshot) {
+    scopedStore.getReadinessSnapshot = store.getReadinessSnapshot;
+  }
+  return scopedStore;
+}
+
+function scopedSession(session: WebReadonlySessionRow | null, binding: WebReadonlyOperatorBinding): WebReadonlySessionRow | null {
+  if (!session) {
+    return null;
+  }
+  const chatIds = [session.chatId, session.telegramChatId]
+    .map((value) => normalizeChatId(value))
+    .filter((value): value is string => Boolean(value));
+  if (chatIds.length === 0 || !chatIds.includes(binding.chatId)) {
+    return null;
+  }
+  return session;
+}
+
+function answerBelongsToBinding(answer: WebReadonlyFinalAnswerRow, binding: WebReadonlyOperatorBinding): boolean {
+  const chatId = normalizeChatId(answer.chatId);
+  return !chatId || chatId === binding.chatId;
+}
+
+function normalizeChatId(value: unknown): string | null {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text.length > 0 ? text : null;
+}

--- a/src/service/web-readonly-view-model.test.ts
+++ b/src/service/web-readonly-view-model.test.ts
@@ -1,0 +1,428 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createWebReadonlyViewModelProvider } from "./web-readonly-view-model.js";
+
+const fixedNow = "2026-04-26T00:00:00.000Z";
+
+function serialized(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function assertNoForbiddenViewModelData(value: unknown): void {
+  const text = serialized(value);
+  for (const forbidden of [
+    "/home/ubuntu/secret-workspace",
+    "chatId",
+    "telegramChatId",
+    "messageId",
+    "callback",
+    "replyMarkup",
+    "promptJson",
+    "responseJson",
+    "submit",
+    "approve",
+    "interrupt",
+    "upload",
+    "switch",
+    "resume"
+  ]) {
+    assert.equal(text.includes(forbidden), false, `view model leaked ${forbidden}: ${text}`);
+  }
+}
+
+const session = {
+  sessionId: "session-1",
+  chatId: "telegram-chat-123",
+  telegramChatId: "telegram-chat-123",
+  threadId: "thread-secret-1",
+  selectedModel: "gpt-test",
+  selectedReasoningEffort: "high",
+  planMode: false,
+  needsDefaultCollaborationModeReset: false,
+  displayName: "Implement read-only Web adapter",
+  displayNameSource: "manual",
+  projectName: "secret-workspace",
+  projectAlias: "Console Core",
+  projectPath: "/home/ubuntu/secret-workspace",
+  status: "running",
+  failureReason: null,
+  archived: false,
+  archivedAt: null,
+  createdAt: "2026-04-25T10:00:00.000Z",
+  lastUsedAt: "2026-04-25T12:00:00.000Z",
+  lastTurnId: "turn-secret-1",
+  lastTurnStatus: "running"
+} as const;
+
+test("returns explicit unavailable/degraded states when injected data is absent", () => {
+  const provider = createWebReadonlyViewModelProvider({ now: () => fixedNow });
+
+  assert.deepEqual(provider.listWorkspaceViewModels().state, "unavailable");
+  assert.deepEqual(provider.listWorkspaceConversationViewModels("wk_missing").state, "unavailable");
+  assert.deepEqual(provider.getConversationResultViewModel("session-1").state, "unavailable");
+  assert.deepEqual(provider.getRuntimeContextViewModel().state, "degraded");
+  assert.deepEqual(provider.getReadinessGuardrailViewModel().state, "unavailable");
+
+  assertNoForbiddenViewModelData(provider.getHomeViewModel());
+});
+
+test("derives safe workspace rows from recent project and session stats without exposing raw paths", () => {
+  const provider = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    store: {
+      listRecentProjects: () => [
+        {
+          projectPath: "/home/ubuntu/secret-workspace",
+          projectName: "secret-workspace",
+          projectAlias: "Console Core",
+          lastUsedAt: "2026-04-25T12:00:00.000Z",
+          pinned: true,
+          lastSessionId: "session-1",
+          lastSuccessAt: "2026-04-25T11:00:00.000Z",
+          source: "pin"
+        }
+      ],
+      listSessionProjectStats: () => [
+        {
+          projectPath: "/home/ubuntu/secret-workspace",
+          projectName: "secret-workspace",
+          sessionCount: 3,
+          lastUsedAt: "2026-04-25T12:00:00.000Z"
+        }
+      ]
+    }
+  });
+
+  const vm = provider.listWorkspaceViewModels();
+
+  assert.equal(vm.state, "available");
+  assert.equal(vm.workspaces.length, 1);
+  assert.equal(vm.workspaces[0]?.label, "Console Core");
+  assert.equal(vm.workspaces[0]?.conversationCount, 3);
+  assert.equal(vm.workspaces[0]?.pinned, true);
+  assert.match(vm.workspaces[0]?.workspaceId ?? "", /^wk_[a-f0-9]{16}$/);
+  assertNoForbiddenViewModelData(vm);
+});
+
+test("uses deterministic opaque labels when path-backed workspaces have no explicit alias", () => {
+  const provider = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    store: {
+      listRecentProjects: () => [
+        {
+          projectPath: "/home/ubuntu/top-secret/secret-client",
+          projectName: "secret-client",
+          projectAlias: null,
+          lastUsedAt: "2026-04-25T12:00:00.000Z",
+          pinned: false,
+          source: "recent"
+        }
+      ],
+      listSessionProjectStats: () => [
+        {
+          projectPath: "/home/ubuntu/top-secret/secret-client",
+          projectName: "secret-client",
+          sessionCount: 1,
+          lastUsedAt: "2026-04-25T12:00:00.000Z"
+        }
+      ]
+    }
+  });
+
+  const first = provider.listWorkspaceViewModels().workspaces[0];
+  const second = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    store: {
+      listSessionProjectStats: () => [
+        {
+          projectPath: "/home/ubuntu/top-secret/secret-client",
+          projectName: "secret-client",
+          sessionCount: 1,
+          lastUsedAt: "2026-04-25T12:00:00.000Z"
+        }
+      ]
+    }
+  }).listWorkspaceViewModels().workspaces[0];
+
+  assert.ok(first);
+  assert.ok(second);
+  assert.match(first.workspaceId, /^wk_[a-f0-9]{16}$/);
+  assert.equal(first.workspaceId, second.workspaceId);
+  assert.match(first.label, /^Workspace [a-f0-9]{8}$/);
+  assert.equal(serialized(first).includes("secret-client"), false);
+  assert.equal(serialized(first).includes("top-secret"), false);
+  assert.equal(serialized(first).includes(Buffer.from("/home/ubuntu/top-secret/secret-client").toString("base64")), false);
+  assertNoForbiddenViewModelData(first);
+});
+
+test("derives safe conversation rows for a workspace without platform ids, paths, or controls", () => {
+  const provider = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    operatorBinding: { chatId: "telegram-chat-123" },
+    store: {
+      listRecentProjects: () => [],
+      listSessionProjectStats: () => [
+        {
+          projectPath: "/home/ubuntu/secret-workspace",
+          projectName: "secret-workspace",
+          sessionCount: 1,
+          lastUsedAt: "2026-04-25T12:00:00.000Z"
+        }
+      ],
+      listSessions: () => [session]
+    }
+  });
+  const workspace = provider.listWorkspaceViewModels().workspaces[0];
+  assert.ok(workspace);
+
+  const vm = provider.listWorkspaceConversationViewModels(workspace.workspaceId);
+
+  assert.equal(vm.state, "available");
+  assert.equal(vm.conversations.length, 1);
+  assert.deepEqual(vm.conversations[0], {
+    conversationId: "session-1",
+    workspaceId: workspace.workspaceId,
+    title: "Implement read-only Web adapter",
+    status: "running",
+    failureReason: null,
+    archived: false,
+    createdAt: "2026-04-25T10:00:00.000Z",
+    lastActivityAt: "2026-04-25T12:00:00.000Z",
+    lastTurnStatus: "running",
+    finalAnswerAvailable: false
+  });
+  assertNoForbiddenViewModelData(vm);
+});
+
+test("allowlists injected final-answer body text and rejects action/control markup", () => {
+  const provider = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    operatorBinding: { chatId: "telegram-chat-123" },
+    store: {
+      getSessionById: () => session,
+      listFinalAnswerViews: () => [
+        {
+          answerId: "answer-safe",
+          chatId: "telegram-chat-123",
+          deliveryMessageId: 100,
+          sessionId: "session-1",
+          threadId: "thread-secret-1",
+          turnId: "turn-secret-1",
+          kind: "final_answer",
+          deliveryState: "delivered",
+          previewHtml: "<b>Telegram preview is not the neutral body</b>",
+          pages: ["<b>Telegram page is not the neutral body</b>"],
+          primaryActionConsumed: false,
+          createdAt: "2026-04-25T12:10:00.000Z"
+        },
+        {
+          answerId: "answer-unsafe",
+          chatId: "telegram-chat-123",
+          deliveryMessageId: 101,
+          sessionId: "session-1",
+          threadId: "thread-secret-1",
+          turnId: "turn-secret-1",
+          kind: "final_answer",
+          deliveryState: "delivered",
+          previewHtml: "<b>Unsafe</b>",
+          pages: ["<b>Unsafe</b>"],
+          primaryActionConsumed: false,
+          createdAt: "2026-04-25T12:11:00.000Z"
+        }
+      ]
+    },
+    getSanitizedFinalAnswerBody: (answer) =>
+      answer.answerId === "answer-safe"
+        ? "Completed safely.\n\n- Tests passed\nUse `npm run check`."
+        : '<a href="tg://callback?data=approve">Approve</a> callback messageId=123 submit interrupt upload switch resume'
+  });
+
+  const vm = provider.getConversationResultViewModel("session-1");
+
+  assert.equal(vm.answers.length, 2);
+  assert.deepEqual(vm.answers[0]?.body, {
+    state: "available",
+    text: "Completed safely.\n\n- Tests passed\nUse `npm run check`."
+  });
+  assert.deepEqual(vm.answers[1]?.body, {
+    state: "unavailable",
+    reason: "unsafe_final_answer_body"
+  });
+  assertNoForbiddenViewModelData(vm);
+});
+
+test("conversation results expose final-answer availability but not raw Telegram HTML by default", () => {
+  const provider = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    operatorBinding: { chatId: "telegram-chat-123" },
+    store: {
+      getSessionById: () => session,
+      listFinalAnswerViews: () => [
+        {
+          answerId: "answer-1",
+          chatId: "telegram-chat-123",
+          deliveryMessageId: 999,
+          sessionId: "session-1",
+          threadId: "thread-secret-1",
+          turnId: "turn-secret-1",
+          kind: "final_answer",
+          deliveryState: "delivered",
+          previewHtml: "<b>Done</b> /home/ubuntu/secret-workspace",
+          pages: ["<i>Unsafe Telegram HTML</i> /home/ubuntu/secret-workspace"],
+          primaryActionConsumed: false,
+          createdAt: "2026-04-25T12:10:00.000Z"
+        }
+      ]
+    }
+  });
+
+  const vm = provider.getConversationResultViewModel("session-1");
+
+  assert.equal(vm.state, "available");
+  assert.equal(vm.answers.length, 1);
+  assert.deepEqual(vm.answers[0], {
+    answerId: "answer-1",
+    kind: "final_answer",
+    deliveryState: "delivered",
+    createdAt: "2026-04-25T12:10:00.000Z",
+    body: { state: "unavailable", reason: "sanitized_body_not_provided" },
+    summary: "Final answer is available, but body is hidden until a Web-safe sanitized body is provided."
+  });
+  assertNoForbiddenViewModelData(vm);
+});
+
+test("sanitizes runtime and readiness view models with strict allowlists", () => {
+  const provider = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    listActiveTurns: () => [
+      {
+        sessionId: "session-1",
+        status: "running",
+        summary: "Running tests; raw output omitted",
+        blockedReason: "awaiting_approval",
+        messageId: 123,
+        replyMarkup: { inline_keyboard: [[{ text: "Approve", callback_data: "callback-secret" }]] },
+        rawTerminal: "cat /home/ubuntu/secret-workspace/.env"
+      }
+    ],
+    getReadinessSnapshot: () => ({
+      state: "degraded",
+      checkedAt: "2026-04-25T12:30:00.000Z",
+      appServerPid: "4242",
+      details: {
+        activePack: "telegram",
+        codexInstalled: true,
+        codexAuthenticated: true,
+        appServerAvailable: false,
+        authorizedUserBound: true,
+        codexBinResolvedPath: "/home/ubuntu/.local/bin/codex",
+        issues: ["App server unavailable at /home/ubuntu/socket"]
+      }
+    })
+  });
+
+  const runtime = provider.getRuntimeContextViewModel();
+  assert.equal(runtime.state, "available");
+  assert.deepEqual(runtime.activeTurns[0], {
+    sessionId: "session-1",
+    status: "running",
+    summary: "Running tests; raw output omitted",
+    blockedReason: "awaiting_approval"
+  });
+
+  const readiness = provider.getReadinessGuardrailViewModel();
+  assert.equal(readiness.state, "degraded");
+  assert.equal(readiness.capabilities.some((row) => row.label === "App server" && row.observed === "missing"), true);
+  assert.equal(readiness.missingGates.includes("App server unavailable"), true);
+
+  assertNoForbiddenViewModelData({ runtime, readiness });
+});
+
+test("returns unavailable pending-interactions view model when the read facade is absent or throws", () => {
+  const unavailable = createWebReadonlyViewModelProvider({ now: () => fixedNow }).getPendingInteractionsViewModel();
+  assert.equal(unavailable.pageId, "web_pending_interactions");
+  assert.equal(unavailable.state, "unavailable");
+  assert.deepEqual(unavailable.pendingInteractions, []);
+  assert.deepEqual(unavailable.warnings, ["pending_interactions_unavailable"]);
+
+  const thrown = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    listPendingInteractions: () => {
+      throw new Error("raw pending interaction store failed /home/ubuntu/secret-workspace");
+    }
+  }).getPendingInteractionsViewModel();
+  assert.equal(thrown.state, "unavailable");
+  assert.deepEqual(thrown.pendingInteractions, []);
+  assert.deepEqual(thrown.warnings, ["pending_interactions_unavailable"]);
+  assertNoForbiddenViewModelData({ unavailable, thrown });
+});
+
+test("normalizes and redacts pending interactions without exposing platform payloads or controls", () => {
+  const provider = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    listPendingInteractions: () => [
+      {
+        id: "telegram:chat-123:message-999:/home/ubuntu/secret-workspace",
+        sessionId: "session-1",
+        conversationId: "session-1",
+        status: "awaiting_callback_submit",
+        kind: "codex_approval",
+        createdAt: "2026-04-25T12:00:00.000Z",
+        updatedAt: "2026-04-25T12:01:00.000Z",
+        summary: "Approve via callback_data=approve messageId=777 /home/ubuntu/secret-workspace",
+        blockingReason: "Waiting for callback payload from telegramChatId=telegram-chat-123",
+        promptJson: { text: "raw prompt should stay hidden" },
+        responseJson: { ok: true },
+        replyMarkup: { inline_keyboard: [[{ text: "Approve", callback_data: "approve:secret" }]] },
+        platformMessageId: 999,
+        chatId: "telegram-chat-123"
+      },
+      {
+        id: "pending_safe_1",
+        sessionId: "session-2",
+        status: "awaiting_user_input",
+        kind: "question",
+        createdAt: "2026-04-25T13:00:00.000Z",
+        updatedAt: null,
+        summary: "Waiting for a short answer from the operator.",
+        blockingReason: "Conversation is waiting for operator input."
+      }
+    ]
+  });
+
+  const vm = provider.getPendingInteractionsViewModel();
+
+  assert.equal(vm.pageId, "web_pending_interactions");
+  assert.equal(vm.state, "degraded");
+  assert.equal(vm.pendingInteractions.length, 2);
+  assert.match(vm.pendingInteractions[0]?.interactionId ?? "", /^pi_[a-f0-9]{16}$/);
+  assert.deepEqual(vm.pendingInteractions[0], {
+    interactionId: vm.pendingInteractions[0]?.interactionId,
+    conversationId: "session-1",
+    sessionId: "session-1",
+    status: "pending",
+    kind: "interaction",
+    createdAt: "2026-04-25T12:00:00.000Z",
+    updatedAt: "2026-04-25T12:01:00.000Z",
+    blockingReason: "Awaiting user input; details hidden for this read-only surface.",
+    summary: { state: "unavailable", reason: "unsafe_pending_interaction_summary" },
+    availability: "degraded",
+    warnings: ["pending_interaction_details_redacted"]
+  });
+  assert.deepEqual(vm.pendingInteractions[1], {
+    interactionId: "pending_safe_1",
+    conversationId: "session-2",
+    sessionId: "session-2",
+    status: "awaiting_user_input",
+    kind: "question",
+    createdAt: "2026-04-25T13:00:00.000Z",
+    updatedAt: null,
+    blockingReason: "Conversation is waiting for operator input.",
+    summary: { state: "available", text: "Waiting for a short answer from the operator." },
+    availability: "available",
+    warnings: []
+  });
+  assert.deepEqual(vm.warnings, ["pending_interaction_details_redacted"]);
+  assertNoForbiddenViewModelData(vm);
+});

--- a/src/service/web-readonly-view-model.test.ts
+++ b/src/service/web-readonly-view-model.test.ts
@@ -272,7 +272,9 @@ test("home rows come from scoped sessions and expose final-answer availability w
     operatorBinding: { chatId: "telegram-chat-123" },
     store: {
       listSessions: () => [session],
-      getSessionById: () => session,
+      getSessionById: () => {
+        throw new Error("detail lookup must not use raw session id");
+      },
       listFinalAnswerViews: () => [
         {
           answerId: "answer-1",
@@ -292,18 +294,23 @@ test("home rows come from scoped sessions and expose final-answer availability w
   });
 
   const home = provider.getHomeViewModel();
-  const result = provider.getConversationResultViewModel("session-1");
+  const conversationHandle = home.recentConversations[0]?.conversationHandle ?? "";
+  const result = provider.getConversationResultViewModel(conversationHandle);
+  const rawResult = provider.getConversationResultViewModel("session-1");
 
   assert.equal(home.state, "available");
   assert.equal(home.workspaces.length, 1);
   assert.equal(home.recentConversations.length, 1);
-  assert.equal(home.recentConversations[0]?.conversationId, "session-1");
+  assert.match(home.recentConversations[0]?.conversationId ?? "", /^cv_[a-f0-9]{16}$/);
+  assert.equal(home.recentConversations[0]?.conversationId, conversationHandle);
   assert.equal(home.recentConversations[0]?.workspaceId, home.workspaces[0]?.workspaceId);
   assert.equal(home.recentConversations[0]?.finalAnswerAvailable, true);
+  assert.equal(rawResult.state, "unavailable");
   assert.deepEqual(result.answers[0]?.body, { state: "unavailable", reason: "sanitized_body_not_provided" });
   const text = serialized({ home, result });
   for (const forbidden of [
     "/home/ubuntu/secret-workspace",
+    "session-1",
     "telegram-chat-123",
     "thread-secret-1",
     "Secret final answer body"
@@ -388,8 +395,10 @@ test("derives safe conversation rows for a workspace without platform ids, paths
 
   assert.equal(vm.state, "available");
   assert.equal(vm.conversations.length, 1);
+  assert.match(vm.conversations[0]?.conversationHandle ?? "", /^cv_[a-f0-9]{16}$/);
   assert.deepEqual(vm.conversations[0], {
-    conversationId: "session-1",
+    conversationId: vm.conversations[0]?.conversationHandle,
+    conversationHandle: vm.conversations[0]?.conversationHandle,
     workspaceId: workspace.workspaceId,
     title: "Implement read-only Web adapter",
     status: "running",
@@ -400,6 +409,7 @@ test("derives safe conversation rows for a workspace without platform ids, paths
     lastTurnStatus: "running",
     finalAnswerAvailable: false
   });
+  assert.equal(serialized(vm).includes("session-1"), false);
   assertNoForbiddenViewModelData(vm);
 });
 
@@ -408,7 +418,10 @@ test("allowlists injected final-answer body text and rejects action/control mark
     now: () => fixedNow,
     operatorBinding: { chatId: "telegram-chat-123" },
     store: {
-      getSessionById: () => session,
+      listSessions: () => [session],
+      getSessionById: () => {
+        throw new Error("detail lookup must not use raw session id");
+      },
       listFinalAnswerViews: () => [
         {
           answerId: "answer-safe",
@@ -446,7 +459,10 @@ test("allowlists injected final-answer body text and rejects action/control mark
         : '<a href="tg://callback?data=approve">Approve</a> callback messageId=123 submit interrupt upload switch resume'
   });
 
-  const vm = provider.getConversationResultViewModel("session-1");
+  const workspace = provider.listWorkspaceViewModels().workspaces[0];
+  assert.ok(workspace);
+  const handle = provider.listWorkspaceConversationViewModels(workspace.workspaceId).conversations[0]?.conversationHandle ?? "";
+  const vm = provider.getConversationResultViewModel(handle);
 
   assert.equal(vm.answers.length, 2);
   assert.deepEqual(vm.answers[0]?.body, {
@@ -465,7 +481,10 @@ test("conversation results expose final-answer availability but not raw Telegram
     now: () => fixedNow,
     operatorBinding: { chatId: "telegram-chat-123" },
     store: {
-      getSessionById: () => session,
+      listSessions: () => [session],
+      getSessionById: () => {
+        throw new Error("detail lookup must not use raw session id");
+      },
       listFinalAnswerViews: () => [
         {
           answerId: "answer-1",
@@ -485,7 +504,10 @@ test("conversation results expose final-answer availability but not raw Telegram
     }
   });
 
-  const vm = provider.getConversationResultViewModel("session-1");
+  const workspace = provider.listWorkspaceViewModels().workspaces[0];
+  assert.ok(workspace);
+  const handle = provider.listWorkspaceConversationViewModels(workspace.workspaceId).conversations[0]?.conversationHandle ?? "";
+  const vm = provider.getConversationResultViewModel(handle);
 
   assert.equal(vm.state, "available");
   assert.equal(vm.answers.length, 1);
@@ -532,8 +554,9 @@ test("sanitizes runtime and readiness view models with strict allowlists", () =>
 
   const runtime = provider.getRuntimeContextViewModel();
   assert.equal(runtime.state, "available");
+  assert.match(runtime.activeTurns[0]?.sessionId ?? "", /^cv_[a-f0-9]{16}$/);
   assert.deepEqual(runtime.activeTurns[0], {
-    sessionId: "session-1",
+    sessionId: runtime.activeTurns[0]?.sessionId,
     status: "running",
     summary: "Running tests; raw output omitted",
     blockedReason: "awaiting_approval"
@@ -605,10 +628,11 @@ test("normalizes and redacts pending interactions without exposing platform payl
   assert.equal(vm.state, "degraded");
   assert.equal(vm.pendingInteractions.length, 2);
   assert.match(vm.pendingInteractions[0]?.interactionId ?? "", /^pi_[a-f0-9]{16}$/);
+  assert.match(vm.pendingInteractions[0]?.conversationId ?? "", /^cv_[a-f0-9]{16}$/);
   assert.deepEqual(vm.pendingInteractions[0], {
     interactionId: vm.pendingInteractions[0]?.interactionId,
-    conversationId: "session-1",
-    sessionId: "session-1",
+    conversationId: vm.pendingInteractions[0]?.conversationId,
+    sessionId: null,
     status: "pending",
     kind: "interaction",
     createdAt: "2026-04-25T12:00:00.000Z",
@@ -618,10 +642,12 @@ test("normalizes and redacts pending interactions without exposing platform payl
     availability: "degraded",
     warnings: ["pending_interaction_details_redacted"]
   });
+  assert.match(vm.pendingInteractions[1]?.interactionId ?? "", /^pi_[a-f0-9]{16}$/);
+  assert.match(vm.pendingInteractions[1]?.conversationId ?? "", /^cv_[a-f0-9]{16}$/);
   assert.deepEqual(vm.pendingInteractions[1], {
-    interactionId: "pending_safe_1",
-    conversationId: "session-2",
-    sessionId: "session-2",
+    interactionId: vm.pendingInteractions[1]?.interactionId,
+    conversationId: vm.pendingInteractions[1]?.conversationId,
+    sessionId: null,
     status: "awaiting_user_input",
     kind: "question",
     createdAt: "2026-04-25T13:00:00.000Z",
@@ -632,5 +658,7 @@ test("normalizes and redacts pending interactions without exposing platform payl
     warnings: []
   });
   assert.deepEqual(vm.warnings, ["pending_interaction_details_redacted"]);
+  assert.equal(serialized(vm).includes("session-1"), false);
+  assert.equal(serialized(vm).includes("session-2"), false);
   assertNoForbiddenViewModelData(vm);
 });

--- a/src/service/web-readonly-view-model.test.ts
+++ b/src/service/web-readonly-view-model.test.ts
@@ -476,6 +476,60 @@ test("allowlists injected final-answer body text and rejects action/control mark
   assertNoForbiddenViewModelData(vm);
 });
 
+test("rejects injected final-answer bodies with local paths or tokenized URLs", () => {
+  const provider = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    operatorBinding: { chatId: "telegram-chat-123" },
+    store: {
+      listSessions: () => [session],
+      listFinalAnswerViews: () => [
+        {
+          answerId: "answer-path",
+          chatId: "telegram-chat-123",
+          deliveryMessageId: 100,
+          sessionId: "session-1",
+          threadId: "thread-secret-1",
+          turnId: "turn-secret-1",
+          kind: "final_answer",
+          deliveryState: "delivered",
+          previewHtml: "<b>Do not use Telegram preview</b>",
+          pages: ["Do not use Telegram-rendered pages"],
+          primaryActionConsumed: false,
+          createdAt: "2026-04-25T12:10:00.000Z"
+        },
+        {
+          answerId: "answer-url",
+          chatId: "telegram-chat-123",
+          deliveryMessageId: 101,
+          sessionId: "session-1",
+          threadId: "thread-secret-1",
+          turnId: "turn-secret-1",
+          kind: "final_answer",
+          deliveryState: "delivered",
+          previewHtml: "<b>Do not use Telegram preview</b>",
+          pages: ["Do not use Telegram-rendered pages"],
+          primaryActionConsumed: false,
+          createdAt: "2026-04-25T12:11:00.000Z"
+        }
+      ]
+    },
+    getSanitizedFinalAnswerBody: (answer) =>
+      answer.answerId === "answer-path"
+        ? "Completed in /home/ubuntu/secret-workspace/result.txt"
+        : "Download result at https://example.invalid/result.txt?token=abc123"
+  });
+
+  const workspace = provider.listWorkspaceViewModels().workspaces[0];
+  assert.ok(workspace);
+  const handle = provider.listWorkspaceConversationViewModels(workspace.workspaceId).conversations[0]?.conversationHandle ?? "";
+  const vm = provider.getConversationResultViewModel(handle);
+
+  assert.equal(vm.answers.length, 2);
+  assert.deepEqual(vm.answers[0]?.body, { state: "unavailable", reason: "unsafe_final_answer_body" });
+  assert.deepEqual(vm.answers[1]?.body, { state: "unavailable", reason: "unsafe_final_answer_body" });
+  assertNoForbiddenViewModelData(vm);
+});
+
 test("conversation results expose final-answer availability but not raw Telegram HTML by default", () => {
   const provider = createWebReadonlyViewModelProvider({
     now: () => fixedNow,

--- a/src/service/web-readonly-view-model.test.ts
+++ b/src/service/web-readonly-view-model.test.ts
@@ -305,7 +305,16 @@ test("home rows come from scoped sessions and expose final-answer availability w
   assert.equal(home.recentConversations[0]?.conversationId, conversationHandle);
   assert.equal(home.recentConversations[0]?.workspaceId, home.workspaces[0]?.workspaceId);
   assert.equal(home.recentConversations[0]?.finalAnswerAvailable, true);
+  assert.deepEqual(home.composer, {
+    state: "disabled",
+    label: "Message Codex",
+    placeholder: "Type a message to Codex",
+    disabledReason: "Sending from Web is landing next.",
+    capability: "web_send_landing_next"
+  });
   assert.equal(rawResult.state, "unavailable");
+  assert.equal(result.composer.state, "disabled");
+  assert.equal(result.composer.disabledReason, "Sending from Web is landing next.");
   assert.deepEqual(result.answers[0]?.body, { state: "unavailable", reason: "sanitized_body_not_provided" });
   const text = serialized({ home, result });
   for (const forbidden of [

--- a/src/service/web-readonly-view-model.test.ts
+++ b/src/service/web-readonly-view-model.test.ts
@@ -233,6 +233,86 @@ test("derives safe workspace rows from recent project and session stats without 
   assertNoForbiddenViewModelData(vm);
 });
 
+test("derives safe workspace rows from scoped sessions without global project readers", () => {
+  const provider = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    operatorBinding: { chatId: "telegram-chat-123" },
+    store: {
+      listSessions: () => [
+        session,
+        {
+          ...session,
+          sessionId: "session-2",
+          displayName: "Second scoped conversation",
+          lastUsedAt: "2026-04-25T13:00:00.000Z",
+          lastTurnId: "turn-secret-2"
+        }
+      ]
+    }
+  });
+
+  const vm = provider.listWorkspaceViewModels();
+
+  assert.equal(vm.state, "available");
+  assert.equal(vm.workspaces.length, 1);
+  assert.equal(vm.workspaces[0]?.label, "Console Core");
+  assert.equal(vm.workspaces[0]?.conversationCount, 2);
+  assert.equal(vm.workspaces[0]?.lastActivityAt, "2026-04-25T13:00:00.000Z");
+  assert.match(vm.workspaces[0]?.workspaceId ?? "", /^wk_[a-f0-9]{16}$/);
+  const text = serialized(vm);
+  for (const forbidden of ["/home/ubuntu/secret-workspace", "telegram-chat-123", "thread-secret-1"]) {
+    assert.equal(text.includes(forbidden), false, `view model leaked ${forbidden}: ${text}`);
+  }
+  assertNoForbiddenViewModelData(vm);
+});
+
+test("home rows come from scoped sessions and expose final-answer availability without body text", () => {
+  const provider = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    operatorBinding: { chatId: "telegram-chat-123" },
+    store: {
+      listSessions: () => [session],
+      getSessionById: () => session,
+      listFinalAnswerViews: () => [
+        {
+          answerId: "answer-1",
+          chatId: "telegram-chat-123",
+          deliveryMessageId: 999,
+          sessionId: "session-1",
+          threadId: "thread-secret-1",
+          turnId: "turn-secret-1",
+          kind: "final_answer",
+          deliveryState: "delivered",
+          previewHtml: "<b>Secret final answer body</b> /home/ubuntu/secret-workspace",
+          pages: ["Secret final answer body from Telegram renderer"],
+          createdAt: "2026-04-25T12:10:00.000Z"
+        }
+      ]
+    }
+  });
+
+  const home = provider.getHomeViewModel();
+  const result = provider.getConversationResultViewModel("session-1");
+
+  assert.equal(home.state, "available");
+  assert.equal(home.workspaces.length, 1);
+  assert.equal(home.recentConversations.length, 1);
+  assert.equal(home.recentConversations[0]?.conversationId, "session-1");
+  assert.equal(home.recentConversations[0]?.workspaceId, home.workspaces[0]?.workspaceId);
+  assert.equal(home.recentConversations[0]?.finalAnswerAvailable, true);
+  assert.deepEqual(result.answers[0]?.body, { state: "unavailable", reason: "sanitized_body_not_provided" });
+  const text = serialized({ home, result });
+  for (const forbidden of [
+    "/home/ubuntu/secret-workspace",
+    "telegram-chat-123",
+    "thread-secret-1",
+    "Secret final answer body"
+  ]) {
+    assert.equal(text.includes(forbidden), false, `view model leaked ${forbidden}: ${text}`);
+  }
+  assertNoForbiddenViewModelData({ home, result });
+});
+
 test("uses deterministic opaque labels when path-backed workspaces have no explicit alias", () => {
   const provider = createWebReadonlyViewModelProvider({
     now: () => fixedNow,

--- a/src/service/web-readonly-view-model.test.ts
+++ b/src/service/web-readonly-view-model.test.ts
@@ -320,6 +320,42 @@ test("home rows come from scoped sessions and expose final-answer availability w
   assertNoForbiddenViewModelData({ home, result });
 });
 
+
+test("home includes pending interaction summary from safe read model", () => {
+  const provider = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    operatorBinding: { chatId: "telegram-chat-123" },
+    store: {
+      listSessions: () => [session]
+    },
+    listPendingInteractions: () => [
+      {
+        id: "pending_safe_home",
+        sessionId: "session-1",
+        status: "awaiting_user_input",
+        kind: "question",
+        createdAt: "2026-04-25T13:00:00.000Z",
+        updatedAt: null,
+        summary: "Waiting for a short product decision.",
+        blockingReason: "Conversation is waiting for operator input."
+      }
+    ]
+  });
+
+  const home = provider.getHomeViewModel();
+
+  assert.equal(home.pendingInteractions.state, "available");
+  assert.equal(home.pendingInteractions.pendingInteractions.length, 1);
+  assert.equal(home.pendingInteractions.pendingInteractions[0]?.summary.state, "available");
+  assert.match(home.pendingInteractions.pendingInteractions[0]?.conversationId ?? "", /^cv_[a-f0-9]{16}$/);
+  const text = serialized(home);
+  for (const forbidden of ["pending_safe_home", "session-1", "telegram-chat-123"]) {
+    assert.equal(text.includes(forbidden), false, `home leaked pending source value ${forbidden}: ${text}`);
+  }
+  assertNoForbiddenViewModelData(home);
+});
+
+
 test("uses deterministic opaque labels when path-backed workspaces have no explicit alias", () => {
   const provider = createWebReadonlyViewModelProvider({
     now: () => fixedNow,

--- a/src/service/web-readonly-view-model.test.ts
+++ b/src/service/web-readonly-view-model.test.ts
@@ -61,10 +61,138 @@ test("returns explicit unavailable/degraded states when injected data is absent"
   assert.deepEqual(provider.listWorkspaceViewModels().state, "unavailable");
   assert.deepEqual(provider.listWorkspaceConversationViewModels("wk_missing").state, "unavailable");
   assert.deepEqual(provider.getConversationResultViewModel("session-1").state, "unavailable");
+  assert.deepEqual(provider.getConversationArtifactCatalogViewModel("session-1").state, "unavailable");
   assert.deepEqual(provider.getRuntimeContextViewModel().state, "degraded");
   assert.deepEqual(provider.getReadinessGuardrailViewModel().state, "unavailable");
 
   assertNoForbiddenViewModelData(provider.getHomeViewModel());
+});
+
+test("returns unavailable, degraded, and empty artifact catalog states without leaking source errors", () => {
+  const unavailable = createWebReadonlyViewModelProvider({
+    now: () => fixedNow
+  }).getConversationArtifactCatalogViewModel("session-1");
+  assert.equal(unavailable.pageId, "web_conversation_artifacts");
+  assert.equal(unavailable.state, "unavailable");
+  assert.deepEqual(unavailable.artifacts, []);
+  assert.equal(unavailable.selectedArtifact, null);
+  assert.deepEqual(unavailable.warnings, ["artifact_catalog_unavailable"]);
+
+  const degraded = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    listArtifactDescriptors: () => {
+      throw new Error("artifact read failed /tmp/secret-result https://example.invalid/raw?messageId=123");
+    }
+  }).getConversationArtifactCatalogViewModel("session-1");
+  assert.equal(degraded.state, "degraded");
+  assert.deepEqual(degraded.artifacts, []);
+  assert.equal(degraded.selectedArtifact, null);
+  assert.deepEqual(degraded.warnings, ["artifact_catalog_degraded"]);
+
+  const empty = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    listArtifactDescriptors: () => []
+  }).getConversationArtifactCatalogViewModel("session-1");
+  assert.equal(empty.state, "empty");
+  assert.deepEqual(empty.artifacts, []);
+  assert.equal(empty.emptyState, "no_artifacts");
+  assert.deepEqual(empty.warnings, []);
+
+  assertNoForbiddenViewModelData({ unavailable, degraded, empty });
+});
+
+test("redacts unsafe artifact descriptors and exposes only neutral descriptor metadata", () => {
+  const provider = createWebReadonlyViewModelProvider({
+    now: () => fixedNow,
+    listArtifactDescriptors: () => [
+      {
+        id: "file:/home/ubuntu/secret-workspace/result.png?token=abc",
+        label: "Approve screenshot /home/ubuntu/secret-workspace/result.png callback_data=approve",
+        filename: "result.png",
+        kind: "image",
+        type: "image/png",
+        mediaType: "image/png",
+        sizeBytes: 2048,
+        createdAt: "2026-04-25T12:20:00.000Z",
+        updatedAt: "2026-04-25T12:21:00.000Z",
+        availability: "available",
+        previewEligible: true,
+        downloadEligible: true,
+        previewUrl: "https://example.invalid/preview/result.png?messageId=123",
+        downloadPath: "/tmp/secret-result/result.png",
+        platformResourceId: "telegram:file:abc",
+        messageId: 123,
+        rawProtocol: { callback: "approve" }
+      },
+      {
+        id: "artifact_safe_1",
+        label: "Test summary",
+        kind: "document",
+        type: "text/markdown",
+        mediaType: "text/markdown",
+        sizeBytes: 512,
+        createdAt: "2026-04-25T12:30:00.000Z",
+        updatedAt: null,
+        availability: "available",
+        previewEligible: false,
+        downloadEligible: false
+      }
+    ]
+  });
+
+  const vm = provider.getConversationArtifactCatalogViewModel("session-1");
+
+  assert.equal(vm.state, "degraded");
+  assert.equal(vm.artifacts.length, 2);
+  assert.match(vm.artifacts[0]?.artifactId ?? "", /^art_[a-f0-9]{16}$/);
+  assert.deepEqual(vm.artifacts[0], {
+    artifactId: vm.artifacts[0]?.artifactId,
+    label: "Artifact descriptor",
+    kind: "image",
+    type: "image/png",
+    mediaType: "image/png",
+    sizeBytes: 2048,
+    createdAt: "2026-04-25T12:20:00.000Z",
+    updatedAt: "2026-04-25T12:21:00.000Z",
+    availability: "degraded",
+    previewEligible: false,
+    previewLabel: "Preview unavailable",
+    downloadEligible: false,
+    downloadLabel: "Download unavailable",
+    warnings: ["artifact_descriptor_redacted"]
+  });
+  assert.deepEqual(vm.artifacts[1], {
+    artifactId: "artifact_safe_1",
+    label: "Test summary",
+    kind: "document",
+    type: "text/markdown",
+    mediaType: "text/markdown",
+    sizeBytes: 512,
+    createdAt: "2026-04-25T12:30:00.000Z",
+    updatedAt: null,
+    availability: "available",
+    previewEligible: false,
+    previewLabel: "Preview unavailable",
+    downloadEligible: false,
+    downloadLabel: "Download unavailable",
+    warnings: []
+  });
+  assert.deepEqual(vm.selectedArtifact, vm.artifacts[1]);
+  assert.deepEqual(vm.warnings, ["artifact_descriptor_redacted"]);
+  assertNoForbiddenViewModelData(vm);
+
+  const text = serialized(vm);
+  for (const forbidden of [
+    "/tmp/secret-result",
+    "https://example.invalid",
+    "platformResourceId",
+    "rawProtocol",
+    "result.png",
+    "token=abc",
+    "telegram:file"
+  ]) {
+    assert.equal(text.includes(forbidden), false, `artifact view model leaked ${forbidden}: ${text}`);
+  }
 });
 
 test("derives safe workspace rows from recent project and session stats without exposing raw paths", () => {

--- a/src/service/web-readonly-view-model.ts
+++ b/src/service/web-readonly-view-model.ts
@@ -330,6 +330,7 @@ export interface WebReadonlyHomeViewModel extends WebReadonlyEnvelope {
   workspaces: WebReadonlyWorkspaceRow[];
   recentConversations: WebReadonlyConversationRow[];
   runtime: Pick<WebReadonlyRuntimeContextViewModel, "state" | "activeTurns">;
+  pendingInteractions: Pick<WebReadonlyPendingInteractionsViewModel, "state" | "pendingInteractions">;
   readiness: Pick<WebReadonlyReadinessGuardrailViewModel, "state" | "missingGates">;
   warnings: string[];
 }
@@ -542,6 +543,7 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
         ? provider.listWorkspaceConversationViewModels(firstWorkspaceId)
         : null;
       const runtime = provider.getRuntimeContextViewModel();
+      const pendingInteractions = provider.getPendingInteractionsViewModel();
       const readiness = provider.getReadinessGuardrailViewModel();
       const warnings = [
         ...workspaceVm.warnings,
@@ -558,6 +560,10 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
         workspaces: workspaceVm.workspaces.slice(0, 5),
         recentConversations: conversationsVm?.conversations.slice(0, 5) ?? [],
         runtime: { state: runtime.state, activeTurns: runtime.activeTurns },
+        pendingInteractions: {
+          state: pendingInteractions.state,
+          pendingInteractions: pendingInteractions.pendingInteractions
+        },
         readiness: { state: readiness.state, missingGates: readiness.missingGates },
         warnings: unique(warnings)
       };

--- a/src/service/web-readonly-view-model.ts
+++ b/src/service/web-readonly-view-model.ts
@@ -229,6 +229,7 @@ export interface WebReadonlyConversationResultViewModel extends WebReadonlyEnvel
   runtime: Pick<WebReadonlyRuntimeContextViewModel, "state" | "activeTurns">;
   pendingInteractions: Pick<WebReadonlyPendingInteractionsViewModel, "state" | "pendingInteractions">;
   readiness: Pick<WebReadonlyReadinessGuardrailViewModel, "state" | "missingGates">;
+  composer: WebReadonlyDisabledComposerViewModel;
   warnings: string[];
 }
 
@@ -332,7 +333,16 @@ export interface WebReadonlyHomeViewModel extends WebReadonlyEnvelope {
   runtime: Pick<WebReadonlyRuntimeContextViewModel, "state" | "activeTurns">;
   pendingInteractions: Pick<WebReadonlyPendingInteractionsViewModel, "state" | "pendingInteractions">;
   readiness: Pick<WebReadonlyReadinessGuardrailViewModel, "state" | "missingGates">;
+  composer: WebReadonlyDisabledComposerViewModel;
   warnings: string[];
+}
+
+export interface WebReadonlyDisabledComposerViewModel {
+  state: "disabled";
+  label: string;
+  placeholder: string;
+  disabledReason: string;
+  capability: "web_send_landing_next";
 }
 
 export interface WebReadonlyViewModelProvider {
@@ -565,6 +575,7 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
           pendingInteractions: pendingInteractions.pendingInteractions
         },
         readiness: { state: readiness.state, missingGates: readiness.missingGates },
+        composer: disabledComposerViewModel(),
         warnings: unique(warnings)
       };
     },
@@ -662,6 +673,7 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
         runtime: runtimePanelForConversation(provider.getRuntimeContextViewModel(), safeConversationHandle),
         pendingInteractions: pendingPanelForConversation(provider.getPendingInteractionsViewModel(), safeConversationHandle),
         readiness: readinessPanel(provider.getReadinessGuardrailViewModel()),
+        composer: disabledComposerViewModel(),
         warnings: unique(warnings)
       };
     },
@@ -832,7 +844,18 @@ function unavailableConversationResult(
     runtime: { state: "degraded", activeTurns: [] },
     pendingInteractions: { state: "unavailable", pendingInteractions: [] },
     readiness: { state: "unavailable", missingGates: [] },
+    composer: disabledComposerViewModel(),
     warnings: [warning]
+  };
+}
+
+function disabledComposerViewModel(): WebReadonlyDisabledComposerViewModel {
+  return {
+    state: "disabled",
+    label: "Message Codex",
+    placeholder: "Type a message to Codex",
+    disabledReason: "Sending from Web is landing next.",
+    capability: "web_send_landing_next"
   };
 }
 

--- a/src/service/web-readonly-view-model.ts
+++ b/src/service/web-readonly-view-model.ts
@@ -632,9 +632,7 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
             body: safeBody.state === "available"
               ? { state: "available", text: safeBody.text }
               : { state: "unavailable", reason: safeBody.reason },
-            summary: safeBody.state === "available"
-              ? "Final answer body was provided by an injected Web-safe sanitizer."
-              : "Final answer is available, but body is hidden until a Web-safe sanitized body is provided."
+            summary: finalAnswerSummary(safeBody)
           };
         });
 
@@ -1321,6 +1319,9 @@ function sanitizeFinalAnswerBody(value: string | null | undefined): WebReadonlyA
   if (containsUnsafeControlMarkup(raw)) {
     return { state: "unavailable", reason: "unsafe_final_answer_body" };
   }
+  if (containsForbiddenBodySource(raw)) {
+    return { state: "unavailable", reason: "unsafe_final_answer_body" };
+  }
 
   const stripped = stripTinySafeHtml(raw);
   if (!stripped) {
@@ -1329,6 +1330,9 @@ function sanitizeFinalAnswerBody(value: string | null | undefined): WebReadonlyA
 
   const decoded = decodeBasicHtmlEntities(stripped);
   if (containsUnsafeControlMarkup(decoded)) {
+    return { state: "unavailable", reason: "unsafe_final_answer_body" };
+  }
+  if (containsForbiddenBodySource(decoded)) {
     return { state: "unavailable", reason: "unsafe_final_answer_body" };
   }
 
@@ -1344,6 +1348,16 @@ function sanitizeFinalAnswerBody(value: string | null | undefined): WebReadonlyA
     return { state: "unavailable", reason: "unsafe_final_answer_body" };
   }
   return { state: "available", text };
+}
+
+function finalAnswerSummary(body: WebReadonlyAnswerBodyUnavailable | WebReadonlyAnswerBodyAvailable): string {
+  if (body.state === "available") {
+    return "Final answer body was provided by an injected Web-safe sanitizer.";
+  }
+  if (body.reason === "unsafe_final_answer_body") {
+    return "Final answer body was rejected by the Web safety filter.";
+  }
+  return "Final answer is available, but body is hidden until a Web-safe sanitized body is provided.";
 }
 
 function stripTinySafeHtml(value: string): string | null {
@@ -1378,6 +1392,15 @@ function containsUnsafeControlMarkup(value: string): boolean {
     /\b(?:submit|approve|interrupt|upload|switch|resume)\b/i,
     /(?:^|["'(\s])(?:tg|javascript|callback):/i,
     /\[[^\]]+\]\((?:tg|javascript|callback):[^)]*\)/i
+  ].some((pattern) => pattern.test(value));
+}
+
+function containsForbiddenBodySource(value: string): boolean {
+  return [
+    /\bfile:\/\/[^\s"'<>)]*/i,
+    /(?:^|[\s"'(])(?:\/(?:home|tmp|var|etc|root|Users|usr)\/[^\s<>"']*|~\/[^\s<>"']*|[A-Za-z]:\\[^\s<>"']*)/,
+    /\bhttps?:\/\/[^\s"'<>)]*[?&](?:access_?token|auth|authorization|bearer|key|sig|signature|token)=[^\s"'<>)]*/i,
+    /(?:^|["'(\s])(?:feishu|lark):\/\//i
   ].some((pattern) => pattern.test(value));
 }
 

--- a/src/service/web-readonly-view-model.ts
+++ b/src/service/web-readonly-view-model.ts
@@ -170,6 +170,7 @@ export interface WebReadonlyWorkspaceListViewModel extends WebReadonlyEnvelope {
 
 export interface WebReadonlyConversationRow {
   conversationId: string;
+  conversationHandle: string;
   workspaceId: string;
   title: string;
   status: string;
@@ -214,6 +215,7 @@ export interface WebReadonlyConversationResultViewModel extends WebReadonlyEnvel
   state: WebReadonlyAvailability;
   conversation: {
     conversationId: string;
+    conversationHandle: string;
     workspaceId: string;
     title: string;
     workspaceLabel: string;
@@ -224,6 +226,9 @@ export interface WebReadonlyConversationResultViewModel extends WebReadonlyEnvel
     lastActivityAt: string;
   } | null;
   answers: WebReadonlyAnswerRow[];
+  runtime: Pick<WebReadonlyRuntimeContextViewModel, "state" | "activeTurns">;
+  pendingInteractions: Pick<WebReadonlyPendingInteractionsViewModel, "state" | "pendingInteractions">;
+  readiness: Pick<WebReadonlyReadinessGuardrailViewModel, "state" | "missingGates">;
   warnings: string[];
 }
 
@@ -333,7 +338,7 @@ export interface WebReadonlyViewModelProvider {
   getHomeViewModel(): WebReadonlyHomeViewModel;
   listWorkspaceViewModels(): WebReadonlyWorkspaceListViewModel;
   listWorkspaceConversationViewModels(workspaceId: string): WebReadonlyWorkspaceConversationListViewModel;
-  getConversationResultViewModel(sessionId: string): WebReadonlyConversationResultViewModel;
+  getConversationResultViewModel(conversationHandle: string): WebReadonlyConversationResultViewModel;
   getConversationArtifactCatalogViewModel(sessionId: string, artifactId?: string): WebReadonlyConversationArtifactCatalogViewModel;
   getRuntimeContextViewModel(): WebReadonlyRuntimeContextViewModel;
   getPendingInteractionsViewModel(): WebReadonlyPendingInteractionsViewModel;
@@ -364,6 +369,7 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
   });
 
   const workspaceIdForPath = (projectPath: string): string => `wk_${hashOpaque(idSalt, projectPath)}`;
+  const conversationHandleForSessionId = (sessionId: string): string => `cv_${hashOpaque(idSalt, sessionId)}`;
 
   const buildWorkspaceIndex = (): { state: WebReadonlyAvailability; rows: WorkspaceAccumulator[]; warnings: string[] } => {
     const store = deps.store;
@@ -476,13 +482,22 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
     return new Set(callSafely(() => deps.store?.listFinalAnswerViews?.(chatId) ?? [], [], [], "").map((answer) => answer.sessionId));
   };
 
-  const listBoundSessions = (warnings: string[]): WebReadonlySessionRow[] | null => {
+  const listBoundSessions = (warnings: string[], archived = false): WebReadonlySessionRow[] | null => {
     const chatId = deps.operatorBinding?.chatId;
     if (!chatId || !deps.store?.listSessions) {
       return null;
     }
-    return callSafely(() => deps.store?.listSessions?.(chatId, { archived: false, limit: 100 }) ?? [], [], warnings, "sessions_unavailable")
-      .filter((session) => !session.archived);
+    return callSafely(() => deps.store?.listSessions?.(chatId, { archived, limit: 100 }) ?? [], [], warnings, "sessions_unavailable")
+      .filter((session) => Boolean(session.archived) === archived);
+  };
+
+  const listBoundSessionsForDetail = (warnings: string[]): WebReadonlySessionRow[] | null => {
+    const active = listBoundSessions(warnings, false);
+    if (!active) {
+      return null;
+    }
+    const archived = listBoundSessions(warnings, true) ?? [];
+    return [...active, ...archived];
   };
 
   const toWorkspaceRow = (row: WorkspaceAccumulator): WebReadonlyWorkspaceRow => {
@@ -502,18 +517,22 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
   const toConversationRow = (
     session: WebReadonlySessionRow,
     finalAnswerSessionIds: Set<string>
-  ): WebReadonlyConversationRow => ({
-    conversationId: session.sessionId,
-    workspaceId: workspaceIdForPath(session.projectPath),
-    title: safeLabel(session.displayName, "Untitled conversation"),
-    status: safeLabel(session.status, "unknown"),
-    failureReason: session.failureReason ? safeLabel(session.failureReason, "failed") : null,
-    archived: Boolean(session.archived),
-    createdAt: session.createdAt,
-    lastActivityAt: session.lastUsedAt,
-    lastTurnStatus: session.lastTurnStatus ? safeLabel(session.lastTurnStatus, "unknown") : null,
-    finalAnswerAvailable: finalAnswerSessionIds.has(session.sessionId)
-  });
+  ): WebReadonlyConversationRow => {
+    const conversationHandle = conversationHandleForSessionId(session.sessionId);
+    return {
+      conversationId: conversationHandle,
+      conversationHandle,
+      workspaceId: workspaceIdForPath(session.projectPath),
+      title: safeLabel(session.displayName, "Untitled conversation"),
+      status: safeLabel(session.status, "unknown"),
+      failureReason: session.failureReason ? safeLabel(session.failureReason, "failed") : null,
+      archived: Boolean(session.archived),
+      createdAt: session.createdAt,
+      lastActivityAt: session.lastUsedAt,
+      lastTurnStatus: session.lastTurnStatus ? safeLabel(session.lastTurnStatus, "unknown") : null,
+      finalAnswerAvailable: finalAnswerSessionIds.has(session.sessionId)
+    };
+  };
 
   const provider: WebReadonlyViewModelProvider = {
     getHomeViewModel() {
@@ -586,17 +605,20 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
       };
     },
 
-    getConversationResultViewModel(sessionId) {
+    getConversationResultViewModel(conversationHandle) {
+      const requestedConversationHandle = conversationHandle.trim();
       const chatId = deps.operatorBinding?.chatId;
-      if (!chatId || !deps.store?.getSessionById) {
+      if (!chatId || !deps.store?.listSessions || !isSafeConversationHandle(requestedConversationHandle)) {
         return unavailableConversationResult(envelope(), "conversation_data_unavailable");
       }
 
       const warnings: string[] = [];
-      const session = callSafely(() => deps.store?.getSessionById?.(sessionId) ?? null, null, warnings, "conversation_data_unavailable");
-      if (!session || (session.chatId && session.chatId !== chatId)) {
+      const sessions = listBoundSessionsForDetail(warnings);
+      const session = sessions?.find((row) => conversationHandleForSessionId(row.sessionId) === requestedConversationHandle) ?? null;
+      if (!session) {
         return unavailableConversationResult(envelope(), "conversation_not_available");
       }
+      const safeConversationHandle = conversationHandleForSessionId(session.sessionId);
 
       const answers = callSafely(() => deps.store?.listFinalAnswerViews?.(chatId) ?? [], [], warnings, "final_answers_unavailable")
         .filter((answer) => answer.sessionId === session.sessionId)
@@ -621,7 +643,8 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
         pageId: "web_conversation_result",
         state: warnings.length > 0 ? "degraded" : "available",
         conversation: {
-          conversationId: session.sessionId,
+          conversationId: safeConversationHandle,
+          conversationHandle: safeConversationHandle,
           workspaceId: workspaceIdForPath(session.projectPath),
           title: safeLabel(session.displayName, "Untitled conversation"),
           workspaceLabel: safeWorkspaceLabel(workspaceIdForPath(session.projectPath), session.projectAlias ?? null),
@@ -632,6 +655,9 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
           lastActivityAt: session.lastUsedAt
         },
         answers,
+        runtime: runtimePanelForConversation(provider.getRuntimeContextViewModel(), safeConversationHandle),
+        pendingInteractions: pendingPanelForConversation(provider.getPendingInteractionsViewModel(), safeConversationHandle),
+        readiness: readinessPanel(provider.getReadinessGuardrailViewModel()),
         warnings: unique(warnings)
       };
     },
@@ -690,7 +716,7 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
       const warnings: string[] = [];
       const activeTurns = callSafely(() => deps.listActiveTurns?.() ?? [], [], warnings, "runtime_data_unavailable").map(
         (turn): WebReadonlyRuntimeTurnRow => ({
-          sessionId: turn.sessionId,
+          sessionId: isSafeConversationHandle(turn.sessionId) ? turn.sessionId : conversationHandleForSessionId(turn.sessionId),
           status: safeLabel(turn.status, "unknown"),
           summary: turn.summary ? redactText(turn.summary) : null,
           blockedReason: turn.blockedReason ? safeLabel(turn.blockedReason, "blocked") : null
@@ -799,7 +825,39 @@ function unavailableConversationResult(
     state: "unavailable",
     conversation: null,
     answers: [],
+    runtime: { state: "degraded", activeTurns: [] },
+    pendingInteractions: { state: "unavailable", pendingInteractions: [] },
+    readiness: { state: "unavailable", missingGates: [] },
     warnings: [warning]
+  };
+}
+
+function runtimePanelForConversation(
+  vm: WebReadonlyRuntimeContextViewModel,
+  conversationHandle: string
+): Pick<WebReadonlyRuntimeContextViewModel, "state" | "activeTurns"> {
+  return {
+    state: vm.state,
+    activeTurns: vm.activeTurns.filter((turn) => turn.sessionId === conversationHandle)
+  };
+}
+
+function pendingPanelForConversation(
+  vm: WebReadonlyPendingInteractionsViewModel,
+  conversationHandle: string
+): Pick<WebReadonlyPendingInteractionsViewModel, "state" | "pendingInteractions"> {
+  return {
+    state: vm.state,
+    pendingInteractions: vm.pendingInteractions.filter((row) => row.conversationId === conversationHandle)
+  };
+}
+
+function readinessPanel(
+  vm: WebReadonlyReadinessGuardrailViewModel
+): Pick<WebReadonlyReadinessGuardrailViewModel, "state" | "missingGates"> {
+  return {
+    state: vm.state,
+    missingGates: vm.missingGates
   };
 }
 
@@ -1025,8 +1083,10 @@ function normalizePendingInteraction(
 ): WebReadonlyPendingInteractionViewRow {
   const rawSessionId = primitiveString(row.sessionId);
   const rawConversationId = primitiveString(row.conversationId) ?? rawSessionId;
-  const sessionId = safePublicEntityId(rawSessionId);
-  const conversationId = safePublicEntityId(rawConversationId) ?? sessionId;
+  const sessionId = null;
+  const conversationId = rawConversationId
+    ? isSafeConversationHandle(rawConversationId) ? rawConversationId : conversationHandleForRawSessionId(idSalt, rawConversationId)
+    : null;
   const summary = sanitizePendingInteractionSummary(firstPrimitiveString(row, ["summary"]));
   const blockingReason = sanitizePendingInteractionText(
     firstPrimitiveString(row, ["blockingReason", "blockedReason", "reason"])
@@ -1056,10 +1116,6 @@ function normalizePendingInteraction(
 
 function safePendingInteractionId(row: WebReadonlyPendingInteractionInputRow, index: number, idSalt: string): string {
   const rawId = firstPrimitiveString(row, ["interactionId", "id", "pendingInteractionId"]);
-  if (rawId && isSafePublicOpaqueId(rawId)) {
-    return rawId;
-  }
-
   const stableKey = [
     rawId,
     primitiveString(row.sessionId),
@@ -1087,6 +1143,14 @@ function isSafePublicOpaqueId(value: string): boolean {
     && !containsUnsafePendingValue(trimmed)
     && !/^(?:ou|oc|om|on|cli|msg|message|chat)_/i.test(trimmed)
     && !/\b(?:telegram|feishu|chat|message|platform|path)\b/i.test(trimmed);
+}
+
+function conversationHandleForRawSessionId(idSalt: string, sessionId: string): string {
+  return `cv_${hashOpaque(idSalt, sessionId)}`;
+}
+
+function isSafeConversationHandle(value: string): boolean {
+  return /^cv_[a-f0-9]{16}$/.test(value.trim());
 }
 
 function safePendingLabel(value: string | null, fallback: string): string {

--- a/src/service/web-readonly-view-model.ts
+++ b/src/service/web-readonly-view-model.ts
@@ -1,0 +1,1029 @@
+import { createHash } from "node:crypto";
+
+export type WebReadonlyAvailability = "available" | "unavailable" | "degraded";
+export type WebReadonlyObservedState = "present" | "missing" | "unknown";
+
+export interface WebReadonlyOperatorBinding {
+  chatId: string;
+}
+
+export interface WebReadonlyRecentProjectRow {
+  projectPath: string;
+  projectName: string;
+  projectAlias?: string | null;
+  lastUsedAt: string;
+  pinned?: boolean;
+  lastSessionId?: string | null;
+  lastSuccessAt?: string | null;
+  source?: string;
+}
+
+export interface WebReadonlySessionProjectStatsRow {
+  projectPath: string;
+  projectName: string;
+  sessionCount: number;
+  lastUsedAt: string | null;
+}
+
+export interface WebReadonlySessionRow {
+  sessionId: string;
+  chatId?: string;
+  telegramChatId?: string;
+  threadId?: string | null;
+  displayName: string;
+  projectName: string;
+  projectAlias?: string | null;
+  projectPath: string;
+  status: string;
+  failureReason?: string | null;
+  archived?: boolean;
+  createdAt: string;
+  lastUsedAt: string;
+  lastTurnId?: string | null;
+  lastTurnStatus?: string | null;
+}
+
+export interface WebReadonlyFinalAnswerRow {
+  answerId: string;
+  chatId?: string;
+  deliveryMessageId?: number | null;
+  sessionId: string;
+  threadId?: string;
+  turnId?: string;
+  kind: string;
+  deliveryState: string;
+  previewHtml?: string;
+  pages?: string[];
+  primaryActionConsumed?: boolean;
+  createdAt: string;
+}
+
+export interface WebReadonlyReadinessSnapshot {
+  state: string;
+  checkedAt: string;
+  details: {
+    activePack?: string;
+    codexInstalled?: boolean;
+    codexAuthenticated?: boolean;
+    appServerAvailable?: boolean;
+    authorizedUserBound?: boolean;
+    issues?: string[];
+    [key: string]: unknown;
+  };
+  appServerPid?: string | null;
+}
+
+export interface WebReadonlyActiveTurn {
+  sessionId: string;
+  status: string;
+  summary?: string | null;
+  blockedReason?: string | null;
+  [key: string]: unknown;
+}
+
+export interface WebReadonlyPendingInteractionInputRow {
+  id?: string | number | null;
+  interactionId?: string | number | null;
+  pendingInteractionId?: string | number | null;
+  conversationId?: string | number | null;
+  sessionId?: string | number | null;
+  status?: string | null;
+  state?: string | null;
+  kind?: string | null;
+  type?: string | null;
+  category?: string | null;
+  summary?: string | null;
+  blockingReason?: string | null;
+  blockedReason?: string | null;
+  reason?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  [key: string]: unknown;
+}
+
+export interface WebReadonlyStoreReader {
+  listRecentProjects?: () => WebReadonlyRecentProjectRow[];
+  listSessionProjectStats?: () => WebReadonlySessionProjectStatsRow[];
+  listSessions?: (chatId: string, options?: { archived?: boolean; limit?: number }) => WebReadonlySessionRow[];
+  getSessionById?: (sessionId: string) => WebReadonlySessionRow | null;
+  listFinalAnswerViews?: (chatId: string) => WebReadonlyFinalAnswerRow[];
+  getReadinessSnapshot?: () => WebReadonlyReadinessSnapshot | null;
+}
+
+export interface WebReadonlyViewModelDeps {
+  store?: WebReadonlyStoreReader;
+  operatorBinding?: WebReadonlyOperatorBinding | null;
+  now?: () => string;
+  idSalt?: string;
+  listActiveTurns?: () => WebReadonlyActiveTurn[] | null | undefined;
+  listPendingInteractions?: () => WebReadonlyPendingInteractionInputRow[] | null | undefined;
+  getReadinessSnapshot?: () => WebReadonlyReadinessSnapshot | null | undefined;
+  getSanitizedFinalAnswerBody?: (answer: WebReadonlyFinalAnswerRow) => string | null | undefined;
+}
+
+export interface WebReadonlyEnvelope {
+  generatedAt: string;
+  prototypeOnly: true;
+  readonly: true;
+}
+
+export interface WebReadonlyWorkspaceRow {
+  workspaceId: string;
+  label: string;
+  availability: WebReadonlyAvailability;
+  conversationCount: number;
+  pinned: boolean;
+  lastActivityAt: string | null;
+  lastSuccessAt: string | null;
+  source: string;
+}
+
+export interface WebReadonlyWorkspaceListViewModel extends WebReadonlyEnvelope {
+  pageId: "web_workspaces";
+  state: WebReadonlyAvailability;
+  workspaces: WebReadonlyWorkspaceRow[];
+  warnings: string[];
+}
+
+export interface WebReadonlyConversationRow {
+  conversationId: string;
+  workspaceId: string;
+  title: string;
+  status: string;
+  failureReason: string | null;
+  archived: boolean;
+  createdAt: string;
+  lastActivityAt: string;
+  lastTurnStatus: string | null;
+  finalAnswerAvailable: boolean;
+}
+
+export interface WebReadonlyWorkspaceConversationListViewModel extends WebReadonlyEnvelope {
+  pageId: "web_workspace_conversations";
+  state: WebReadonlyAvailability;
+  workspaceId: string;
+  conversations: WebReadonlyConversationRow[];
+  emptyState: string | null;
+  warnings: string[];
+}
+
+export interface WebReadonlyAnswerBodyUnavailable {
+  state: "unavailable";
+  reason: "sanitized_body_not_provided" | "unsafe_final_answer_body";
+}
+
+export interface WebReadonlyAnswerBodyAvailable {
+  state: "available";
+  text: string;
+}
+
+export interface WebReadonlyAnswerRow {
+  answerId: string;
+  kind: string;
+  deliveryState: string;
+  createdAt: string;
+  body: WebReadonlyAnswerBodyUnavailable | WebReadonlyAnswerBodyAvailable;
+  summary: string;
+}
+
+export interface WebReadonlyConversationResultViewModel extends WebReadonlyEnvelope {
+  pageId: "web_conversation_result";
+  state: WebReadonlyAvailability;
+  conversation: {
+    conversationId: string;
+    workspaceId: string;
+    title: string;
+    workspaceLabel: string;
+    status: string;
+    failureReason: string | null;
+    archived: boolean;
+    createdAt: string;
+    lastActivityAt: string;
+  } | null;
+  answers: WebReadonlyAnswerRow[];
+  warnings: string[];
+}
+
+export interface WebReadonlyRuntimeTurnRow {
+  sessionId: string;
+  status: string;
+  summary: string | null;
+  blockedReason: string | null;
+}
+
+export interface WebReadonlyRuntimeContextViewModel extends WebReadonlyEnvelope {
+  pageId: "web_runtime_context";
+  state: WebReadonlyAvailability;
+  activeTurns: WebReadonlyRuntimeTurnRow[];
+  warnings: string[];
+}
+
+export interface WebReadonlyPendingInteractionSummaryUnavailable {
+  state: "unavailable";
+  reason: "pending_interaction_summary_not_provided" | "unsafe_pending_interaction_summary";
+}
+
+export interface WebReadonlyPendingInteractionSummaryAvailable {
+  state: "available";
+  text: string;
+}
+
+export interface WebReadonlyPendingInteractionViewRow {
+  interactionId: string;
+  conversationId: string | null;
+  sessionId: string | null;
+  status: string;
+  kind: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  blockingReason: string;
+  summary: WebReadonlyPendingInteractionSummaryUnavailable | WebReadonlyPendingInteractionSummaryAvailable;
+  availability: WebReadonlyAvailability;
+  warnings: string[];
+}
+
+export interface WebReadonlyPendingInteractionsViewModel extends WebReadonlyEnvelope {
+  pageId: "web_pending_interactions";
+  state: WebReadonlyAvailability;
+  pendingInteractions: WebReadonlyPendingInteractionViewRow[];
+  warnings: string[];
+}
+
+export interface WebReadonlyReadinessCapabilityRow {
+  key: string;
+  label: string;
+  declared: WebReadonlyObservedState;
+  configured: WebReadonlyObservedState;
+  observed: WebReadonlyObservedState;
+  uxExposed: WebReadonlyObservedState;
+}
+
+export interface WebReadonlyReadinessGuardrailViewModel extends WebReadonlyEnvelope {
+  pageId: "web_readiness_guardrails";
+  state: string;
+  checkedAt: string | null;
+  activePack: string | null;
+  capabilities: WebReadonlyReadinessCapabilityRow[];
+  missingGates: string[];
+  warnings: string[];
+}
+
+export interface WebReadonlyHomeViewModel extends WebReadonlyEnvelope {
+  pageId: "web_home";
+  state: WebReadonlyAvailability;
+  operator: { binding: WebReadonlyAvailability };
+  workspaces: WebReadonlyWorkspaceRow[];
+  recentConversations: WebReadonlyConversationRow[];
+  runtime: Pick<WebReadonlyRuntimeContextViewModel, "state" | "activeTurns">;
+  readiness: Pick<WebReadonlyReadinessGuardrailViewModel, "state" | "missingGates">;
+  warnings: string[];
+}
+
+export interface WebReadonlyViewModelProvider {
+  getHomeViewModel(): WebReadonlyHomeViewModel;
+  listWorkspaceViewModels(): WebReadonlyWorkspaceListViewModel;
+  listWorkspaceConversationViewModels(workspaceId: string): WebReadonlyWorkspaceConversationListViewModel;
+  getConversationResultViewModel(sessionId: string): WebReadonlyConversationResultViewModel;
+  getRuntimeContextViewModel(): WebReadonlyRuntimeContextViewModel;
+  getPendingInteractionsViewModel(): WebReadonlyPendingInteractionsViewModel;
+  getReadinessGuardrailViewModel(): WebReadonlyReadinessGuardrailViewModel;
+}
+
+interface WorkspaceAccumulator {
+  path: string;
+  label: string | null;
+  projectName: string;
+  pinned: boolean;
+  conversationCount: number;
+  lastActivityAt: string | null;
+  lastSuccessAt: string | null;
+  source: string;
+}
+
+const DEFAULT_ID_SALT = "web-readonly-view-model:v1";
+
+export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDeps): WebReadonlyViewModelProvider {
+  const now = () => deps.now?.() ?? new Date().toISOString();
+  const idSalt = deps.idSalt ?? DEFAULT_ID_SALT;
+
+  const envelope = (): WebReadonlyEnvelope => ({
+    generatedAt: now(),
+    prototypeOnly: true,
+    readonly: true
+  });
+
+  const workspaceIdForPath = (projectPath: string): string => `wk_${hashOpaque(idSalt, projectPath)}`;
+
+  const buildWorkspaceIndex = (): { state: WebReadonlyAvailability; rows: WorkspaceAccumulator[]; warnings: string[] } => {
+    const store = deps.store;
+    if (!store || (!store.listRecentProjects && !store.listSessionProjectStats)) {
+      return { state: "unavailable", rows: [], warnings: ["workspace_data_unavailable"] };
+    }
+
+    const warnings: string[] = [];
+    const byPath = new Map<string, WorkspaceAccumulator>();
+
+    const upsert = (projectPath: string, projectName: string, patch: Partial<WorkspaceAccumulator>): void => {
+      const current = byPath.get(projectPath) ?? {
+        path: projectPath,
+        label: null,
+        projectName: safeLabel(projectName, "Workspace"),
+        pinned: false,
+        conversationCount: 0,
+        lastActivityAt: null,
+        lastSuccessAt: null,
+        source: "unknown"
+      };
+      const nextLastActivity = latestIso(current.lastActivityAt, patch.lastActivityAt ?? null);
+      byPath.set(projectPath, {
+        ...current,
+        ...patch,
+        label: safeOptionalLabel(patch.label === undefined ? current.label : patch.label),
+        projectName: safeLabel(patch.projectName ?? current.projectName, "Workspace"),
+        pinned: Boolean(current.pinned || patch.pinned),
+        conversationCount: Math.max(current.conversationCount, patch.conversationCount ?? 0),
+        lastActivityAt: nextLastActivity,
+        lastSuccessAt: latestIso(current.lastSuccessAt, patch.lastSuccessAt ?? null),
+        source: patch.source ?? current.source
+      });
+    };
+
+    for (const project of callSafely(store.listRecentProjects, [], warnings, "recent_projects_unavailable")) {
+      upsert(project.projectPath, project.projectName, {
+        label: project.projectAlias ?? null,
+        projectName: project.projectName,
+        pinned: Boolean(project.pinned),
+        lastActivityAt: project.lastUsedAt,
+        lastSuccessAt: project.lastSuccessAt ?? null,
+        source: project.source ?? "recent"
+      });
+    }
+
+    for (const stat of callSafely(store.listSessionProjectStats, [], warnings, "workspace_stats_unavailable")) {
+      upsert(stat.projectPath, stat.projectName, {
+        projectName: stat.projectName,
+        conversationCount: stat.sessionCount,
+        lastActivityAt: stat.lastUsedAt,
+        source: "session_stats"
+      });
+    }
+
+    return {
+      state: warnings.length > 0 ? "degraded" : "available",
+      rows: Array.from(byPath.values()).sort(compareWorkspaceRows),
+      warnings
+    };
+  };
+
+  const getFinalAnswerSessionSet = (): Set<string> => {
+    const chatId = deps.operatorBinding?.chatId;
+    if (!chatId || !deps.store?.listFinalAnswerViews) {
+      return new Set();
+    }
+    return new Set(callSafely(() => deps.store?.listFinalAnswerViews?.(chatId) ?? [], [], [], "").map((answer) => answer.sessionId));
+  };
+
+  const listBoundSessions = (warnings: string[]): WebReadonlySessionRow[] | null => {
+    const chatId = deps.operatorBinding?.chatId;
+    if (!chatId || !deps.store?.listSessions) {
+      return null;
+    }
+    return callSafely(() => deps.store?.listSessions?.(chatId, { archived: false, limit: 100 }) ?? [], [], warnings, "sessions_unavailable");
+  };
+
+  const toWorkspaceRow = (row: WorkspaceAccumulator): WebReadonlyWorkspaceRow => {
+    const workspaceId = workspaceIdForPath(row.path);
+    return {
+      workspaceId,
+      label: safeWorkspaceLabel(workspaceId, row.label),
+      availability: "available",
+      conversationCount: row.conversationCount,
+      pinned: row.pinned,
+      lastActivityAt: row.lastActivityAt,
+      lastSuccessAt: row.lastSuccessAt,
+      source: row.source
+    };
+  };
+
+  const toConversationRow = (
+    session: WebReadonlySessionRow,
+    finalAnswerSessionIds: Set<string>
+  ): WebReadonlyConversationRow => ({
+    conversationId: session.sessionId,
+    workspaceId: workspaceIdForPath(session.projectPath),
+    title: safeLabel(session.displayName, "Untitled conversation"),
+    status: safeLabel(session.status, "unknown"),
+    failureReason: session.failureReason ? safeLabel(session.failureReason, "failed") : null,
+    archived: Boolean(session.archived),
+    createdAt: session.createdAt,
+    lastActivityAt: session.lastUsedAt,
+    lastTurnStatus: session.lastTurnStatus ? safeLabel(session.lastTurnStatus, "unknown") : null,
+    finalAnswerAvailable: finalAnswerSessionIds.has(session.sessionId)
+  });
+
+  const provider: WebReadonlyViewModelProvider = {
+    getHomeViewModel() {
+      const workspaceVm = provider.listWorkspaceViewModels();
+      const firstWorkspaceId = workspaceVm.workspaces[0]?.workspaceId;
+      const conversationsVm = firstWorkspaceId
+        ? provider.listWorkspaceConversationViewModels(firstWorkspaceId)
+        : null;
+      const runtime = provider.getRuntimeContextViewModel();
+      const readiness = provider.getReadinessGuardrailViewModel();
+      const warnings = [
+        ...workspaceVm.warnings,
+        ...(conversationsVm?.warnings ?? []),
+        ...runtime.warnings,
+        ...readiness.warnings
+      ];
+
+      return {
+        ...envelope(),
+        pageId: "web_home",
+        state: workspaceVm.state === "available" ? "available" : "degraded",
+        operator: { binding: deps.operatorBinding?.chatId ? "available" : "unavailable" },
+        workspaces: workspaceVm.workspaces.slice(0, 5),
+        recentConversations: conversationsVm?.conversations.slice(0, 5) ?? [],
+        runtime: { state: runtime.state, activeTurns: runtime.activeTurns },
+        readiness: { state: readiness.state, missingGates: readiness.missingGates },
+        warnings: unique(warnings)
+      };
+    },
+
+    listWorkspaceViewModels() {
+      const index = buildWorkspaceIndex();
+      return {
+        ...envelope(),
+        pageId: "web_workspaces",
+        state: index.state,
+        workspaces: index.rows.map(toWorkspaceRow),
+        warnings: index.warnings
+      };
+    },
+
+    listWorkspaceConversationViewModels(workspaceId) {
+      const warnings: string[] = [];
+      const sessions = listBoundSessions(warnings);
+      if (!sessions) {
+        return {
+          ...envelope(),
+          pageId: "web_workspace_conversations",
+          state: "unavailable",
+          workspaceId,
+          conversations: [],
+          emptyState: "session_data_unavailable",
+          warnings: unique(["operator_binding_or_session_data_unavailable", ...warnings])
+        };
+      }
+
+      const finalAnswerSessionIds = getFinalAnswerSessionSet();
+      const conversations = sessions
+        .filter((session) => workspaceIdForPath(session.projectPath) === workspaceId)
+        .map((session) => toConversationRow(session, finalAnswerSessionIds));
+
+      return {
+        ...envelope(),
+        pageId: "web_workspace_conversations",
+        state: warnings.length > 0 ? "degraded" : "available",
+        workspaceId,
+        conversations,
+        emptyState: conversations.length === 0 ? "no_conversations" : null,
+        warnings: unique(warnings)
+      };
+    },
+
+    getConversationResultViewModel(sessionId) {
+      const chatId = deps.operatorBinding?.chatId;
+      if (!chatId || !deps.store?.getSessionById) {
+        return unavailableConversationResult(envelope(), "conversation_data_unavailable");
+      }
+
+      const warnings: string[] = [];
+      const session = callSafely(() => deps.store?.getSessionById?.(sessionId) ?? null, null, warnings, "conversation_data_unavailable");
+      if (!session || (session.chatId && session.chatId !== chatId)) {
+        return unavailableConversationResult(envelope(), "conversation_not_available");
+      }
+
+      const answers = callSafely(() => deps.store?.listFinalAnswerViews?.(chatId) ?? [], [], warnings, "final_answers_unavailable")
+        .filter((answer) => answer.sessionId === session.sessionId)
+        .map((answer): WebReadonlyAnswerRow => {
+          const safeBody = sanitizeFinalAnswerBody(deps.getSanitizedFinalAnswerBody?.(answer));
+          return {
+            answerId: answer.answerId,
+            kind: safeLabel(answer.kind, "final_answer"),
+            deliveryState: safeLabel(answer.deliveryState, "unknown"),
+            createdAt: answer.createdAt,
+            body: safeBody.state === "available"
+              ? { state: "available", text: safeBody.text }
+              : { state: "unavailable", reason: safeBody.reason },
+            summary: safeBody.state === "available"
+              ? "Final answer body was provided by an injected Web-safe sanitizer."
+              : "Final answer is available, but body is hidden until a Web-safe sanitized body is provided."
+          };
+        });
+
+      return {
+        ...envelope(),
+        pageId: "web_conversation_result",
+        state: warnings.length > 0 ? "degraded" : "available",
+        conversation: {
+          conversationId: session.sessionId,
+          workspaceId: workspaceIdForPath(session.projectPath),
+          title: safeLabel(session.displayName, "Untitled conversation"),
+          workspaceLabel: safeWorkspaceLabel(workspaceIdForPath(session.projectPath), session.projectAlias ?? null),
+          status: safeLabel(session.status, "unknown"),
+          failureReason: session.failureReason ? safeLabel(session.failureReason, "failed") : null,
+          archived: Boolean(session.archived),
+          createdAt: session.createdAt,
+          lastActivityAt: session.lastUsedAt
+        },
+        answers,
+        warnings: unique(warnings)
+      };
+    },
+
+    getRuntimeContextViewModel() {
+      if (!deps.listActiveTurns) {
+        return {
+          ...envelope(),
+          pageId: "web_runtime_context",
+          state: "degraded",
+          activeTurns: [],
+          warnings: ["runtime_data_unavailable"]
+        };
+      }
+
+      const warnings: string[] = [];
+      const activeTurns = callSafely(() => deps.listActiveTurns?.() ?? [], [], warnings, "runtime_data_unavailable").map(
+        (turn): WebReadonlyRuntimeTurnRow => ({
+          sessionId: turn.sessionId,
+          status: safeLabel(turn.status, "unknown"),
+          summary: turn.summary ? redactText(turn.summary) : null,
+          blockedReason: turn.blockedReason ? safeLabel(turn.blockedReason, "blocked") : null
+        })
+      );
+
+      return {
+        ...envelope(),
+        pageId: "web_runtime_context",
+        state: warnings.length > 0 ? "degraded" : "available",
+        activeTurns,
+        warnings: unique(warnings)
+      };
+    },
+
+    getPendingInteractionsViewModel() {
+      if (!deps.listPendingInteractions) {
+        return unavailablePendingInteractions(envelope(), "pending_interactions_unavailable");
+      }
+
+      const warnings: string[] = [];
+      const pendingRows = callSafely(
+        () => deps.listPendingInteractions?.() ?? null,
+        null as WebReadonlyPendingInteractionInputRow[] | null,
+        warnings,
+        "pending_interactions_unavailable"
+      );
+      if (!pendingRows) {
+        return unavailablePendingInteractions(envelope(), "pending_interactions_unavailable");
+      }
+
+      const pendingInteractions = pendingRows.map((row, index) => normalizePendingInteraction(row, index, idSalt));
+      const rowWarnings = pendingInteractions.flatMap((row) => row.warnings);
+      return {
+        ...envelope(),
+        pageId: "web_pending_interactions",
+        state: warnings.length > 0 || rowWarnings.length > 0 ? "degraded" : "available",
+        pendingInteractions,
+        warnings: unique([...warnings, ...rowWarnings])
+      };
+    },
+
+    getReadinessGuardrailViewModel() {
+      const getSnapshot = deps.getReadinessSnapshot ?? deps.store?.getReadinessSnapshot;
+      if (!getSnapshot) {
+        return {
+          ...envelope(),
+          pageId: "web_readiness_guardrails",
+          state: "unavailable",
+          checkedAt: null,
+          activePack: null,
+          capabilities: [],
+          missingGates: ["readiness_data_unavailable"],
+          warnings: ["readiness_data_unavailable"]
+        };
+      }
+
+      const warnings: string[] = [];
+      const snapshot = callSafely(getSnapshot, null, warnings, "readiness_data_unavailable");
+      if (!snapshot) {
+        return {
+          ...envelope(),
+          pageId: "web_readiness_guardrails",
+          state: "unavailable",
+          checkedAt: null,
+          activePack: null,
+          capabilities: [],
+          missingGates: ["readiness_data_unavailable"],
+          warnings: unique(warnings)
+        };
+      }
+
+      const details = snapshot.details;
+      const missingGates = (details.issues ?? [])
+        .map(summarizeIssue)
+        .filter((issue): issue is string => Boolean(issue));
+
+      return {
+        ...envelope(),
+        pageId: "web_readiness_guardrails",
+        state: safeLabel(snapshot.state, "unknown"),
+        checkedAt: snapshot.checkedAt,
+        activePack: details.activePack ? safeLabel(details.activePack, "unknown") : null,
+        capabilities: [
+          capability("codex_installed", "Codex installed", details.codexInstalled),
+          capability("codex_authenticated", "Codex authenticated", details.codexAuthenticated),
+          capability("app_server", "App server", details.appServerAvailable),
+          capability("operator_binding", "Operator binding", details.authorizedUserBound)
+        ],
+        missingGates: unique(missingGates),
+        warnings: unique(warnings)
+      };
+    }
+  };
+
+  return provider;
+}
+
+function unavailableConversationResult(
+  envelope: WebReadonlyEnvelope,
+  warning: string
+): WebReadonlyConversationResultViewModel {
+  return {
+    ...envelope,
+    pageId: "web_conversation_result",
+    state: "unavailable",
+    conversation: null,
+    answers: [],
+    warnings: [warning]
+  };
+}
+
+function unavailablePendingInteractions(
+  envelope: WebReadonlyEnvelope,
+  warning: string
+): WebReadonlyPendingInteractionsViewModel {
+  return {
+    ...envelope,
+    pageId: "web_pending_interactions",
+    state: "unavailable",
+    pendingInteractions: [],
+    warnings: [warning]
+  };
+}
+
+function normalizePendingInteraction(
+  row: WebReadonlyPendingInteractionInputRow,
+  index: number,
+  idSalt: string
+): WebReadonlyPendingInteractionViewRow {
+  const rawSessionId = primitiveString(row.sessionId);
+  const rawConversationId = primitiveString(row.conversationId) ?? rawSessionId;
+  const sessionId = safePublicEntityId(rawSessionId);
+  const conversationId = safePublicEntityId(rawConversationId) ?? sessionId;
+  const summary = sanitizePendingInteractionSummary(firstPrimitiveString(row, ["summary"]));
+  const blockingReason = sanitizePendingInteractionText(
+    firstPrimitiveString(row, ["blockingReason", "blockedReason", "reason"])
+  );
+  const warnings = unique([
+    summary.state === "unavailable" && summary.reason === "unsafe_pending_interaction_summary"
+      ? "pending_interaction_details_redacted"
+      : "",
+    blockingReason.safe ? "" : "pending_interaction_details_redacted",
+    rowContainsRawOnlyPendingData(row) ? "pending_interaction_details_redacted" : ""
+  ]);
+
+  return {
+    interactionId: safePendingInteractionId(row, index, idSalt),
+    conversationId,
+    sessionId,
+    status: safePendingLabel(firstPrimitiveString(row, ["status", "state"]), "pending"),
+    kind: safePendingLabel(firstPrimitiveString(row, ["kind", "type", "category"]), "interaction"),
+    createdAt: safeTimestamp(row.createdAt),
+    updatedAt: safeTimestamp(row.updatedAt),
+    blockingReason: blockingReason.text ?? "Awaiting user input; details hidden for this read-only surface.",
+    summary,
+    availability: warnings.length > 0 ? "degraded" : "available",
+    warnings
+  };
+}
+
+function safePendingInteractionId(row: WebReadonlyPendingInteractionInputRow, index: number, idSalt: string): string {
+  const rawId = firstPrimitiveString(row, ["interactionId", "id", "pendingInteractionId"]);
+  if (rawId && isSafePublicOpaqueId(rawId)) {
+    return rawId;
+  }
+
+  const stableKey = [
+    rawId,
+    primitiveString(row.sessionId),
+    primitiveString(row.conversationId),
+    primitiveString(row.status),
+    primitiveString(row.kind),
+    primitiveString(row.createdAt),
+    primitiveString(row.updatedAt),
+    String(index)
+  ].join("\0");
+  return `pi_${hashOpaque(idSalt, stableKey)}`;
+}
+
+function safePublicEntityId(value: string | null): string | null {
+  if (!value || !isSafePublicOpaqueId(value)) {
+    return null;
+  }
+  return value;
+}
+
+function isSafePublicOpaqueId(value: string): boolean {
+  const trimmed = value.trim();
+  return /^[A-Za-z0-9_-]{1,80}$/.test(trimmed)
+    && !looksPathLike(trimmed)
+    && !containsUnsafePendingValue(trimmed)
+    && !/^(?:ou|oc|om|on|cli|msg|message|chat)_/i.test(trimmed)
+    && !/\b(?:telegram|feishu|chat|message|platform|path)\b/i.test(trimmed);
+}
+
+function safePendingLabel(value: string | null, fallback: string): string {
+  const raw = String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  if (!raw || looksPathLike(raw) || containsUnsafePendingValue(raw) || !/^[a-z0-9_.:-]{1,80}$/.test(raw)) {
+    return fallback;
+  }
+  return raw;
+}
+
+function safeTimestamp(value: string | null | undefined): string | null {
+  const raw = String(value ?? "").trim();
+  if (!raw || looksPathLike(raw) || containsUnsafePendingValue(raw)) {
+    return null;
+  }
+  return raw;
+}
+
+function sanitizePendingInteractionSummary(
+  value: string | null
+): WebReadonlyPendingInteractionSummaryUnavailable | WebReadonlyPendingInteractionSummaryAvailable {
+  const text = sanitizePendingInteractionText(value);
+  if (text.safe && text.text) {
+    return { state: "available", text: text.text };
+  }
+  return {
+    state: "unavailable",
+    reason: text.reason === "unsafe" ? "unsafe_pending_interaction_summary" : "pending_interaction_summary_not_provided"
+  };
+}
+
+function sanitizePendingInteractionText(value: string | null): { safe: boolean; text: string | null; reason: "missing" | "unsafe" | null } {
+  const raw = String(value ?? "").trim();
+  if (!raw) {
+    return { safe: true, text: null, reason: "missing" };
+  }
+  if (containsUnsafePendingValue(raw)) {
+    return { safe: false, text: null, reason: "unsafe" };
+  }
+
+  const stripped = stripTinySafeHtml(raw);
+  if (!stripped) {
+    return { safe: false, text: null, reason: "unsafe" };
+  }
+
+  const text = redactText(decodeBasicHtmlEntities(stripped))
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{4,}/g, "\n\n\n")
+    .trim();
+  if (!text) {
+    return { safe: true, text: null, reason: "missing" };
+  }
+  if (containsUnsafePendingValue(text)) {
+    return { safe: false, text: null, reason: "unsafe" };
+  }
+  return { safe: true, text, reason: null };
+}
+
+function rowContainsRawOnlyPendingData(row: WebReadonlyPendingInteractionInputRow): boolean {
+  return [
+    "promptJson",
+    "responseJson",
+    "replyMarkup",
+    "callback",
+    "callback_data",
+    "messageId",
+    "platformMessageId",
+    "deliveryMessageId",
+    "chatId",
+    "telegramChatId",
+    "feishuChatId",
+    "feishuMessageId",
+    "openId",
+    "open_id",
+    "unionId",
+    "union_id",
+    "userId",
+    "user_id",
+    "rawTerminal",
+    "terminal"
+  ].some((key) => Object.prototype.hasOwnProperty.call(row, key));
+}
+
+function containsUnsafePendingValue(value: string): boolean {
+  return containsUnsafeControlMarkup(value)
+    || /(?:callback|callback_data|replyMarkup|messageId|platformMessageId|deliveryMessageId|chatId|telegramChatId)/i.test(value)
+    || /(?:open_id|union_id|user_id|chat_id|message_id)/i.test(value)
+    || /(?:telegram|feishu|rawTerminal|stdout|stderr)/i.test(value)
+    || /(?:raw\s*terminal|terminal\s*(?:output|snippet))/i.test(value)
+    || /(?:submit|approv\w*|interrupt|upload|switch|resume)/i.test(value);
+}
+
+function firstPrimitiveString(row: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = primitiveString(row[key]);
+    if (value) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function primitiveString(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+}
+
+function capability(key: string, label: string, value: boolean | undefined): WebReadonlyReadinessCapabilityRow {
+  const observed: WebReadonlyObservedState = value === true ? "present" : value === false ? "missing" : "unknown";
+  return {
+    key,
+    label,
+    declared: "present",
+    configured: observed,
+    observed,
+    uxExposed: "missing"
+  };
+}
+
+function hashOpaque(salt: string, value: string): string {
+  return createHash("sha256").update(salt).update("\0").update(value).digest("hex").slice(0, 16);
+}
+
+function safeLabel(value: string | null | undefined, fallback: string): string {
+  const redacted = redactText(String(value ?? "").trim());
+  return redacted.length > 0 ? redacted : fallback;
+}
+
+function safeOptionalLabel(value: string | null | undefined): string | null {
+  const raw = String(value ?? "").trim();
+  if (raw.length === 0 || looksPathLike(raw) || containsUnsafeControlMarkup(raw)) {
+    return null;
+  }
+  const redacted = redactText(raw).trim();
+  if (redacted.length === 0 || redacted.includes("[redacted-path]") || containsUnsafeControlMarkup(redacted)) {
+    return null;
+  }
+  return redacted;
+}
+
+function safeWorkspaceLabel(workspaceId: string, label: string | null | undefined): string {
+  return safeOptionalLabel(label) ?? `Workspace ${workspaceId.slice(3, 11)}`;
+}
+
+function sanitizeFinalAnswerBody(value: string | null | undefined): WebReadonlyAnswerBodyUnavailable | WebReadonlyAnswerBodyAvailable {
+  const raw = String(value ?? "").trim();
+  if (raw.length === 0) {
+    return { state: "unavailable", reason: "sanitized_body_not_provided" };
+  }
+  if (containsUnsafeControlMarkup(raw)) {
+    return { state: "unavailable", reason: "unsafe_final_answer_body" };
+  }
+
+  const stripped = stripTinySafeHtml(raw);
+  if (!stripped) {
+    return { state: "unavailable", reason: "unsafe_final_answer_body" };
+  }
+
+  const decoded = decodeBasicHtmlEntities(stripped);
+  if (containsUnsafeControlMarkup(decoded)) {
+    return { state: "unavailable", reason: "unsafe_final_answer_body" };
+  }
+
+  const text = redactText(decoded)
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{4,}/g, "\n\n\n")
+    .trim();
+  if (text.length === 0) {
+    return { state: "unavailable", reason: "sanitized_body_not_provided" };
+  }
+  if (containsUnsafeControlMarkup(text)) {
+    return { state: "unavailable", reason: "unsafe_final_answer_body" };
+  }
+  return { state: "available", text };
+}
+
+function stripTinySafeHtml(value: string): string | null {
+  let rejected = false;
+  const text = value.replace(/<\/?([A-Za-z][A-Za-z0-9:-]*)(?:\s[^<>]*)?>/g, (match, tagName: string) => {
+    const tag = tagName.toLowerCase();
+    if (!/^(?:<\/?(?:b|strong|i|em|code|pre|p)\s*>|<br\s*\/?>)$/i.test(match)) {
+      rejected = true;
+      return "";
+    }
+    if (tag === "br" || tag === "p") {
+      return "\n";
+    }
+    return "";
+  });
+  return rejected ? null : text;
+}
+
+function decodeBasicHtmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function containsUnsafeControlMarkup(value: string): boolean {
+  return [
+    /<\s*(?:script|style|a|button|form|input|textarea|select)\b/i,
+    /\b(?:callback|callback_data|replyMarkup|messageId|deliveryMessageId|primaryActionConsumed|actionId|platformMessageId)\b/i,
+    /\b(?:submit|approve|interrupt|upload|switch|resume)\b/i,
+    /(?:^|["'(\s])(?:tg|javascript|callback):/i,
+    /\[[^\]]+\]\((?:tg|javascript|callback):[^)]*\)/i
+  ].some((pattern) => pattern.test(value));
+}
+
+function looksPathLike(value: string): boolean {
+  return /(?:^|[\s"'(])(?:\/|~\/|[A-Za-z]:\\)/.test(value);
+}
+
+function redactText(value: string): string {
+  return value
+    .replace(/\/home\/[A-Za-z0-9._-]+(?:\/[^\s"'<>)]*)*/g, "[redacted-path]")
+    .replace(/\/tmp(?:\/[^\s"'<>)]*)*/g, "[redacted-path]")
+    .replace(/\bchatId\b/g, "chat-id")
+    .replace(/\btelegramChatId\b/g, "platform-chat-id")
+    .replace(/\bmessageId\b/g, "message-id")
+    .replace(/\breplyMarkup\b/g, "reply-markup")
+    .replace(/\bpromptJson\b/g, "prompt-json")
+    .replace(/\bresponseJson\b/g, "response-json");
+}
+
+function summarizeIssue(value: string): string | null {
+  const redacted = redactText(value).replace(/\s+at\s+\[redacted-path\].*$/i, "").trim();
+  return redacted.length > 0 ? redacted : null;
+}
+
+function latestIso(left: string | null, right: string | null): string | null {
+  if (!left) {
+    return right;
+  }
+  if (!right) {
+    return left;
+  }
+  return right > left ? right : left;
+}
+
+function compareWorkspaceRows(left: WorkspaceAccumulator, right: WorkspaceAccumulator): number {
+  if (left.pinned !== right.pinned) {
+    return left.pinned ? -1 : 1;
+  }
+  const leftLast = left.lastActivityAt ?? "";
+  const rightLast = right.lastActivityAt ?? "";
+  return rightLast.localeCompare(leftLast) || (left.label ?? "").localeCompare(right.label ?? "");
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function callSafely<T>(fn: (() => T) | undefined, fallback: T, warnings: string[], warning: string): T {
+  if (!fn) {
+    return fallback;
+  }
+  try {
+    return fn();
+  } catch {
+    if (warning) {
+      warnings.push(warning);
+    }
+    return fallback;
+  }
+}

--- a/src/service/web-readonly-view-model.ts
+++ b/src/service/web-readonly-view-model.ts
@@ -367,7 +367,9 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
 
   const buildWorkspaceIndex = (): { state: WebReadonlyAvailability; rows: WorkspaceAccumulator[]; warnings: string[] } => {
     const store = deps.store;
-    if (!store || (!store.listRecentProjects && !store.listSessionProjectStats)) {
+    const chatId = deps.operatorBinding?.chatId;
+    const canListScopedSessions = Boolean(chatId && store?.listSessions);
+    if (!store || (!store.listRecentProjects && !store.listSessionProjectStats && !canListScopedSessions)) {
       return { state: "unavailable", rows: [], warnings: ["workspace_data_unavailable"] };
     }
 
@@ -419,6 +421,46 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
       });
     }
 
+    if (chatId && store.listSessions) {
+      const bySessionPath = new Map<
+        string,
+        { projectName: string; label: string | null; conversationCount: number; lastActivityAt: string | null }
+      >();
+      const sessions = callSafely(
+        () => store.listSessions?.(chatId, { archived: false, limit: 100 }) ?? [],
+        [],
+        warnings,
+        "sessions_unavailable"
+      );
+      for (const session of sessions) {
+        if (session.archived || !session.projectPath) {
+          continue;
+        }
+        const current = bySessionPath.get(session.projectPath) ?? {
+          projectName: session.projectName,
+          label: null,
+          conversationCount: 0,
+          lastActivityAt: null
+        };
+        bySessionPath.set(session.projectPath, {
+          projectName: session.projectName || current.projectName,
+          label: session.projectAlias ?? current.label,
+          conversationCount: current.conversationCount + 1,
+          lastActivityAt: latestIso(current.lastActivityAt, session.lastUsedAt)
+        });
+      }
+
+      for (const [projectPath, stat] of bySessionPath) {
+        upsert(projectPath, stat.projectName, {
+          label: stat.label,
+          projectName: stat.projectName,
+          conversationCount: stat.conversationCount,
+          lastActivityAt: stat.lastActivityAt,
+          source: "sessions"
+        });
+      }
+    }
+
     return {
       state: warnings.length > 0 ? "degraded" : "available",
       rows: Array.from(byPath.values()).sort(compareWorkspaceRows),
@@ -439,7 +481,8 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
     if (!chatId || !deps.store?.listSessions) {
       return null;
     }
-    return callSafely(() => deps.store?.listSessions?.(chatId, { archived: false, limit: 100 }) ?? [], [], warnings, "sessions_unavailable");
+    return callSafely(() => deps.store?.listSessions?.(chatId, { archived: false, limit: 100 }) ?? [], [], warnings, "sessions_unavailable")
+      .filter((session) => !session.archived);
   };
 
   const toWorkspaceRow = (row: WorkspaceAccumulator): WebReadonlyWorkspaceRow => {

--- a/src/service/web-readonly-view-model.ts
+++ b/src/service/web-readonly-view-model.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 export type WebReadonlyAvailability = "available" | "unavailable" | "degraded";
+export type WebReadonlyCatalogState = WebReadonlyAvailability | "empty";
 export type WebReadonlyObservedState = "present" | "missing" | "unknown";
 
 export interface WebReadonlyOperatorBinding {
@@ -101,6 +102,27 @@ export interface WebReadonlyPendingInteractionInputRow {
   [key: string]: unknown;
 }
 
+export interface WebReadonlyArtifactDescriptorInputRow {
+  id?: string | number | null;
+  artifactId?: string | number | null;
+  finalResultId?: string | number | null;
+  label?: string | null;
+  title?: string | null;
+  name?: string | null;
+  filename?: string | null;
+  kind?: string | null;
+  type?: string | null;
+  mediaType?: string | null;
+  mimeType?: string | null;
+  sizeBytes?: string | number | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  availability?: string | null;
+  previewEligible?: boolean | null;
+  downloadEligible?: boolean | null;
+  [key: string]: unknown;
+}
+
 export interface WebReadonlyStoreReader {
   listRecentProjects?: () => WebReadonlyRecentProjectRow[];
   listSessionProjectStats?: () => WebReadonlySessionProjectStatsRow[];
@@ -117,6 +139,7 @@ export interface WebReadonlyViewModelDeps {
   idSalt?: string;
   listActiveTurns?: () => WebReadonlyActiveTurn[] | null | undefined;
   listPendingInteractions?: () => WebReadonlyPendingInteractionInputRow[] | null | undefined;
+  listArtifactDescriptors?: (sessionId: string) => WebReadonlyArtifactDescriptorInputRow[] | null | undefined;
   getReadinessSnapshot?: () => WebReadonlyReadinessSnapshot | null | undefined;
   getSanitizedFinalAnswerBody?: (answer: WebReadonlyFinalAnswerRow) => string | null | undefined;
 }
@@ -204,6 +227,33 @@ export interface WebReadonlyConversationResultViewModel extends WebReadonlyEnvel
   warnings: string[];
 }
 
+export interface WebReadonlyArtifactDescriptorRow {
+  artifactId: string;
+  label: string;
+  kind: string;
+  type: string | null;
+  mediaType: string | null;
+  sizeBytes: number | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  availability: WebReadonlyAvailability;
+  previewEligible: boolean;
+  previewLabel: string;
+  downloadEligible: boolean;
+  downloadLabel: string;
+  warnings: string[];
+}
+
+export interface WebReadonlyConversationArtifactCatalogViewModel extends WebReadonlyEnvelope {
+  pageId: "web_conversation_artifacts";
+  state: WebReadonlyCatalogState;
+  conversationId: string;
+  artifacts: WebReadonlyArtifactDescriptorRow[];
+  selectedArtifact: WebReadonlyArtifactDescriptorRow | null;
+  emptyState: string | null;
+  warnings: string[];
+}
+
 export interface WebReadonlyRuntimeTurnRow {
   sessionId: string;
   status: string;
@@ -284,6 +334,7 @@ export interface WebReadonlyViewModelProvider {
   listWorkspaceViewModels(): WebReadonlyWorkspaceListViewModel;
   listWorkspaceConversationViewModels(workspaceId: string): WebReadonlyWorkspaceConversationListViewModel;
   getConversationResultViewModel(sessionId: string): WebReadonlyConversationResultViewModel;
+  getConversationArtifactCatalogViewModel(sessionId: string, artifactId?: string): WebReadonlyConversationArtifactCatalogViewModel;
   getRuntimeContextViewModel(): WebReadonlyRuntimeContextViewModel;
   getPendingInteractionsViewModel(): WebReadonlyPendingInteractionsViewModel;
   getReadinessGuardrailViewModel(): WebReadonlyReadinessGuardrailViewModel;
@@ -542,6 +593,46 @@ export function createWebReadonlyViewModelProvider(deps: WebReadonlyViewModelDep
       };
     },
 
+    getConversationArtifactCatalogViewModel(sessionId, artifactId) {
+      if (!deps.listArtifactDescriptors) {
+        return unavailableArtifactCatalog(envelope(), sessionId, "artifact_catalog_unavailable");
+      }
+
+      const warnings: string[] = [];
+      const rawRows = callSafely(
+        () => deps.listArtifactDescriptors?.(sessionId) ?? null,
+        null as WebReadonlyArtifactDescriptorInputRow[] | null,
+        warnings,
+        "artifact_catalog_degraded"
+      );
+      if (!rawRows) {
+        return {
+          ...envelope(),
+          pageId: "web_conversation_artifacts",
+          state: warnings.length > 0 ? "degraded" : "unavailable",
+          conversationId: safeArtifactConversationId(sessionId),
+          artifacts: [],
+          selectedArtifact: null,
+          emptyState: null,
+          warnings: unique(warnings.length > 0 ? warnings : ["artifact_catalog_unavailable"])
+        };
+      }
+
+      const artifacts = rawRows.map((row, index) => normalizeArtifactDescriptor(row, index, idSalt));
+      const rowWarnings = artifacts.flatMap((row) => row.warnings);
+      const selectedArtifact = selectArtifactDescriptor(artifacts, artifactId);
+      return {
+        ...envelope(),
+        pageId: "web_conversation_artifacts",
+        state: artifacts.length === 0 ? "empty" : warnings.length > 0 || rowWarnings.length > 0 ? "degraded" : "available",
+        conversationId: safeArtifactConversationId(sessionId),
+        artifacts,
+        selectedArtifact,
+        emptyState: artifacts.length === 0 ? "no_artifacts" : null,
+        warnings: unique([...warnings, ...rowWarnings])
+      };
+    },
+
     getRuntimeContextViewModel() {
       if (!deps.listActiveTurns) {
         return {
@@ -680,6 +771,208 @@ function unavailablePendingInteractions(
     pendingInteractions: [],
     warnings: [warning]
   };
+}
+
+function unavailableArtifactCatalog(
+  envelope: WebReadonlyEnvelope,
+  sessionId: string,
+  warning: string
+): WebReadonlyConversationArtifactCatalogViewModel {
+  return {
+    ...envelope,
+    pageId: "web_conversation_artifacts",
+    state: "unavailable",
+    conversationId: safeArtifactConversationId(sessionId),
+    artifacts: [],
+    selectedArtifact: null,
+    emptyState: null,
+    warnings: [warning]
+  };
+}
+
+function normalizeArtifactDescriptor(
+  row: WebReadonlyArtifactDescriptorInputRow,
+  index: number,
+  idSalt: string
+): WebReadonlyArtifactDescriptorRow {
+  const hasRawOnlyData = rowContainsRawOnlyArtifactData(row);
+  const label = safeArtifactLabel(firstPrimitiveString(row, ["label", "title", "name"]));
+  const kind = safeArtifactKind(firstPrimitiveString(row, ["kind"]), "artifact");
+  const type = safeArtifactMediaType(firstPrimitiveString(row, ["type"]));
+  const mediaType = safeArtifactMediaType(firstPrimitiveString(row, ["mediaType", "mimeType"]));
+  const sizeBytes = safeSizeBytes(row.sizeBytes);
+  const createdAt = safeArtifactTimestamp(firstPrimitiveString(row, ["createdAt"]));
+  const updatedAt = safeArtifactTimestamp(firstPrimitiveString(row, ["updatedAt"]));
+  const warnings = unique([
+    label.safe ? "" : "artifact_descriptor_redacted",
+    kind.safe ? "" : "artifact_descriptor_redacted",
+    type.safe ? "" : "artifact_descriptor_redacted",
+    mediaType.safe ? "" : "artifact_descriptor_redacted",
+    sizeBytes.safe ? "" : "artifact_descriptor_redacted",
+    createdAt.safe ? "" : "artifact_descriptor_redacted",
+    updatedAt.safe ? "" : "artifact_descriptor_redacted",
+    hasRawOnlyData ? "artifact_descriptor_redacted" : ""
+  ]);
+  const degraded = warnings.length > 0;
+  const previewEligible = !degraded && row.previewEligible === true;
+  const downloadEligible = !degraded && row.downloadEligible === true;
+
+  return {
+    artifactId: safeArtifactId(row, index, idSalt),
+    label: label.text,
+    kind: kind.text,
+    type: type.text,
+    mediaType: mediaType.text,
+    sizeBytes: sizeBytes.value,
+    createdAt: createdAt.text,
+    updatedAt: updatedAt.text,
+    availability: degraded ? "degraded" : safeArtifactAvailability(row.availability),
+    previewEligible,
+    previewLabel: previewEligible ? "Preview eligible" : "Preview unavailable",
+    downloadEligible,
+    downloadLabel: downloadEligible ? "Download eligible" : "Download unavailable",
+    warnings
+  };
+}
+
+function selectArtifactDescriptor(
+  artifacts: WebReadonlyArtifactDescriptorRow[],
+  artifactId: string | undefined
+): WebReadonlyArtifactDescriptorRow | null {
+  if (artifacts.length === 0) {
+    return null;
+  }
+  if (artifactId && isSafePublicOpaqueId(artifactId)) {
+    const selected = artifacts.find((artifact) => artifact.artifactId === artifactId);
+    if (selected) {
+      return selected;
+    }
+  }
+  return artifacts.find((artifact) => artifact.availability === "available") ?? artifacts[0] ?? null;
+}
+
+function safeArtifactConversationId(sessionId: string): string {
+  return safePublicEntityId(sessionId) ?? "conversation";
+}
+
+function safeArtifactId(row: WebReadonlyArtifactDescriptorInputRow, index: number, idSalt: string): string {
+  const rawId = firstPrimitiveString(row, ["artifactId", "id", "finalResultId"]);
+  if (rawId && isSafePublicOpaqueId(rawId) && !containsUnsafeArtifactValue(rawId)) {
+    return rawId;
+  }
+
+  const stableKey = [
+    rawId,
+    firstPrimitiveString(row, ["label", "title", "name", "filename"]),
+    firstPrimitiveString(row, ["kind", "type", "mediaType", "mimeType"]),
+    firstPrimitiveString(row, ["createdAt"]),
+    firstPrimitiveString(row, ["updatedAt"]),
+    String(index)
+  ].join("\0");
+  return `art_${hashOpaque(idSalt, stableKey)}`;
+}
+
+function safeArtifactLabel(value: string | null): { safe: boolean; text: string } {
+  const raw = String(value ?? "").trim();
+  if (!raw || looksPathLike(raw) || containsUnsafeArtifactValue(raw)) {
+    return { safe: !raw, text: "Artifact descriptor" };
+  }
+  const stripped = stripTinySafeHtml(raw);
+  if (!stripped) {
+    return { safe: false, text: "Artifact descriptor" };
+  }
+  const text = redactText(decodeBasicHtmlEntities(stripped)).trim();
+  if (!text || looksPathLike(text) || text.includes("[redacted-") || containsUnsafeArtifactValue(text)) {
+    return { safe: false, text: "Artifact descriptor" };
+  }
+  return { safe: true, text };
+}
+
+function safeArtifactKind(value: string | null, fallback: string): { safe: boolean; text: string } {
+  const raw = String(value ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  if (!raw) {
+    return { safe: true, text: fallback };
+  }
+  if (!/^[a-z0-9_.:-]{1,80}$/.test(raw) || looksPathLike(raw) || containsUnsafeArtifactValue(raw)) {
+    return { safe: false, text: fallback };
+  }
+  return { safe: true, text: raw };
+}
+
+function safeArtifactMediaType(value: string | null): { safe: boolean; text: string | null } {
+  const raw = String(value ?? "").trim().toLowerCase();
+  if (!raw) {
+    return { safe: true, text: null };
+  }
+  if (
+    !/^[a-z0-9][a-z0-9.+-]{0,63}\/[a-z0-9][a-z0-9.+-]{0,127}$/.test(raw)
+    || looksPathLike(raw)
+    || containsUnsafeArtifactValue(raw)
+  ) {
+    return { safe: false, text: null };
+  }
+  return { safe: true, text: raw };
+}
+
+function safeArtifactAvailability(value: string | null | undefined): WebReadonlyAvailability {
+  const raw = String(value ?? "").trim().toLowerCase();
+  return raw === "available" || raw === "unavailable" || raw === "degraded" ? raw : "available";
+}
+
+function safeArtifactTimestamp(value: string | null): { safe: boolean; text: string | null } {
+  const raw = String(value ?? "").trim();
+  if (!raw) {
+    return { safe: true, text: null };
+  }
+  if (looksPathLike(raw) || containsUnsafeArtifactValue(raw)) {
+    return { safe: false, text: null };
+  }
+  return { safe: true, text: raw };
+}
+
+function safeSizeBytes(value: unknown): { safe: boolean; value: number | null } {
+  if (value === null || value === undefined || value === "") {
+    return { safe: true, value: null };
+  }
+  const size = typeof value === "number" ? value : typeof value === "string" && /^\d+$/.test(value.trim()) ? Number(value) : NaN;
+  if (!Number.isSafeInteger(size) || size < 0) {
+    return { safe: false, value: null };
+  }
+  return { safe: true, value: size };
+}
+
+function rowContainsRawOnlyArtifactData(row: WebReadonlyArtifactDescriptorInputRow): boolean {
+  return [
+    "path",
+    "filePath",
+    "downloadPath",
+    "previewPath",
+    "url",
+    "uri",
+    "href",
+    "downloadUrl",
+    "previewUrl",
+    "localPath",
+    "tempPath",
+    "platformResourceId",
+    "resourceId",
+    "messageId",
+    "deliveryMessageId",
+    "callback",
+    "callback_data",
+    "chatId",
+    "telegramChatId",
+    "feishuChatId",
+    "threadId",
+    "rawJson",
+    "rawProtocol",
+    "protocol",
+    "terminal",
+    "rawTerminal",
+    "stdout",
+    "stderr",
+    "logs"
+  ].some((key) => Object.prototype.hasOwnProperty.call(row, key));
 }
 
 function normalizePendingInteraction(
@@ -844,6 +1137,17 @@ function containsUnsafePendingValue(value: string): boolean {
     || /(?:submit|approv\w*|interrupt|upload|switch|resume)/i.test(value);
 }
 
+function containsUnsafeArtifactValue(value: string): boolean {
+  return containsUnsafeControlMarkup(value)
+    || looksPathLike(value)
+    || /\b(?:https?|file|tg|javascript|callback):/i.test(value)
+    || /(?:callback|callback_data|replyMarkup|messageId|platformMessageId|deliveryMessageId|chatId|telegramChatId|threadId)/i.test(value)
+    || /(?:open_id|union_id|user_id|chat_id|message_id|thread_id|resource_id)/i.test(value)
+    || /(?:telegram|feishu|platformResourceId|rawProtocol|rawJson|protocol|rawTerminal|stdout|stderr|terminal)/i.test(value)
+    || /(?:submit|approv\w*|interrupt|upload|switch|resume)/i.test(value)
+    || /\b[\w.-]+\.(?:png|jpe?g|gif|webp|pdf|txt|md|log|json|zip|tar|gz|mp4|mov|wav|mp3)\b/i.test(value);
+}
+
 function firstPrimitiveString(row: Record<string, unknown>, keys: string[]): string | null {
   for (const key of keys) {
     const value = primitiveString(row[key]);
@@ -976,6 +1280,7 @@ function looksPathLike(value: string): boolean {
 
 function redactText(value: string): string {
   return value
+    .replace(/\b(?:https?|file):\/\/[^\s"'<>)]*/gi, "[redacted-url]")
     .replace(/\/home\/[A-Za-z0-9._-]+(?:\/[^\s"'<>)]*)*/g, "[redacted-path]")
     .replace(/\/tmp(?:\/[^\s"'<>)]*)*/g, "[redacted-path]")
     .replace(/\bchatId\b/g, "chat-id")

--- a/src/web/readonly-access.ts
+++ b/src/web/readonly-access.ts
@@ -1,0 +1,63 @@
+import type { IncomingHttpHeaders } from "node:http";
+
+export interface ReadonlyAccessGateOptions {
+  enabled?: boolean;
+  token?: string | null;
+}
+
+export interface ReadonlyLocalServerOptions {
+  host: string;
+  port: number;
+  enabled: boolean;
+  token?: string;
+}
+
+export interface ReadonlyAccessGate {
+  readonly enabled: boolean;
+  authorize(headers: IncomingHttpHeaders): boolean;
+}
+
+const DEFAULT_LOCAL_HOST = "127.0.0.1";
+
+export function createReadonlyLocalServerOptions(
+  options: Partial<ReadonlyLocalServerOptions> = {}
+): ReadonlyLocalServerOptions {
+  const result: ReadonlyLocalServerOptions = {
+    host: options.host ?? DEFAULT_LOCAL_HOST,
+    port: options.port ?? 0,
+    enabled: options.enabled ?? false
+  };
+  if (options.token !== undefined) {
+    result.token = options.token;
+  }
+  return result;
+}
+
+export function createReadonlyAccessGate(options: ReadonlyAccessGateOptions = {}): ReadonlyAccessGate {
+  const token = normalizeToken(options.token);
+  const enabled = options.enabled === true && Boolean(token);
+
+  return {
+    enabled,
+    authorize(headers) {
+      if (!enabled || !token) {
+        return false;
+      }
+      return readBearerToken(headers.authorization) === token;
+    }
+  };
+}
+
+function normalizeToken(token: string | null | undefined): string | null {
+  const trimmed = String(token ?? "").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readBearerToken(header: string | string[] | undefined): string | null {
+  const value = Array.isArray(header) ? header[0] : header;
+  if (!value) {
+    return null;
+  }
+  const match = /^Bearer\s+(.+)$/i.exec(value.trim());
+  return match?.[1]?.trim() || null;
+}

--- a/src/web/readonly-cli.test.ts
+++ b/src/web/readonly-cli.test.ts
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createLogger } from "../logger.js";
+import { getBridgePaths } from "../paths.js";
+import {
+  buildWebReadonlyLocalHarnessConfig,
+  startWebReadonlyLocalHarness
+} from "./readonly-cli.js";
+
+const secretToken = "super-secret-local-token";
+
+test("web readonly harness refuses to build without an explicit token", () => {
+  assert.throws(
+    () => buildWebReadonlyLocalHarnessConfig({ env: {} }),
+    /CTB_WEB_READONLY_TOKEN|--token/u
+  );
+});
+
+test("web readonly harness defaults to localhost and accepts env token", () => {
+  const config = buildWebReadonlyLocalHarnessConfig({ env: { CTB_WEB_READONLY_TOKEN: secretToken } });
+
+  assert.equal(config.host, "127.0.0.1");
+  assert.equal(config.port, 0);
+  assert.equal(config.access.enabled, true);
+});
+
+test("web readonly harness rejects non-local host override", () => {
+  assert.throws(
+    () => buildWebReadonlyLocalHarnessConfig({ token: secretToken, host: "0.0.0.0" }),
+    /local-only/u
+  );
+});
+
+test("web readonly harness start output never prints the token", async () => {
+  const homeDir = await mkdtemp(join(tmpdir(), "ctb-web-readonly-home-"));
+  const paths = getBridgePaths(import.meta.url, homeDir);
+  const logger = createLogger("web-readonly-cli-test", paths.bootstrapLogPath);
+  const lines: string[] = [];
+
+  try {
+    const harness = await startWebReadonlyLocalHarness({
+      paths,
+      logger,
+      token: secretToken,
+      port: 0,
+      write: (line) => lines.push(line)
+    });
+    await harness.close();
+
+    const output = lines.join("\n");
+    assert.match(output, /http:\/\/127\.0\.0\.1:\d+\//u);
+    assert.match(output, /read-only prototype/u);
+    assert.match(output, /Bearer token required/u);
+    assert.equal(output.includes(secretToken), false);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});

--- a/src/web/readonly-cli.test.ts
+++ b/src/web/readonly-cli.test.ts
@@ -7,6 +7,9 @@ import { join } from "node:path";
 
 import { createLogger } from "../logger.js";
 import { getBridgePaths } from "../paths.js";
+import { BridgeStateStore } from "../state/store.js";
+import type { BridgePlatform } from "../core/domain/binding.js";
+import type { ChatBindingRow } from "../types.js";
 import {
   buildWebReadonlyLocalHarnessConfig,
   startWebReadonlyLocalHarness
@@ -27,6 +30,47 @@ test("web readonly harness defaults to localhost and accepts env token", () => {
   assert.equal(config.host, "127.0.0.1");
   assert.equal(config.port, 0);
   assert.equal(config.access.enabled, true);
+});
+
+test("web readonly harness accepts env platform filters", () => {
+  for (const platform of ["telegram", "feishu"] as const) {
+    const config = buildWebReadonlyLocalHarnessConfig({
+      env: {
+        CTB_WEB_READONLY_TOKEN: secretToken,
+        CTB_WEB_READONLY_PLATFORM: platform
+      }
+    });
+
+    assert.equal(config.platform, platform);
+  }
+});
+
+test("web readonly harness accepts platform options", () => {
+  for (const platform of ["telegram", "feishu"] as const) {
+    const config = buildWebReadonlyLocalHarnessConfig({ token: secretToken, platform });
+
+    assert.equal(config.platform, platform);
+  }
+});
+
+test("web readonly harness accepts platform argv flags", () => {
+  for (const platform of ["telegram", "feishu"] as const) {
+    const config = buildWebReadonlyLocalHarnessConfig({
+      token: secretToken,
+      argv: ["node", "ctb", "web", "readonly", "--platform", platform]
+    });
+
+    assert.equal(config.platform, platform);
+  }
+});
+
+test("web readonly harness rejects invalid platform filters", () => {
+  for (const platform of ["slack", "Telegram", "", true] as const) {
+    assert.throws(
+      () => buildWebReadonlyLocalHarnessConfig({ token: secretToken, platform }),
+      /CTB_WEB_READONLY_PLATFORM|--platform/u
+    );
+  }
 });
 
 test("web readonly harness rejects non-local host override", () => {
@@ -61,3 +105,86 @@ test("web readonly harness start output never prints the token", async () => {
     await rm(homeDir, { recursive: true, force: true });
   }
 });
+
+test("web readonly harness start filters operator bindings by configured platform without printing secrets", async () => {
+  for (const platform of ["telegram", "feishu"] as const) {
+    const homeDir = await mkdtemp(join(tmpdir(), `ctb-web-readonly-${platform}-home-`));
+    const paths = getBridgePaths(import.meta.url, homeDir);
+    const logger = createLogger("web-readonly-cli-test", paths.bootstrapLogPath);
+    const lines: string[] = [];
+    const calls: Array<{ argc: number; platform: BridgePlatform | undefined }> = [];
+    const original = BridgeStateStore.prototype.listChatBindings;
+    BridgeStateStore.prototype.listChatBindings = function patchedListChatBindings(
+      this: BridgeStateStore,
+      platformArg?: BridgePlatform
+    ): ChatBindingRow[] {
+      calls.push({ argc: arguments.length, platform: platformArg });
+      return [bindingRow("chat-secret", platformArg ?? platform)];
+    };
+
+    try {
+      const harness = await startWebReadonlyLocalHarness({
+        paths,
+        logger,
+        token: secretToken,
+        port: 0,
+        ...(platform === "telegram" ? { platform } : { argv: ["node", "ctb", "web", "readonly", "--platform", platform] }),
+        write: (line) => lines.push(line)
+      });
+      await harness.close();
+
+      assert.deepEqual(calls, [{ argc: 1, platform }]);
+      const output = lines.join("\n");
+      assert.match(output, /http:\/\/127\.0\.0\.1:\d+\//u);
+      assert.equal(output.includes(secretToken), false);
+      assert.equal(output.includes("chat-secret"), false);
+    } finally {
+      BridgeStateStore.prototype.listChatBindings = original;
+      await rm(homeDir, { recursive: true, force: true });
+    }
+  }
+});
+
+test("web readonly harness start uses unfiltered binding resolution by default", async () => {
+  const homeDir = await mkdtemp(join(tmpdir(), "ctb-web-readonly-unfiltered-home-"));
+  const paths = getBridgePaths(import.meta.url, homeDir);
+  const logger = createLogger("web-readonly-cli-test", paths.bootstrapLogPath);
+  const calls: Array<{ argc: number; platform: BridgePlatform | undefined }> = [];
+  const original = BridgeStateStore.prototype.listChatBindings;
+  BridgeStateStore.prototype.listChatBindings = function patchedListChatBindings(
+    this: BridgeStateStore,
+    platformArg?: BridgePlatform
+  ): ChatBindingRow[] {
+    calls.push({ argc: arguments.length, platform: platformArg });
+    return [];
+  };
+
+  try {
+    const harness = await startWebReadonlyLocalHarness({
+      paths,
+      logger,
+      token: secretToken,
+      port: 0,
+      write: () => undefined
+    });
+    await harness.close();
+
+    assert.deepEqual(calls, [{ argc: 0, platform: undefined }]);
+  } finally {
+    BridgeStateStore.prototype.listChatBindings = original;
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
+function bindingRow(chatId: string, platform: BridgePlatform): ChatBindingRow {
+  return {
+    platform,
+    chatId,
+    userId: `${platform}-user-secret`,
+    telegramChatId: chatId,
+    telegramUserId: `${platform}-user-secret`,
+    activeSessionId: null,
+    createdAt: "2026-04-26T00:00:00.000Z",
+    updatedAt: "2026-04-26T00:00:00.000Z"
+  };
+}

--- a/src/web/readonly-cli.ts
+++ b/src/web/readonly-cli.ts
@@ -5,6 +5,7 @@ import { dirname } from "node:path";
 
 import type { Logger } from "../logger.js";
 import type { BridgePaths } from "../paths.js";
+import type { BridgePlatform } from "../core/domain/binding.js";
 import { createWebReadonlyLiveProvider } from "../service/web-readonly-live-provider.js";
 import type {
   WebReadonlyPendingInteractionInputRow,
@@ -18,18 +19,24 @@ import { createReadonlyHttpServer } from "./readonly-http-server.js";
 const DEFAULT_WEB_READONLY_HOST = "127.0.0.1";
 const DEFAULT_WEB_READONLY_PORT = 0;
 const TOKEN_ENV_NAME = "CTB_WEB_READONLY_TOKEN";
+const PLATFORM_ENV_NAME = "CTB_WEB_READONLY_PLATFORM";
+
+export type WebReadonlyLocalHarnessPlatform = Extract<BridgePlatform, "telegram" | "feishu">;
 
 export interface WebReadonlyLocalHarnessConfigInput {
   token?: string | boolean | undefined;
   env?: NodeJS.ProcessEnv | undefined;
   host?: string | boolean | undefined;
   port?: string | number | boolean | undefined;
+  platform?: string | boolean | undefined;
+  argv?: readonly string[] | undefined;
 }
 
 export interface WebReadonlyLocalHarnessConfig {
   host: string;
   port: number;
   token: string;
+  platform: WebReadonlyLocalHarnessPlatform | undefined;
   access: ReadonlyAccessGate;
 }
 
@@ -50,14 +57,18 @@ export function buildWebReadonlyLocalHarnessConfig(
 ): WebReadonlyLocalHarnessConfig {
   const host = normalizeHost(input.host);
   const token = normalizeToken(typeof input.token === "string" ? input.token : input.env?.[TOKEN_ENV_NAME]);
+  const platformInput = input.platform ?? parsePlatformArg(input.argv ?? []) ?? input.env?.[PLATFORM_ENV_NAME];
   if (!token) {
     throw new Error(`${TOKEN_ENV_NAME} or --token is required for the local read-only prototype harness`);
   }
+
+  const platform = normalizePlatform(platformInput);
 
   return {
     host,
     port: normalizePort(input.port),
     token,
+    platform,
     access: createReadonlyAccessGate({ enabled: true, token })
   };
 }
@@ -65,12 +76,18 @@ export function buildWebReadonlyLocalHarnessConfig(
 export async function startWebReadonlyLocalHarness(
   options: WebReadonlyLocalHarnessStartOptions
 ): Promise<WebReadonlyLocalHarnessHandle> {
-  const config = buildWebReadonlyLocalHarnessConfig(options);
+  const config = buildWebReadonlyLocalHarnessConfig({
+    ...options,
+    argv: options.argv ?? process.argv
+  });
   await mkdir(dirname(options.paths.dbPath), { recursive: true });
   const store = await BridgeStateStore.open(options.paths, options.logger);
   const provider = createWebReadonlyLiveProvider({
     auth: {
-      listOperatorBindings: () => store.listChatBindings().map((binding) => ({ chatId: binding.chatId }))
+      listOperatorBindings: () => {
+        const bindings = config.platform ? store.listChatBindings(config.platform) : store.listChatBindings();
+        return bindings.map((binding) => ({ chatId: binding.chatId }));
+      }
     },
     store: {
       listRecentProjects: () => store.listRecentProjects(),
@@ -131,6 +148,31 @@ function normalizePort(port: string | number | boolean | undefined): number {
 function normalizeToken(token: string | undefined): string | null {
   const trimmed = token?.trim() ?? "";
   return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizePlatform(platform: string | boolean | undefined): WebReadonlyLocalHarnessPlatform | undefined {
+  if (platform === undefined || platform === false) {
+    return undefined;
+  }
+  const value = typeof platform === "string" ? platform.trim() : "";
+  if (value === "telegram" || value === "feishu") {
+    return value;
+  }
+  throw new Error(`${PLATFORM_ENV_NAME} or --platform must be either "telegram" or "feishu"`);
+}
+
+function parsePlatformArg(argv: readonly string[]): string | boolean | undefined {
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--platform") {
+      const next = argv[index + 1];
+      return next && !next.startsWith("--") ? next : true;
+    }
+    if (token?.startsWith("--platform=")) {
+      return token.slice("--platform=".length);
+    }
+  }
+  return undefined;
 }
 
 function toReadonlyReadinessSnapshot(snapshot: ReadinessSnapshot | null): WebReadonlyReadinessSnapshot | null {

--- a/src/web/readonly-cli.ts
+++ b/src/web/readonly-cli.ts
@@ -1,0 +1,167 @@
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { Logger } from "../logger.js";
+import type { BridgePaths } from "../paths.js";
+import { createWebReadonlyLiveProvider } from "../service/web-readonly-live-provider.js";
+import type {
+  WebReadonlyPendingInteractionInputRow,
+  WebReadonlyReadinessSnapshot
+} from "../service/web-readonly-view-model.js";
+import { BridgeStateStore } from "../state/store.js";
+import type { PendingInteractionRow, ReadinessSnapshot } from "../types.js";
+import { createReadonlyAccessGate, type ReadonlyAccessGate } from "./readonly-access.js";
+import { createReadonlyHttpServer } from "./readonly-http-server.js";
+
+const DEFAULT_WEB_READONLY_HOST = "127.0.0.1";
+const DEFAULT_WEB_READONLY_PORT = 0;
+const TOKEN_ENV_NAME = "CTB_WEB_READONLY_TOKEN";
+
+export interface WebReadonlyLocalHarnessConfigInput {
+  token?: string | boolean | undefined;
+  env?: NodeJS.ProcessEnv | undefined;
+  host?: string | boolean | undefined;
+  port?: string | number | boolean | undefined;
+}
+
+export interface WebReadonlyLocalHarnessConfig {
+  host: string;
+  port: number;
+  token: string;
+  access: ReadonlyAccessGate;
+}
+
+export interface WebReadonlyLocalHarnessStartOptions extends WebReadonlyLocalHarnessConfigInput {
+  paths: BridgePaths;
+  logger: Logger;
+  write?: (line: string) => void;
+}
+
+export interface WebReadonlyLocalHarnessHandle {
+  url: string;
+  server: Server;
+  close: () => Promise<void>;
+}
+
+export function buildWebReadonlyLocalHarnessConfig(
+  input: WebReadonlyLocalHarnessConfigInput = {}
+): WebReadonlyLocalHarnessConfig {
+  const host = normalizeHost(input.host);
+  const token = normalizeToken(typeof input.token === "string" ? input.token : input.env?.[TOKEN_ENV_NAME]);
+  if (!token) {
+    throw new Error(`${TOKEN_ENV_NAME} or --token is required for the local read-only prototype harness`);
+  }
+
+  return {
+    host,
+    port: normalizePort(input.port),
+    token,
+    access: createReadonlyAccessGate({ enabled: true, token })
+  };
+}
+
+export async function startWebReadonlyLocalHarness(
+  options: WebReadonlyLocalHarnessStartOptions
+): Promise<WebReadonlyLocalHarnessHandle> {
+  const config = buildWebReadonlyLocalHarnessConfig(options);
+  await mkdir(dirname(options.paths.dbPath), { recursive: true });
+  const store = await BridgeStateStore.open(options.paths, options.logger);
+  const provider = createWebReadonlyLiveProvider({
+    auth: {
+      listOperatorBindings: () => store.listChatBindings().map((binding) => ({ chatId: binding.chatId }))
+    },
+    store: {
+      listRecentProjects: () => store.listRecentProjects(),
+      listSessionProjectStats: () => store.listSessionProjectStats(),
+      listSessions: (chatId, listOptions) => store.listSessions(chatId, listOptions),
+      getSessionById: (sessionId) => store.getSessionById(sessionId),
+      listFinalAnswerViews: (chatId) => store.listFinalAnswerViews(chatId),
+      getReadinessSnapshot: () => toReadonlyReadinessSnapshot(store.getReadinessSnapshot()),
+      listPendingInteractions: (chatId) => toReadonlyPendingInteractions(store.listPendingInteractionsByChat(chatId))
+    }
+  });
+  const server = createReadonlyHttpServer({ provider, access: config.access });
+
+  try {
+    await listen(server, config.port, config.host);
+  } catch (error) {
+    store.close();
+    throw error;
+  }
+
+  const address = server.address() as AddressInfo;
+  const url = `http://${config.host}:${address.port}/`;
+  const write = options.write ?? ((line: string) => process.stdout.write(`${line}\n`));
+  write(`ctb web readonly local read-only prototype listening at ${url}`);
+  write("Bearer token required. Local-only prototype; do not expose or treat as supported Web service.");
+
+  return {
+    url,
+    server,
+    close: async () => {
+      await closeServer(server);
+      store.close();
+    }
+  };
+}
+
+function normalizeHost(host: string | boolean | undefined): string {
+  if (host === undefined || host === false) {
+    return DEFAULT_WEB_READONLY_HOST;
+  }
+  if (host === DEFAULT_WEB_READONLY_HOST || host === "localhost") {
+    return host;
+  }
+  throw new Error("ctb web readonly is local-only; external host binding is not supported");
+}
+
+function normalizePort(port: string | number | boolean | undefined): number {
+  if (port === undefined || port === false) {
+    return DEFAULT_WEB_READONLY_PORT;
+  }
+  const value = typeof port === "number" ? port : typeof port === "string" ? Number.parseInt(port, 10) : NaN;
+  if (!Number.isInteger(value) || value < 0 || value > 65535 || String(port).trim() !== String(value)) {
+    throw new Error("invalid --port value; expected an integer from 0 to 65535");
+  }
+  return value;
+}
+
+function normalizeToken(token: string | undefined): string | null {
+  const trimmed = token?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function toReadonlyReadinessSnapshot(snapshot: ReadinessSnapshot | null): WebReadonlyReadinessSnapshot | null {
+  return snapshot ? { ...snapshot, details: { ...snapshot.details } } : null;
+}
+
+function toReadonlyPendingInteractions(rows: PendingInteractionRow[]): WebReadonlyPendingInteractionInputRow[] {
+  return rows.map((row) => ({ ...row }));
+}
+
+async function listen(server: Server, port: number, host: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, host);
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+  });
+}

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -6,6 +6,7 @@ import type { AddressInfo } from "node:net";
 import { createReadonlyAccessGate } from "./readonly-access.js";
 import { createReadonlyHttpServer } from "./readonly-http-server.js";
 import type {
+  WebReadonlyConversationRow,
   WebReadonlyConversationResultViewModel,
   WebReadonlyViewModelProvider
 } from "../service/web-readonly-view-model.js";
@@ -16,6 +17,8 @@ function makeProvider(
   calls: string[],
   options: {
     throwOnHome?: boolean;
+    homeConversations?: WebReadonlyConversationRow[];
+    workspaceConversations?: WebReadonlyConversationRow[];
     detailAnswers?: WebReadonlyConversationResultViewModel["answers"];
   } = {}
 ): WebReadonlyViewModelProvider {
@@ -44,7 +47,7 @@ function makeProvider(
             source: "recent"
           }
         ],
-        recentConversations: [
+        recentConversations: options.homeConversations ?? [
           {
             conversationId: "cv_1234567890abcdef",
             conversationHandle: "cv_1234567890abcdef",
@@ -95,7 +98,7 @@ function makeProvider(
         pageId: "web_workspace_conversations",
         state: "available",
         workspaceId,
-        conversations: [
+        conversations: options.workspaceConversations ?? [
           {
             conversationId: "cv_1234567890abcdef",
             conversationHandle: "cv_1234567890abcdef",
@@ -386,6 +389,80 @@ test("authenticated conversation detail explains rejected final-answer body sour
   });
 });
 
+test("home recent conversations use user-language state groups and copy", async () => {
+  const calls: string[] = [];
+  const rows: WebReadonlyConversationRow[] = [
+    conversationFixture("cv_aaaaaaaaaaaaaaaa", "Answer product question", "pending_question", false),
+    conversationFixture("cv_bbbbbbbbbbbbbbbb", "Approve safe change", "pending_approval", false),
+    conversationFixture("cv_cccccccccccccccc", "Blocked on owner input", "blocked", false),
+    conversationFixture("cv_dddddddddddddddd", "Run implementation", "running", false),
+    conversationFixture("cv_eeeeeeeeeeeeeeee", "Finished slice", "completed", true),
+    conversationFixture("cv_ffffffffffffffff", "Failed check", "failed", false),
+    conversationFixture("cv_1111111111111111", "Partial state", "degraded", false),
+    conversationFixture("cv_2222222222222222", "Unknown state", "source_unknown", false)
+  ];
+
+  await withServer({
+    provider: makeProvider(calls, { homeConversations: rows }),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["home"]);
+    for (const heading of ["Needs attention", "Running now", "Recently completed", "Other/Older"]) {
+      assert.match(result.text, new RegExp(`<h3>${heading}</h3>`), `missing grouped heading ${heading}: ${result.text}`);
+    }
+    for (const label of ["Needs answer", "Approval needed", "Blocked", "Running", "Done", "Failed", "Degraded", "Unavailable"]) {
+      assert.match(result.text, new RegExp(`class="console-badge">${label}</span>`), `missing label ${label}: ${result.text}`);
+    }
+    for (const copy of [
+      "Codex asked a question; the answer lane is read-only until enabled.",
+      "Codex requested an approval; the approval lane is read-only until enabled.",
+      "Progress is stopped until required owner interaction is resolved.",
+      "Codex is working; result will appear here when complete.",
+      "Completion metadata or a final result is available.",
+      "The task ended without a usable final result in this preview.",
+      "State is partial, stale, or missing a safe source.",
+      "The current state is unavailable or unknown from the safe reader."
+    ]) {
+      assert.match(result.text, new RegExp(escapeRegExp(copy)), `missing copy ${copy}: ${result.text}`);
+    }
+    for (const raw of ["pending_question", "pending_approval", "source_unknown"]) {
+      assert.equal(result.text.includes(raw), false, `raw state leaked ${raw}: ${result.text}`);
+    }
+  });
+});
+
+test("workspace conversation list groups mixed states without exposing raw state enums", async () => {
+  const calls: string[] = [];
+  const rows: WebReadonlyConversationRow[] = [
+    conversationFixture("cv_aaaaaaaaaaaaaaaa", "Needs approval", "pending_approval", false),
+    conversationFixture("cv_bbbbbbbbbbbbbbbb", "Running task", "running", false),
+    conversationFixture("cv_cccccccccccccccc", "Completed task", "done", true),
+    conversationFixture("cv_dddddddddddddddd", "Unknown task", "state_unknown", false)
+  ];
+
+  await withServer({
+    provider: makeProvider(calls, { workspaceConversations: rows }),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/workspaces/wk_safe_1/conversations`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["workspace:wk_safe_1"]);
+    for (const heading of ["Needs attention", "Running now", "Recently completed", "Other/Older"]) {
+      assert.match(result.text, new RegExp(`<h3>${heading}</h3>`), `missing grouped heading ${heading}: ${result.text}`);
+    }
+    assert.match(result.text, /Approval needed/);
+    assert.match(result.text, /Running/);
+    assert.match(result.text, /Done/);
+    assert.match(result.text, /Unavailable/);
+    assert.match(result.text, /The current state is unavailable or unknown from the safe reader\./);
+    for (const raw of ["pending_approval", "state_unknown"]) {
+      assert.equal(result.text.includes(raw), false, `raw state leaked ${raw}: ${result.text}`);
+    }
+  });
+});
+
 test("raw session and unsafe conversation route parts are generic 404s", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
@@ -406,6 +483,31 @@ test("raw session and unsafe conversation route parts are generic 404s", async (
     assert.deepEqual(calls, []);
   });
 });
+
+function conversationFixture(
+  handle: string,
+  title: string,
+  status: string,
+  finalAnswerAvailable: boolean
+): WebReadonlyConversationRow {
+  return {
+    conversationId: handle,
+    conversationHandle: handle,
+    workspaceId: "wk_safe_1",
+    title,
+    status,
+    failureReason: null,
+    archived: false,
+    createdAt: "2026-04-25T10:00:00.000Z",
+    lastActivityAt: "2026-04-25T12:00:00.000Z",
+    lastTurnStatus: status,
+    finalAnswerAvailable
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 test("state responses include no-store, CSP, nosniff, and HTML charset headers", async () => {
   const calls: string[] = [];

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -89,6 +89,7 @@ function makeProvider(
           pendingInteractions: options.homePendingInteractions ?? []
         },
         readiness: { state: "ready", missingGates: [] },
+        composer: disabledComposerFixture(),
         warnings: []
       };
     },
@@ -159,6 +160,7 @@ function makeProvider(
           pendingInteractions: options.detailPendingInteractions ?? []
         },
         readiness: { state: "ready", missingGates: [] },
+        composer: disabledComposerFixture(),
         warnings: []
       };
     },
@@ -283,6 +285,21 @@ test("authenticated state route invokes only expected provider method", async ()
   });
 });
 
+test("chat alias renders the same read-only chat home", async () => {
+  const calls: string[] = [];
+  await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
+    const root = await get(`${baseUrl}/`, token);
+    const alias = await get(`${baseUrl}/chat`, token);
+    assert.equal(root.status, 200);
+    assert.equal(alias.status, 200);
+    assert.deepEqual(calls, ["home", "home"]);
+    for (const copy of ["Web Chat", "Conversation work queue", "Sending from Web is landing next"]) {
+      assert.match(alias.text, new RegExp(escapeRegExp(copy)), `missing alias copy ${copy}: ${alias.text}`);
+    }
+    assert.equal(alias.text, root.text);
+  });
+});
+
 test("runtime page renders owner-language runtime settings panels without action controls or internals", async () => {
   const calls: string[] = [];
   await withServer({
@@ -398,12 +415,12 @@ test("authenticated HTML escapes hostile strings and emits no raw script/action/
     assert.deepEqual(calls, ["home"]);
     assert.match(result.text, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
     assert.match(result.text, /Codex Console/);
-    assert.match(result.text, /Personal workspace/);
-    assert.match(result.text, /View-only preview/);
+    assert.match(result.text, /Web Chat/);
+    assert.match(result.text, /Chat-first, view-only preview/);
     assert.match(result.text, /<header class="console-shell__header">/);
     assert.match(result.text, /<nav class="console-shell__nav" aria-label="Console navigation">/);
     for (const [href, label] of [
-      ["/", "Home"],
+      ["/", "Chat"],
       ["/workspaces", "Workspaces"],
       ["/interactions", "Pending"],
       ["/runtime", "Runtime"],
@@ -412,8 +429,10 @@ test("authenticated HTML escapes hostile strings and emits no raw script/action/
       assert.match(result.text, new RegExp(`<a[^>]*href="${href.replace("/", "\\/")}"[^>]*>${label}</a>`), `missing nav link ${href}: ${result.text}`);
     }
     assert.match(result.text, /class="console-card"/);
-    assert.match(result.text, /Recent results/);
-    assert.match(result.text, /Active \/ needs attention/);
+    assert.match(result.text, /Conversation work queue/);
+    assert.match(result.text, /Selected thread preview/);
+    assert.match(result.text, /Recent results and artifacts/);
+    assert.match(result.text, /Runtime summary/);
     assert.equal(result.text.includes("<table"), false, `home should use card/list shell, not primary tables: ${result.text}`);
     assert.equal(result.text.includes("<script>"), false);
     assert.equal(result.text.includes("<img"), false);
@@ -425,32 +444,35 @@ test("authenticated HTML escapes hostile strings and emits no raw script/action/
     assert.match(result.text, /href="\/workspaces\/wk_safe_1\/conversations"/);
     assert.match(result.text, /href="\/conversations\/cv_1234567890abcdef"/);
     assert.equal(result.text.includes("/sessions/"), false);
-    for (const forbidden of ["<form", "<button", "<input", "onclick", "download=", "?token", "href=\"#", "submit", "approve", "interrupt", "upload", "switch", "resume"]) {
+    for (const forbidden of ["<form", "<button", "<input", "<textarea", "method=\"post\"", "action=", "onclick", "download=", "?token", "href=\"#", "submit", "approve", "interrupt", "upload", "switch", "resume"]) {
       assert.equal(result.text.toLowerCase().includes(forbidden), false, `rendered forbidden content ${forbidden}: ${result.text}`);
     }
   });
 });
 
-test("home renders a product dashboard with personal workflow sections", async () => {
+test("home renders a chat-first work queue with disabled composer posture", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
     assert.deepEqual(calls, ["home"]);
-    assert.match(result.text, /<h2 id="page-heading">Codex Console<\/h2>/);
-    assert.match(result.text, /Your personal console for continuing Codex work, reviewing results, and browsing projects\./);
+    assert.match(result.text, /<h2 id="page-heading">Web Chat<\/h2>/);
+    assert.match(result.text, /Conversation work queue for Codex Bridge\./);
+    assert.match(result.text, /Sending from Web is landing next/);
+    assert.match(result.text, /role="textbox" aria-readonly="true" aria-disabled="true"/);
     for (const heading of [
-      "Continue working",
-      "Active / needs attention",
-      "Recent results",
-      "Projects / workspaces"
+      "Conversation work queue",
+      "Selected thread preview",
+      "Runtime summary",
+      "Recent results and artifacts",
+      "Projects / workspaces",
+      "Secondary utilities"
     ]) {
-      assert.match(result.text, new RegExp(`<h2[^>]*>${escapeRegExp(heading)}</h2>`), `missing dashboard section ${heading}: ${result.text}`);
+      assert.match(result.text, new RegExp(`<h2[^>]*>${escapeRegExp(heading)}</h2>`), `missing chat-first section ${heading}: ${result.text}`);
     }
-    assert.match(result.text, /View-only preview/);
-    assert.match(result.text, /Open/);
+    assert.match(result.text, /Open durable thread/);
     assert.equal(result.text.includes("Current state"), false, `home should not be centered on status metrics: ${result.text}`);
-    assert.equal(result.text.includes("Settings / access posture"), false, `home should keep access posture off the landing dashboard: ${result.text}`);
+    assert.equal(result.text.includes("Settings / access posture"), false, `home should keep access posture off the landing chat: ${result.text}`);
   });
 });
 
@@ -476,6 +498,8 @@ test("home empty state is friendly product copy, not degraded/security copy", as
     assert.equal(result.status, 200);
     assert.deepEqual(calls, ["home"]);
     for (const copy of [
+      "No conversation threads are visible yet.",
+      "No thread selected",
       "No active work needs attention right now.",
       "Recent results will appear here after Codex finishes work.",
       "Projects and workspaces will appear here once the bridge has recent workspace history."
@@ -541,10 +565,12 @@ test("authenticated conversation detail route uses only opaque handles and keeps
     const result = await get(`${baseUrl}/conversations/cv_1234567890abcdef`, token);
     assert.equal(result.status, 200);
     assert.deepEqual(calls, ["conversation:cv_1234567890abcdef"]);
-    assert.match(result.text, /Task page/);
+    assert.match(result.text, /Conversation thread/);
     assert.match(result.text, /<h2 id="detail-heading">Readonly detail<\/h2>/);
     assert.match(result.text, /Last updated/);
-    assert.match(result.text, /View-only preview/);
+    assert.match(result.text, /Read-only thread/);
+    assert.match(result.text, /Sending from Web is landing next/);
+    assert.match(result.text, /role="textbox" aria-readonly="true" aria-disabled="true"/);
     assert.match(result.text, /<section class="console-panel console-result" aria-labelledby="result-heading">/);
     assert.match(result.text, /Result/);
     assert.match(result.text, /No Web-ready final answer has been captured yet\. When Codex finishes with a shareable result, it will appear in this panel\./);
@@ -555,7 +581,7 @@ test("authenticated conversation detail route uses only opaque handles and keeps
     assert.match(result.text, /Readonly detail/);
     assert.equal(result.text.includes("/sessions/"), false);
     assert.equal(result.text.includes("session-1"), false);
-    for (const forbidden of [token, "/home/ubuntu/secret", "callback_data", "messageId", "<form", "<button", "<input", "onclick", "download=", "?token", "href=\"#"]) {
+    for (const forbidden of [token, "/home/ubuntu/secret", "callback_data", "messageId", "<form", "<button", "<input", "<textarea", "method=\"post\"", "action=", "onclick", "download=", "?token", "href=\"#"]) {
       assert.equal(result.text.includes(forbidden), false, `detail leaked ${forbidden}: ${result.text}`);
     }
     assert.equal(result.headers.get("cache-control"), "no-store");
@@ -690,6 +716,21 @@ test("conversation detail pending panel shares read-only pending cards and actio
     assert.match(result.text, /Responses are not enabled in this preview\./);
     assertPendingSurfaceHasNoActionsOrInternals(result.text);
     assert.equal(result.text.includes("pi_detail_question"), false, `raw pending id leaked: ${result.text}`);
+  });
+});
+
+test("phase B pages expose disabled composer posture without enabled write controls", async () => {
+  const calls: string[] = [];
+  await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
+    for (const path of ["/", "/chat", "/conversations/cv_1234567890abcdef"]) {
+      const result = await get(`${baseUrl}${path}`, token);
+      assert.equal(result.status, 200, path);
+      assert.match(result.text, /Sending from Web is landing next/);
+      assert.match(result.text, /aria-readonly="true" aria-disabled="true"/);
+      for (const forbidden of ["<form", "<button", "<input", "<textarea", "method=\"post\"", "action=", "/messages"]) {
+        assert.equal(result.text.toLowerCase().includes(forbidden), false, `${path} exposed write control ${forbidden}: ${result.text}`);
+      }
+    }
   });
 });
 
@@ -834,13 +875,25 @@ function pendingInteractionFixture(
   };
 }
 
+function disabledComposerFixture() {
+  return {
+    state: "disabled" as const,
+    label: "Message Codex",
+    placeholder: "Type a message to Codex",
+    disabledReason: "Sending from Web is landing next.",
+    capability: "web_send_landing_next" as const
+  };
+}
+
 function assertPendingSurfaceHasNoActionsOrInternals(html: string): void {
   const lower = html.toLowerCase();
   for (const forbidden of [
     "<form",
     "<button",
     "<input",
+    "<textarea",
     "method=\"post\"",
+    "action=",
     "form-action",
     "onclick",
     "callback_data",
@@ -870,6 +923,7 @@ function assertWebPanelHasNoActionsOrInternals(html: string): void {
     "<form",
     "<button",
     "<input",
+    "<textarea",
     "method=\"post\"",
     "action=",
     "onclick",

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -1,0 +1,275 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { AddressInfo } from "node:net";
+
+import { createReadonlyAccessGate } from "./readonly-access.js";
+import { createReadonlyHttpServer } from "./readonly-http-server.js";
+import type { WebReadonlyViewModelProvider } from "../service/web-readonly-view-model.js";
+
+const token = "local-test-token";
+
+function makeProvider(calls: string[], options: { throwOnHome?: boolean } = {}): WebReadonlyViewModelProvider {
+  return {
+    getHomeViewModel() {
+      calls.push("home");
+      if (options.throwOnHome) {
+        throw new Error("boom stack secret /tmp/secret-store messageId=123");
+      }
+      return {
+        generatedAt: "2026-04-26T00:00:00.000Z",
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_home",
+        state: "available",
+        operator: { binding: "available" },
+        workspaces: [
+          {
+            workspaceId: "wk_safe_1",
+            label: "<script>alert('x')</script> Console /home/ubuntu/secret token=abc callback_data=approve messageId=5",
+            availability: "available",
+            conversationCount: 1,
+            pinned: true,
+            lastActivityAt: "2026-04-25T12:00:00.000Z",
+            lastSuccessAt: null,
+            source: "recent"
+          }
+        ],
+        recentConversations: [
+          {
+            conversationId: "session-1",
+            workspaceId: "wk_safe_1",
+            title: "Need <b>escape</b> & no submit approve interrupt upload switch resume",
+            status: "running",
+            failureReason: null,
+            archived: false,
+            createdAt: "2026-04-25T10:00:00.000Z",
+            lastActivityAt: "2026-04-25T12:00:00.000Z",
+            lastTurnStatus: "running",
+            finalAnswerAvailable: true
+          }
+        ],
+        runtime: {
+          state: "available",
+          activeTurns: [
+            {
+              sessionId: "session-1",
+              status: "running",
+              summary: "safe <img src=x onerror=alert(1)>",
+              blockedReason: null
+            }
+          ]
+        },
+        readiness: { state: "ready", missingGates: [] },
+        warnings: []
+      };
+    },
+    listWorkspaceViewModels() {
+      calls.push("workspaces");
+      return {
+        generatedAt: "2026-04-26T00:00:00.000Z",
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_workspaces",
+        state: "available",
+        workspaces: [],
+        warnings: []
+      };
+    },
+    listWorkspaceConversationViewModels(workspaceId: string) {
+      calls.push(`workspace:${workspaceId}`);
+      return {
+        generatedAt: "2026-04-26T00:00:00.000Z",
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_workspace_conversations",
+        state: "available",
+        workspaceId,
+        conversations: [],
+        emptyState: "no_conversations",
+        warnings: []
+      };
+    },
+    getConversationResultViewModel(sessionId: string) {
+      calls.push(`session:${sessionId}`);
+      return {
+        generatedAt: "2026-04-26T00:00:00.000Z",
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_conversation_result",
+        state: "available",
+        conversation: null,
+        answers: [],
+        warnings: []
+      };
+    },
+    getConversationArtifactCatalogViewModel(sessionId: string) {
+      calls.push(`artifacts:${sessionId}`);
+      return {
+        generatedAt: "2026-04-26T00:00:00.000Z",
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_conversation_artifacts",
+        state: "empty",
+        conversationId: sessionId,
+        artifacts: [],
+        selectedArtifact: null,
+        emptyState: "no_artifacts",
+        warnings: []
+      };
+    },
+    getRuntimeContextViewModel() {
+      calls.push("runtime");
+      return {
+        generatedAt: "2026-04-26T00:00:00.000Z",
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_runtime_context",
+        state: "available",
+        activeTurns: [],
+        warnings: []
+      };
+    },
+    getPendingInteractionsViewModel() {
+      calls.push("interactions");
+      return {
+        generatedAt: "2026-04-26T00:00:00.000Z",
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_pending_interactions",
+        state: "available",
+        pendingInteractions: [],
+        warnings: []
+      };
+    },
+    getReadinessGuardrailViewModel() {
+      calls.push("readiness");
+      return {
+        generatedAt: "2026-04-26T00:00:00.000Z",
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_readiness_guardrails",
+        state: "ready",
+        checkedAt: "2026-04-26T00:00:00.000Z",
+        activePack: null,
+        capabilities: [],
+        missingGates: [],
+        warnings: []
+      };
+    }
+  };
+}
+
+async function withServer<T>(
+  options: Parameters<typeof createReadonlyHttpServer>[0],
+  run: (baseUrl: string) => Promise<T>
+): Promise<T> {
+  const server = createReadonlyHttpServer(options);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address() as AddressInfo;
+    return await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+}
+
+async function get(url: string, bearer?: string): Promise<{ status: number; text: string; headers: Headers }> {
+  const init: RequestInit = bearer ? { headers: { Authorization: `Bearer ${bearer}` } } : {};
+  const response = await fetch(url, init);
+  return { status: response.status, text: await response.text(), headers: response.headers };
+}
+
+test("disabled or missing token denies generically and does not invoke provider", async () => {
+  for (const access of [
+    createReadonlyAccessGate({ enabled: false, token }),
+    createReadonlyAccessGate({ enabled: true })
+  ]) {
+    const calls: string[] = [];
+    await withServer({ provider: makeProvider(calls), access }, async (baseUrl) => {
+      const result = await get(`${baseUrl}/`);
+      assert.equal(result.status, 404);
+      assert.match(result.text, /Not found/);
+      assert.equal(result.text.includes("token"), false);
+      assert.deepEqual(calls, []);
+    });
+  }
+});
+
+test("wrong or missing bearer denies generically and does not invoke provider", async () => {
+  const calls: string[] = [];
+  await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
+    for (const bearer of [undefined, "wrong-token"]) {
+      const result = await get(`${baseUrl}/`, bearer);
+      assert.equal(result.status, 404);
+      assert.match(result.text, /Not found/);
+      assert.equal(result.text.includes("Bearer"), false);
+      assert.deepEqual(calls, []);
+    }
+
+    const urlToken = await get(`${baseUrl}/?token=${token}`);
+    assert.equal(urlToken.status, 404);
+    assert.match(urlToken.text, /Not found/);
+    assert.deepEqual(calls, []);
+  });
+});
+
+test("authenticated state route invokes only expected provider method", async () => {
+  const calls: string[] = [];
+  await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/runtime`, token);
+    assert.equal(result.status, 200);
+    assert.match(result.text, /Runtime/);
+    assert.deepEqual(calls, ["runtime"]);
+  });
+});
+
+test("authenticated HTML escapes hostile strings and emits no raw script/action/form/control content", async () => {
+  const calls: string[] = [];
+  await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["home"]);
+    assert.match(result.text, /prototype/i);
+    assert.match(result.text, /read-only/i);
+    assert.equal(result.text.includes("<script>"), false);
+    assert.equal(result.text.includes("<img"), false);
+    assert.match(result.text, /&lt;script&gt;alert/);
+    assert.match(result.text, /&lt;b&gt;escape&lt;\/b&gt;/);
+    for (const forbidden of ["/home/ubuntu/secret", "token=abc", "callback_data", "messageId"]) {
+      assert.equal(result.text.includes(forbidden), false, `rendered forbidden raw value ${forbidden}: ${result.text}`);
+    }
+    for (const forbidden of ["<form", "<button", "<input", "onclick", "href=", "submit", "approve", "interrupt", "upload", "switch", "resume"]) {
+      assert.equal(result.text.toLowerCase().includes(forbidden), false, `rendered forbidden content ${forbidden}: ${result.text}`);
+    }
+  });
+});
+
+test("state responses include no-store, CSP, nosniff, and HTML charset headers", async () => {
+  const calls: string[] = [];
+  await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/workspaces`, token);
+    assert.equal(result.status, 200);
+    assert.equal(result.headers.get("cache-control"), "no-store");
+    assert.match(result.headers.get("content-security-policy") ?? "", /default-src 'none'/);
+    assert.equal(result.headers.get("x-content-type-options"), "nosniff");
+    assert.match(result.headers.get("content-type") ?? "", /^text\/html; charset=utf-8/);
+  });
+});
+
+test("unknown route and provider error are generic without stack traces", async () => {
+  const calls: string[] = [];
+  await withServer({ provider: makeProvider(calls, { throwOnHome: true }), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
+    const unknown = await get(`${baseUrl}/unknown`, token);
+    assert.equal(unknown.status, 404);
+    assert.match(unknown.text, /Not found/);
+    assert.deepEqual(calls, []);
+
+    const errored = await get(`${baseUrl}/`, token);
+    assert.equal(errored.status, 500);
+    assert.match(errored.text, /Temporarily unavailable/);
+    for (const forbidden of ["boom", "secret", "/tmp/secret-store", "messageId", "Error:", " at "]) {
+      assert.equal(errored.text.includes(forbidden), false, `error leaked ${forbidden}: ${errored.text}`);
+    }
+  });
+});

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -241,6 +241,24 @@ async function get(url: string, bearer?: string): Promise<{ status: number; text
   return { status: response.status, text: await response.text(), headers: response.headers };
 }
 
+async function post(
+  url: string,
+  bearer: string | undefined,
+  body: string,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; text: string; headers: Headers }> {
+  const response = await fetch(url, {
+    method: "POST",
+    body,
+    redirect: "manual",
+    headers: {
+      ...(bearer ? { Authorization: `Bearer ${bearer}` } : {}),
+      ...headers
+    }
+  });
+  return { status: response.status, text: await response.text(), headers: response.headers };
+}
+
 test("disabled or missing token denies generically and does not invoke provider", async () => {
   for (const access of [
     createReadonlyAccessGate({ enabled: false, token }),
@@ -732,6 +750,170 @@ test("phase B pages expose disabled composer posture without enabled write contr
       }
     }
   });
+});
+
+test("send capability enables only the safe text composer with opaque conversation action and csrf", async () => {
+  const calls: string[] = [];
+  const submitted: unknown[] = [];
+  await withServer({
+    provider: makeProvider(calls),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    send: {
+      csrfToken: "csrf-safe-token",
+      submitTextMessage: (request) => {
+        submitted.push(request);
+        return { status: "accepted" };
+      }
+    }
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/conversations/cv_1234567890abcdef`, token);
+    assert.equal(result.status, 200);
+    assert.match(result.text, /<form method="post" action="\/conversations\/cv_1234567890abcdef\/messages">/);
+    assert.match(result.text, /name="_csrf" value="csrf-safe-token"/);
+    assert.match(result.text, /<textarea[^>]*name="message"[^>]*maxlength="8000"[^>]*required/);
+    assert.match(result.text, /<button type="submit">Send message<\/button>/);
+    assert.equal(result.text.includes("session-1"), false);
+    assert.equal(result.text.includes("chat-secret"), false);
+    assert.equal(result.headers.get("content-security-policy")?.includes("form-action 'self'"), true);
+    assert.deepEqual(submitted, []);
+  });
+});
+
+test("POST message denies unauthorized, CSRF-denied, invalid handle, blank, and oversize without submit", async () => {
+  const calls: string[] = [];
+  const submitted: unknown[] = [];
+  await withServer({
+    provider: makeProvider(calls),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    send: {
+      csrfToken: "csrf-safe-token",
+      submitTextMessage: (request) => {
+        submitted.push(request);
+        return { status: "accepted" };
+      }
+    }
+  }, async (baseUrl) => {
+    const validPath = `${baseUrl}/conversations/cv_1234567890abcdef/messages`;
+    const unauthorized = await post(validPath, undefined, "_csrf=csrf-safe-token&message=hello", {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json"
+    });
+    assert.equal(unauthorized.status, 404);
+    const wrongBearer = await post(validPath, "wrong-token", "_csrf=csrf-safe-token&message=hello", {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json"
+    });
+    assert.equal(wrongBearer.status, 404);
+    const missingCsrf = await post(validPath, token, "message=hello", {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json"
+    });
+    assert.equal(missingCsrf.status, 400);
+    assert.deepEqual(JSON.parse(missingCsrf.text), { status: "invalid" });
+    const wrongCsrfHeader = await post(validPath, token, "_csrf=csrf-safe-token&message=hello", {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "X-CSRF-Token": "wrong-token",
+      Accept: "application/json"
+    });
+    assert.equal(wrongCsrfHeader.status, 403);
+    assert.deepEqual(JSON.parse(wrongCsrfHeader.text), { status: "denied" });
+    const wrongOrigin = await post(validPath, token, "_csrf=csrf-safe-token&message=hello", {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Origin: "https://evil.example.test",
+      Host: "owner.example.test",
+      Accept: "application/json"
+    });
+    assert.equal(wrongOrigin.status, 403);
+    assert.deepEqual(JSON.parse(wrongOrigin.text), { status: "denied" });
+    const invalidHandle = await post(`${baseUrl}/conversations/session-1/messages`, token, "_csrf=csrf-safe-token&message=hello", {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json"
+    });
+    assert.equal(invalidHandle.status, 404);
+    assert.equal(invalidHandle.text.includes("session-1"), false);
+    const blank = await post(validPath, token, "_csrf=csrf-safe-token&message=%20%20", {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json"
+    });
+    assert.equal(blank.status, 400);
+    const oversize = await post(validPath, token, `_csrf=csrf-safe-token&message=${"a".repeat(8001)}`, {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json"
+    });
+    assert.equal(oversize.status, 400);
+    const attachment = await post(validPath, token, JSON.stringify({ _csrf: "csrf-safe-token", message: "hello", attachments: [] }), {
+      "Content-Type": "application/json",
+      Accept: "application/json"
+    });
+    assert.equal(attachment.status, 400);
+    assert.deepEqual(submitted, []);
+  });
+});
+
+test("POST message invokes submit dependency once and returns safe redirect or JSON outcome", async () => {
+  const calls: string[] = [];
+  const submitted: unknown[] = [];
+  await withServer({
+    provider: makeProvider(calls),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    send: {
+      csrfToken: "csrf-safe-token",
+      submitTextMessage: (request) => {
+        submitted.push(request);
+        return { status: "accepted" };
+      }
+    }
+  }, async (baseUrl) => {
+    const html = await post(`${baseUrl}/conversations/cv_1234567890abcdef/messages`, token, "_csrf=csrf-safe-token&message=%20hello%20&nonce=nonce-1", {
+      "Content-Type": "application/x-www-form-urlencoded"
+    });
+    assert.equal(html.status, 303);
+    assert.equal(html.headers.get("location"), "/conversations/cv_1234567890abcdef?send=accepted");
+    assert.equal(html.text, "");
+    assert.deepEqual(submitted, [{
+      conversationHandle: "cv_1234567890abcdef",
+      text: "hello",
+      nonce: "nonce-1"
+    }]);
+    assert.equal(JSON.stringify({ headers: Object.fromEntries(html.headers), body: html.text }).includes("session-1"), false);
+
+    const json = await post(`${baseUrl}/conversations/cv_1234567890abcdef/messages`, token, JSON.stringify({ _csrf: "csrf-safe-token", text: "from json" }), {
+      "Content-Type": "application/json",
+      Accept: "application/json"
+    });
+    assert.equal(json.status, 202);
+    assert.deepEqual(JSON.parse(json.text), { status: "accepted" });
+    assert.deepEqual(submitted.at(-1), {
+      conversationHandle: "cv_1234567890abcdef",
+      text: "from json",
+      nonce: null
+    });
+  });
+});
+
+test("POST message maps blocked, missing, archived, or unavailable submit outcomes safely", async () => {
+  const calls: string[] = [];
+  const statuses = ["blocked", "rejected", "unavailable"] as const;
+  for (const status of statuses) {
+    await withServer({
+      provider: makeProvider(calls),
+      access: createReadonlyAccessGate({ enabled: true, token }),
+      send: {
+        csrfToken: "csrf-safe-token",
+        submitTextMessage: () => ({ status })
+      }
+    }, async (baseUrl) => {
+      const result = await post(`${baseUrl}/conversations/cv_1234567890abcdef/messages`, token, "_csrf=csrf-safe-token&message=hello", {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json"
+      });
+      assert.equal(result.status, status === "blocked" ? 409 : status === "unavailable" ? 503 : 400);
+      assert.deepEqual(JSON.parse(result.text), { status });
+      for (const forbidden of [token, "session-1", "chat-secret", "/home/", "/tmp/", "thread", "turn", "stack"]) {
+        assert.equal(result.text.includes(forbidden), false, `${status} leaked ${forbidden}: ${result.text}`);
+      }
+    });
+  }
 });
 
 test("home recent conversations use user-language state groups and copy", async () => {

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -37,7 +37,8 @@ function makeProvider(calls: string[], options: { throwOnHome?: boolean } = {}):
         ],
         recentConversations: [
           {
-            conversationId: "session-1",
+            conversationId: "cv_1234567890abcdef",
+            conversationHandle: "cv_1234567890abcdef",
             workspaceId: "wk_safe_1",
             title: "Need <b>escape</b> & no submit approve interrupt upload switch resume",
             status: "running",
@@ -85,21 +86,49 @@ function makeProvider(calls: string[], options: { throwOnHome?: boolean } = {}):
         pageId: "web_workspace_conversations",
         state: "available",
         workspaceId,
-        conversations: [],
-        emptyState: "no_conversations",
+        conversations: [
+          {
+            conversationId: "cv_1234567890abcdef",
+            conversationHandle: "cv_1234567890abcdef",
+            workspaceId,
+            title: "Readonly detail",
+            status: "completed",
+            failureReason: null,
+            archived: false,
+            createdAt: "2026-04-25T10:00:00.000Z",
+            lastActivityAt: "2026-04-25T12:00:00.000Z",
+            lastTurnStatus: "completed",
+            finalAnswerAvailable: true
+          }
+        ],
+        emptyState: null,
         warnings: []
       };
     },
-    getConversationResultViewModel(sessionId: string) {
-      calls.push(`session:${sessionId}`);
+    getConversationResultViewModel(conversationHandle: string) {
+      calls.push(`conversation:${conversationHandle}`);
       return {
         generatedAt: "2026-04-26T00:00:00.000Z",
         prototypeOnly: true,
         readonly: true,
         pageId: "web_conversation_result",
         state: "available",
-        conversation: null,
+        conversation: {
+          conversationId: conversationHandle,
+          conversationHandle,
+          workspaceId: "wk_safe_1",
+          title: "Readonly detail",
+          workspaceLabel: "Console Core",
+          status: "completed",
+          failureReason: null,
+          archived: false,
+          createdAt: "2026-04-25T10:00:00.000Z",
+          lastActivityAt: "2026-04-25T12:00:00.000Z"
+        },
         answers: [],
+        runtime: { state: "degraded", activeTurns: [] },
+        pendingInteractions: { state: "unavailable", pendingInteractions: [] },
+        readiness: { state: "ready", missingGates: [] },
         warnings: []
       };
     },
@@ -239,9 +268,53 @@ test("authenticated HTML escapes hostile strings and emits no raw script/action/
     for (const forbidden of ["/home/ubuntu/secret", "token=abc", "callback_data", "messageId"]) {
       assert.equal(result.text.includes(forbidden), false, `rendered forbidden raw value ${forbidden}: ${result.text}`);
     }
-    for (const forbidden of ["<form", "<button", "<input", "onclick", "href=", "submit", "approve", "interrupt", "upload", "switch", "resume"]) {
+    assert.match(result.text, /href="\/workspaces\/wk_safe_1\/conversations"/);
+    assert.match(result.text, /href="\/conversations\/cv_1234567890abcdef"/);
+    assert.equal(result.text.includes("/sessions/"), false);
+    for (const forbidden of ["<form", "<button", "<input", "onclick", "download=", "?token", "href=\"#", "submit", "approve", "interrupt", "upload", "switch", "resume"]) {
       assert.equal(result.text.toLowerCase().includes(forbidden), false, `rendered forbidden content ${forbidden}: ${result.text}`);
     }
+  });
+});
+
+test("authenticated conversation detail route uses only opaque handles and keeps security headers", async () => {
+  const calls: string[] = [];
+  await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/conversations/cv_1234567890abcdef`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["conversation:cv_1234567890abcdef"]);
+    assert.match(result.text, /Conversation result/);
+    assert.match(result.text, /Readonly detail/);
+    assert.equal(result.text.includes("/sessions/"), false);
+    assert.equal(result.text.includes("session-1"), false);
+    for (const forbidden of [token, "/home/ubuntu/secret", "callback_data", "messageId", "<form", "<button", "<input", "onclick", "download=", "?token", "href=\"#"]) {
+      assert.equal(result.text.includes(forbidden), false, `detail leaked ${forbidden}: ${result.text}`);
+    }
+    assert.equal(result.headers.get("cache-control"), "no-store");
+    assert.match(result.headers.get("content-security-policy") ?? "", /default-src 'none'/);
+    assert.equal(result.headers.get("x-content-type-options"), "nosniff");
+    assert.match(result.headers.get("content-type") ?? "", /^text\/html; charset=utf-8/);
+  });
+});
+
+test("raw session and unsafe conversation route parts are generic 404s", async () => {
+  const calls: string[] = [];
+  await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
+    for (const path of [
+      "/sessions/session-1",
+      "/sessions/session-1/artifacts",
+      "/conversations/session-1",
+      "/conversations/cv_1234567890abcdeg",
+      "/conversations/%2Ftmp%2Fsecret",
+      "/workspaces/%2Ftmp%2Fsecret/conversations"
+    ]) {
+      const result = await get(`${baseUrl}${path}`, token);
+      assert.equal(result.status, 404, path);
+      assert.match(result.text, /Not found/);
+      assert.equal(result.text.includes("session-1"), false);
+      assert.equal(result.text.includes("/tmp/secret"), false);
+    }
+    assert.deepEqual(calls, []);
   });
 });
 

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -9,6 +9,8 @@ import type {
   WebReadonlyConversationRow,
   WebReadonlyConversationResultViewModel,
   WebReadonlyPendingInteractionViewRow,
+  WebReadonlyReadinessGuardrailViewModel,
+  WebReadonlyRuntimeContextViewModel,
   WebReadonlyViewModelProvider
 } from "../service/web-readonly-view-model.js";
 
@@ -23,6 +25,8 @@ function makeProvider(
     detailAnswers?: WebReadonlyConversationResultViewModel["answers"];
     pendingInteractions?: WebReadonlyPendingInteractionViewRow[];
     detailPendingInteractions?: WebReadonlyPendingInteractionViewRow[];
+    runtime?: WebReadonlyRuntimeContextViewModel;
+    readiness?: WebReadonlyReadinessGuardrailViewModel;
   } = {}
 ): WebReadonlyViewModelProvider {
   return {
@@ -167,7 +171,7 @@ function makeProvider(
     },
     getRuntimeContextViewModel() {
       calls.push("runtime");
-      return {
+      return options.runtime ?? {
         generatedAt: "2026-04-26T00:00:00.000Z",
         prototypeOnly: true,
         readonly: true,
@@ -191,7 +195,7 @@ function makeProvider(
     },
     getReadinessGuardrailViewModel() {
       calls.push("readiness");
-      return {
+      return options.readiness ?? {
         generatedAt: "2026-04-26T00:00:00.000Z",
         prototypeOnly: true,
         readonly: true,
@@ -268,6 +272,113 @@ test("authenticated state route invokes only expected provider method", async ()
     assert.equal(result.status, 200);
     assert.match(result.text, /Runtime/);
     assert.deepEqual(calls, ["runtime"]);
+  });
+});
+
+test("runtime page renders owner-language runtime settings panels without action controls or internals", async () => {
+  const calls: string[] = [];
+  await withServer({
+    provider: makeProvider(calls, {
+      runtime: {
+        generatedAt: "2026-04-26T00:00:00.000Z",
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_runtime_context",
+        state: "degraded",
+        activeTurns: [
+          {
+            sessionId: "session-secret-1",
+            status: "running",
+            summary: "Codex is working from /tmp/private token=abc callback_data=raw messageId=55",
+            blockedReason: null
+          },
+          {
+            sessionId: "session-secret-2",
+            status: "blocked",
+            summary: null,
+            blockedReason: "Waiting on safe owner context from /home/ubuntu/private"
+          }
+        ],
+        warnings: ["runtime source unavailable at /sessions/session-secret-1", "telegramChatId=999 messageId=55"]
+      }
+    }),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/runtime`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["runtime"]);
+    for (const copy of [
+      "Current operating state",
+      "Active conversation/task turns",
+      "Settings / access posture",
+      "Owner/private",
+      "Read-only preview",
+      "Denied by default",
+      "Actions are not enabled",
+      "Degraded",
+      "Unavailable",
+      "Setup needed"
+    ]) {
+      assert.match(result.text, new RegExp(escapeRegExp(copy)), `missing runtime owner copy ${copy}: ${result.text}`);
+    }
+    assert.match(result.text, /Codex is working/);
+    assert.match(result.text, /Progress is stopped until required owner interaction is resolved\./);
+    assertWebPanelHasNoActionsOrInternals(result.text);
+  });
+});
+
+test("readiness page renders owner-language capability and access posture without unsafe support claims", async () => {
+  const calls: string[] = [];
+  await withServer({
+    provider: makeProvider(calls, {
+      readiness: {
+        generatedAt: "2026-04-26T00:00:00.000Z",
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_readiness_guardrails",
+        state: "degraded",
+        checkedAt: "2026-04-26T00:00:00.000Z",
+        activePack: "feishu token=abc /tmp/pack callback_data=raw",
+        capabilities: [
+          { key: "codex_installed", label: "Codex installed", declared: "present", configured: "present", observed: "present", uxExposed: "missing" },
+          { key: "codex_authenticated", label: "Codex authenticated", declared: "present", configured: "missing", observed: "missing", uxExposed: "missing" },
+          { key: "app_server", label: "App server", declared: "present", configured: "unknown", observed: "unknown", uxExposed: "missing" },
+          { key: "operator_binding", label: "Owner binding", declared: "present", configured: "present", observed: "present", uxExposed: "missing" }
+        ],
+        missingGates: [
+          "setup needed at /home/ubuntu/.codex",
+          "messageId=12 callback_data=approve token=secret"
+        ],
+        warnings: ["telegramChatId=999 /sessions/session-secret-1"]
+      }
+    }),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/readiness`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["readiness"]);
+    for (const copy of [
+      "Baseline capability/readiness matrix",
+      "Declared",
+      "Configured",
+      "Observed",
+      "UX exposed",
+      "Setup / access posture",
+      "Owner/private",
+      "Denied by default",
+      "Read-only preview",
+      "Setup needed",
+      "not a public support claim",
+      "public support is not claimed"
+    ]) {
+      assert.match(result.text, new RegExp(escapeRegExp(copy)), `missing readiness owner copy ${copy}: ${result.text}`);
+    }
+    for (const label of ["Codex installed", "Codex authenticated", "App server", "Owner binding"]) {
+      assert.match(result.text, new RegExp(escapeRegExp(label)), `missing readiness capability ${label}: ${result.text}`);
+    }
+    assertWebPanelHasNoActionsOrInternals(result.text);
+    assert.equal(result.text.includes("activePack"), false);
+    assert.equal(result.text.includes("codex_installed"), false);
   });
 });
 
@@ -634,6 +745,44 @@ function assertPendingSurfaceHasNoActionsOrInternals(html: string): void {
     "/interrupt"
   ]) {
     assert.equal(lower.includes(forbidden), false, `pending surface leaked forbidden content ${forbidden}: ${html}`);
+  }
+}
+
+function assertWebPanelHasNoActionsOrInternals(html: string): void {
+  const lower = html.toLowerCase();
+  for (const forbidden of [
+    token,
+    "<form",
+    "<button",
+    "<input",
+    "method=\"post\"",
+    "action=",
+    "onclick",
+    "download=",
+    "?token",
+    "/tmp",
+    "/home",
+    "/sessions/",
+    "callback_data",
+    "callback:",
+    "messageid",
+    "platformmessageid",
+    "telegramchatid",
+    "feishuchatid",
+    "chatid",
+    "threadid",
+    "session-secret",
+    "raw platform",
+    "/approval-answer",
+    "/question-answer",
+    "/submit",
+    "/interrupt",
+    " submit ",
+    " approve ",
+    " answer ",
+    " interrupt "
+  ]) {
+    assert.equal(lower.includes(forbidden), false, `surface leaked forbidden content ${forbidden}: ${html}`);
   }
 }
 

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -5,11 +5,20 @@ import type { AddressInfo } from "node:net";
 
 import { createReadonlyAccessGate } from "./readonly-access.js";
 import { createReadonlyHttpServer } from "./readonly-http-server.js";
-import type { WebReadonlyViewModelProvider } from "../service/web-readonly-view-model.js";
+import type {
+  WebReadonlyConversationResultViewModel,
+  WebReadonlyViewModelProvider
+} from "../service/web-readonly-view-model.js";
 
 const token = "local-test-token";
 
-function makeProvider(calls: string[], options: { throwOnHome?: boolean } = {}): WebReadonlyViewModelProvider {
+function makeProvider(
+  calls: string[],
+  options: {
+    throwOnHome?: boolean;
+    detailAnswers?: WebReadonlyConversationResultViewModel["answers"];
+  } = {}
+): WebReadonlyViewModelProvider {
   return {
     getHomeViewModel() {
       calls.push("home");
@@ -125,7 +134,7 @@ function makeProvider(calls: string[], options: { throwOnHome?: boolean } = {}):
           createdAt: "2026-04-25T10:00:00.000Z",
           lastActivityAt: "2026-04-25T12:00:00.000Z"
         },
-        answers: [],
+        answers: options.detailAnswers ?? [],
         runtime: { state: "degraded", activeTurns: [] },
         pendingInteractions: { state: "unavailable", pendingInteractions: [] },
         readiness: { state: "ready", missingGates: [] },
@@ -318,6 +327,62 @@ test("authenticated conversation detail route uses only opaque handles and keeps
     assert.match(result.headers.get("content-security-policy") ?? "", /default-src 'none'/);
     assert.equal(result.headers.get("x-content-type-options"), "nosniff");
     assert.match(result.headers.get("content-type") ?? "", /^text\/html; charset=utf-8/);
+  });
+});
+
+test("authenticated conversation detail renders available final-answer body escaped and readable", async () => {
+  const calls: string[] = [];
+  await withServer({
+    provider: makeProvider(calls, {
+      detailAnswers: [
+        {
+          answerId: "answer-safe",
+          kind: "final_answer",
+          deliveryState: "delivered",
+          createdAt: "2026-04-25T12:10:00.000Z",
+          body: {
+            state: "available",
+            text: "Useful result:\n- Render <result> & \"details\" safely."
+          },
+          summary: "Final answer body was provided by a Web-safe source."
+        }
+      ]
+    }),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/conversations/cv_1234567890abcdef`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["conversation:cv_1234567890abcdef"]);
+    assert.match(result.text, /<pre class="console-result-body">Useful result:/);
+    assert.match(result.text, /Render &lt;result&gt; &amp; &quot;details&quot; safely\./);
+    assert.equal(result.text.includes("<result>"), false);
+    assert.equal(result.text.includes("Final answer body unavailable"), false);
+  });
+});
+
+test("authenticated conversation detail explains rejected final-answer body source", async () => {
+  const calls: string[] = [];
+  await withServer({
+    provider: makeProvider(calls, {
+      detailAnswers: [
+        {
+          answerId: "answer-unsafe",
+          kind: "final_answer",
+          deliveryState: "delivered",
+          createdAt: "2026-04-25T12:10:00.000Z",
+          body: { state: "unavailable", reason: "unsafe_final_answer_body" },
+          summary: "Final answer body was rejected by the Web safety filter."
+        }
+      ]
+    }),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/conversations/cv_1234567890abcdef`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["conversation:cv_1234567890abcdef"]);
+    assert.match(result.text, /Final answer body unavailable/);
+    assert.match(result.text, /rejected by the Web safety filter/);
+    assert.equal(result.text.includes("<table"), false);
   });
 });
 

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -8,6 +8,7 @@ import { createReadonlyHttpServer } from "./readonly-http-server.js";
 import type {
   WebReadonlyConversationRow,
   WebReadonlyConversationResultViewModel,
+  WebReadonlyPendingInteractionViewRow,
   WebReadonlyViewModelProvider
 } from "../service/web-readonly-view-model.js";
 
@@ -20,6 +21,8 @@ function makeProvider(
     homeConversations?: WebReadonlyConversationRow[];
     workspaceConversations?: WebReadonlyConversationRow[];
     detailAnswers?: WebReadonlyConversationResultViewModel["answers"];
+    pendingInteractions?: WebReadonlyPendingInteractionViewRow[];
+    detailPendingInteractions?: WebReadonlyPendingInteractionViewRow[];
   } = {}
 ): WebReadonlyViewModelProvider {
   return {
@@ -139,7 +142,10 @@ function makeProvider(
         },
         answers: options.detailAnswers ?? [],
         runtime: { state: "degraded", activeTurns: [] },
-        pendingInteractions: { state: "unavailable", pendingInteractions: [] },
+        pendingInteractions: {
+          state: options.detailPendingInteractions ? "available" : "unavailable",
+          pendingInteractions: options.detailPendingInteractions ?? []
+        },
         readiness: { state: "ready", missingGates: [] },
         warnings: []
       };
@@ -179,7 +185,7 @@ function makeProvider(
         readonly: true,
         pageId: "web_pending_interactions",
         state: "available",
-        pendingInteractions: [],
+        pendingInteractions: options.pendingInteractions ?? [],
         warnings: []
       };
     },
@@ -389,6 +395,78 @@ test("authenticated conversation detail explains rejected final-answer body sour
   });
 });
 
+test("authenticated pending interactions route renders read-only owner attention cards by status without action controls", async () => {
+  const calls: string[] = [];
+  const rows: WebReadonlyPendingInteractionViewRow[] = [
+    pendingInteractionFixture("pi_pending_question", "cv_aaaaaaaaaaaaaaaa", "awaiting_user_input", "question", "Codex needs a product decision."),
+    pendingInteractionFixture("pi_pending_approval", "cv_bbbbbbbbbbbbbbbb", "pending_approval", "codex_approval", "A safe change needs owner review."),
+    pendingInteractionFixture("pi_resolved", "cv_cccccccccccccccc", "resolved", "question", "The owner interaction was resolved."),
+    pendingInteractionFixture("pi_expired", "cv_dddddddddddddddd", "expired", "question", "This prompt is no longer current."),
+    pendingInteractionFixture("pi_stale", "cv_eeeeeeeeeeeeeeee", "stale", "approval", "The visible state may be stale."),
+    pendingInteractionFixture("pi_duplicate", "cv_ffffffffffffffff", "duplicate", "question", "A newer owner prompt replaced this one."),
+    pendingInteractionFixture("pi_failed", "cv_1111111111111111", "failed", "interaction", "The pending item could not be read safely."),
+    pendingInteractionFixture("pi_unavailable", "cv_2222222222222222", "source_unavailable", "interaction", null, "unavailable")
+  ];
+
+  await withServer({
+    provider: makeProvider(calls, { pendingInteractions: rows }),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/interactions`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["interactions"]);
+    assert.match(result.text, /Pending\/Approvals/);
+    assert.match(result.text, /Responses are not enabled in this preview\./);
+    for (const heading of ["Needs owner attention", "Resolved or duplicate", "Stale or expired", "Unavailable or failed"]) {
+      assert.match(result.text, new RegExp(`<h3>${escapeRegExp(heading)}</h3>`), `missing pending group ${heading}: ${result.text}`);
+    }
+    for (const label of ["Needs answer", "Approval needed", "Resolved", "Expired", "Stale", "Duplicate", "Failed", "Unavailable"]) {
+      assert.match(result.text, new RegExp(`class="console-badge">${escapeRegExp(label)}</span>`), `missing pending label ${label}: ${result.text}`);
+    }
+    for (const copy of [
+      "Codex asked a question; responses are not enabled in this preview.",
+      "Codex requested an approval; responses are not enabled in this preview.",
+      "This owner interaction is already resolved; no Web action is available.",
+      "This owner interaction expired or is no longer current; refresh or use the current bridge chat if needed.",
+      "This owner interaction may be stale; refresh before relying on it.",
+      "This owner interaction appears to duplicate another item; use the current item in the bridge chat if needed.",
+      "This owner interaction could not be read safely; use the current bridge chat if needed.",
+      "Pending interaction data is unavailable from the safe reader."
+    ]) {
+      assert.match(result.text, new RegExp(escapeRegExp(copy)), `missing pending copy ${copy}: ${result.text}`);
+    }
+    assert.match(result.text, /href="\/conversations\/cv_aaaaaaaaaaaaaaaa"/);
+    assert.match(result.text, /href="\/conversations\/cv_bbbbbbbbbbbbbbbb"/);
+    assertPendingSurfaceHasNoActionsOrInternals(result.text);
+    for (const raw of ["awaiting_user_input", "pending_approval", "source_unavailable", "codex_approval", "pi_pending_question", "pi_pending_approval"]) {
+      assert.equal(result.text.includes(raw), false, `raw pending value leaked ${raw}: ${result.text}`);
+    }
+  });
+});
+
+test("conversation detail pending panel shares read-only pending cards and action-disabled copy", async () => {
+  const calls: string[] = [];
+  const rows: WebReadonlyPendingInteractionViewRow[] = [
+    pendingInteractionFixture("pi_detail_question", "cv_1234567890abcdef", "awaiting_user_input", "question", "Codex needs a sizing answer.")
+  ];
+
+  await withServer({
+    provider: makeProvider(calls, { detailPendingInteractions: rows }),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/conversations/cv_1234567890abcdef`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["conversation:cv_1234567890abcdef"]);
+    assert.match(result.text, /Pending interactions/);
+    assert.match(result.text, /Needs owner attention/);
+    assert.match(result.text, /Codex needs a sizing answer\./);
+    assert.match(result.text, /Codex asked a question; responses are not enabled in this preview\./);
+    assert.match(result.text, /Responses are not enabled in this preview\./);
+    assertPendingSurfaceHasNoActionsOrInternals(result.text);
+    assert.equal(result.text.includes("pi_detail_question"), false, `raw pending id leaked: ${result.text}`);
+  });
+});
+
 test("home recent conversations use user-language state groups and copy", async () => {
   const calls: string[] = [];
   const rows: WebReadonlyConversationRow[] = [
@@ -503,6 +581,60 @@ function conversationFixture(
     lastTurnStatus: status,
     finalAnswerAvailable
   };
+}
+
+function pendingInteractionFixture(
+  interactionId: string,
+  conversationId: string,
+  status: string,
+  kind: string,
+  summaryText: string | null,
+  availability: "available" | "unavailable" | "degraded" = "available"
+): WebReadonlyPendingInteractionViewRow {
+  return {
+    interactionId,
+    conversationId,
+    sessionId: null,
+    status,
+    kind,
+    createdAt: "2026-04-25T10:00:00.000Z",
+    updatedAt: "2026-04-25T10:05:00.000Z",
+    blockingReason: "Safe owner attention state.",
+    summary: summaryText
+      ? { state: "available", text: summaryText }
+      : { state: "unavailable", reason: "pending_interaction_summary_not_provided" },
+    availability,
+    warnings: []
+  };
+}
+
+function assertPendingSurfaceHasNoActionsOrInternals(html: string): void {
+  const lower = html.toLowerCase();
+  for (const forbidden of [
+    "<form",
+    "<button",
+    "<input",
+    "method=\"post\"",
+    "form-action",
+    "onclick",
+    "callback_data",
+    "callback:",
+    "messageid",
+    "platformmessageid",
+    "telegramchatid",
+    "feishuchatid",
+    "token=",
+    "?token",
+    "/tmp/",
+    "/home/",
+    "/sessions/",
+    "/approval-answer",
+    "/question-answer",
+    "/submit",
+    "/interrupt"
+  ]) {
+    assert.equal(lower.includes(forbidden), false, `pending surface leaked forbidden content ${forbidden}: ${html}`);
+  }
 }
 
 function escapeRegExp(value: string): string {

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -259,8 +259,25 @@ test("authenticated HTML escapes hostile strings and emits no raw script/action/
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
     assert.deepEqual(calls, ["home"]);
-    assert.match(result.text, /prototype/i);
+    assert.match(result.text, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
+    assert.match(result.text, /Codex Console/);
+    assert.match(result.text, /Owner preview/);
     assert.match(result.text, /read-only/i);
+    assert.match(result.text, /<header class="console-shell__header">/);
+    assert.match(result.text, /<nav class="console-shell__nav" aria-label="Console navigation">/);
+    for (const [href, label] of [
+      ["/", "Home"],
+      ["/workspaces", "Workspaces"],
+      ["/interactions", "Pending"],
+      ["/runtime", "Runtime"],
+      ["/readiness", "Readiness"]
+    ] as const) {
+      assert.match(result.text, new RegExp(`<a[^>]*href="${href.replace("/", "\\/")}"[^>]*>${label}</a>`), `missing nav link ${href}: ${result.text}`);
+    }
+    assert.match(result.text, /class="console-card"/);
+    assert.match(result.text, /Recent conversations/);
+    assert.match(result.text, /Active turns/);
+    assert.equal(result.text.includes("<table"), false, `home should use card/list shell, not primary tables: ${result.text}`);
     assert.equal(result.text.includes("<script>"), false);
     assert.equal(result.text.includes("<img"), false);
     assert.match(result.text, /&lt;script&gt;alert/);
@@ -283,7 +300,14 @@ test("authenticated conversation detail route uses only opaque handles and keeps
     const result = await get(`${baseUrl}/conversations/cv_1234567890abcdef`, token);
     assert.equal(result.status, 200);
     assert.deepEqual(calls, ["conversation:cv_1234567890abcdef"]);
-    assert.match(result.text, /Conversation result/);
+    assert.match(result.text, /Conversation\/task detail/);
+    assert.match(result.text, /<section class="console-panel console-result" aria-labelledby="result-heading">/);
+    assert.match(result.text, /Final answer\/result/);
+    assert.match(result.text, /Final answer body unavailable: this run has no sanitized Web-readable answer source yet\./);
+    assert.match(result.text, /Pending interactions/);
+    assert.match(result.text, /Runtime/);
+    assert.match(result.text, /Readiness/);
+    assert.match(result.text, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
     assert.match(result.text, /Readonly detail/);
     assert.equal(result.text.includes("/sessions/"), false);
     assert.equal(result.text.includes("session-1"), false);

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -435,7 +435,7 @@ test("authenticated HTML escapes hostile strings and emits no raw script/action/
     assert.match(result.text, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
     assert.match(result.text, /Codex Console/);
     assert.match(result.text, /Web Chat/);
-    assert.match(result.text, /Chat-first, view-only preview/);
+    assert.match(result.text, /Chat-first owner preview/);
     assert.match(result.text, /<header class="console-shell__header">/);
     assert.match(result.text, /<nav class="console-shell__nav" aria-label="Console navigation">/);
     for (const [href, label] of [

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -20,6 +20,7 @@ function makeProvider(
   calls: string[],
   options: {
     throwOnHome?: boolean;
+    homeWorkspaces?: ReturnType<WebReadonlyViewModelProvider["getHomeViewModel"]>["workspaces"];
     homeConversations?: WebReadonlyConversationRow[];
     workspaceConversations?: WebReadonlyConversationRow[];
     detailAnswers?: WebReadonlyConversationResultViewModel["answers"];
@@ -42,7 +43,7 @@ function makeProvider(
         pageId: "web_home",
         state: "available",
         operator: { binding: "available" },
-        workspaces: [
+        workspaces: options.homeWorkspaces ?? [
           {
             workspaceId: "wk_safe_1",
             label: "<script>alert('x')</script> Console /home/ubuntu/secret token=abc callback_data=approve messageId=5",
@@ -69,7 +70,9 @@ function makeProvider(
             finalAnswerAvailable: true
           }
         ],
-        runtime: {
+        runtime: options.runtime
+          ? { state: options.runtime.state, activeTurns: options.runtime.activeTurns }
+          : {
           state: "available",
           activeTurns: [
             {
@@ -390,8 +393,8 @@ test("authenticated HTML escapes hostile strings and emits no raw script/action/
     assert.deepEqual(calls, ["home"]);
     assert.match(result.text, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
     assert.match(result.text, /Codex Console/);
-    assert.match(result.text, /Owner preview/);
-    assert.match(result.text, /read-only/i);
+    assert.match(result.text, /Personal workspace/);
+    assert.match(result.text, /View-only preview/);
     assert.match(result.text, /<header class="console-shell__header">/);
     assert.match(result.text, /<nav class="console-shell__nav" aria-label="Console navigation">/);
     for (const [href, label] of [
@@ -404,8 +407,8 @@ test("authenticated HTML escapes hostile strings and emits no raw script/action/
       assert.match(result.text, new RegExp(`<a[^>]*href="${href.replace("/", "\\/")}"[^>]*>${label}</a>`), `missing nav link ${href}: ${result.text}`);
     }
     assert.match(result.text, /class="console-card"/);
-    assert.match(result.text, /Recent conversations/);
-    assert.match(result.text, /Active turns/);
+    assert.match(result.text, /Recent results/);
+    assert.match(result.text, /Active \/ needs attention/);
     assert.equal(result.text.includes("<table"), false, `home should use card/list shell, not primary tables: ${result.text}`);
     assert.equal(result.text.includes("<script>"), false);
     assert.equal(result.text.includes("<img"), false);
@@ -423,17 +426,76 @@ test("authenticated HTML escapes hostile strings and emits no raw script/action/
   });
 });
 
+test("home renders a product dashboard with personal workflow sections", async () => {
+  const calls: string[] = [];
+  await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["home"]);
+    assert.match(result.text, /<h2 id="page-heading">Codex Console<\/h2>/);
+    assert.match(result.text, /Your personal console for continuing Codex work, reviewing results, and browsing projects\./);
+    for (const heading of [
+      "Continue working",
+      "Active / needs attention",
+      "Recent results",
+      "Projects / workspaces"
+    ]) {
+      assert.match(result.text, new RegExp(`<h2[^>]*>${escapeRegExp(heading)}</h2>`), `missing dashboard section ${heading}: ${result.text}`);
+    }
+    assert.match(result.text, /View-only preview/);
+    assert.match(result.text, /Open/);
+    assert.equal(result.text.includes("Current state"), false, `home should not be centered on status metrics: ${result.text}`);
+    assert.equal(result.text.includes("Settings / access posture"), false, `home should keep access posture off the landing dashboard: ${result.text}`);
+  });
+});
+
+test("home empty state is friendly product copy, not degraded/security copy", async () => {
+  const calls: string[] = [];
+  await withServer({
+    provider: makeProvider(calls, {
+      homeWorkspaces: [],
+      homeConversations: [],
+      runtime: {
+        generatedAt: "2026-04-26T00:00:00.000Z",
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_runtime_context",
+        state: "available",
+        activeTurns: [],
+        warnings: []
+      }
+    }),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["home"]);
+    for (const copy of [
+      "No active work needs attention right now.",
+      "Recent results will appear here after Codex finishes work.",
+      "Projects and workspaces will appear here once the bridge has recent workspace history."
+    ]) {
+      assert.match(result.text, new RegExp(escapeRegExp(copy)), `missing friendly empty copy ${copy}: ${result.text}`);
+    }
+    assert.equal(result.text.includes("degraded"), false, `empty home should not lead with degraded copy: ${result.text}`);
+    assert.equal(result.text.includes("denied-by-default"), false, `empty home should not lead with security posture: ${result.text}`);
+  });
+});
+
 test("authenticated conversation detail route uses only opaque handles and keeps security headers", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     const result = await get(`${baseUrl}/conversations/cv_1234567890abcdef`, token);
     assert.equal(result.status, 200);
     assert.deepEqual(calls, ["conversation:cv_1234567890abcdef"]);
-    assert.match(result.text, /Conversation\/task detail/);
+    assert.match(result.text, /Task page/);
+    assert.match(result.text, /<h2 id="detail-heading">Readonly detail<\/h2>/);
+    assert.match(result.text, /Last updated/);
+    assert.match(result.text, /View-only preview/);
     assert.match(result.text, /<section class="console-panel console-result" aria-labelledby="result-heading">/);
-    assert.match(result.text, /Final answer\/result/);
-    assert.match(result.text, /Final answer body unavailable: this run has no sanitized Web-readable answer source yet\./);
-    assert.match(result.text, /Pending interactions/);
+    assert.match(result.text, /Result/);
+    assert.match(result.text, /No Web-ready final answer has been captured yet\. When Codex finishes with a shareable result, it will appear in this panel\./);
+    assert.match(result.text, /Needs attention/);
     assert.match(result.text, /Runtime/);
     assert.match(result.text, /Readiness/);
     assert.match(result.text, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
@@ -500,8 +562,8 @@ test("authenticated conversation detail explains rejected final-answer body sour
     const result = await get(`${baseUrl}/conversations/cv_1234567890abcdef`, token);
     assert.equal(result.status, 200);
     assert.deepEqual(calls, ["conversation:cv_1234567890abcdef"]);
-    assert.match(result.text, /Final answer body unavailable/);
-    assert.match(result.text, /rejected by the Web safety filter/);
+    assert.match(result.text, /This result is available in the bridge conversation, but it is not shown in the Web preview yet\./);
+    assert.equal(result.text.includes("Web safety filter"), false);
     assert.equal(result.text.includes("<table"), false);
   });
 });
@@ -568,7 +630,7 @@ test("conversation detail pending panel shares read-only pending cards and actio
     const result = await get(`${baseUrl}/conversations/cv_1234567890abcdef`, token);
     assert.equal(result.status, 200);
     assert.deepEqual(calls, ["conversation:cv_1234567890abcdef"]);
-    assert.match(result.text, /Pending interactions/);
+    assert.match(result.text, /Needs attention/);
     assert.match(result.text, /Needs owner attention/);
     assert.match(result.text, /Codex needs a sizing answer\./);
     assert.match(result.text, /Codex asked a question; responses are not enabled in this preview\./);

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -25,6 +25,7 @@ function makeProvider(
     workspaceConversations?: WebReadonlyConversationRow[];
     detailAnswers?: WebReadonlyConversationResultViewModel["answers"];
     pendingInteractions?: WebReadonlyPendingInteractionViewRow[];
+    homePendingInteractions?: WebReadonlyPendingInteractionViewRow[];
     detailPendingInteractions?: WebReadonlyPendingInteractionViewRow[];
     runtime?: WebReadonlyRuntimeContextViewModel;
     readiness?: WebReadonlyReadinessGuardrailViewModel;
@@ -82,6 +83,10 @@ function makeProvider(
               blockedReason: null
             }
           ]
+        },
+        pendingInteractions: {
+          state: options.homePendingInteractions ? "available" : "unavailable",
+          pendingInteractions: options.homePendingInteractions ?? []
         },
         readiness: { state: "ready", missingGates: [] },
         warnings: []
@@ -481,6 +486,54 @@ test("home empty state is friendly product copy, not degraded/security copy", as
     assert.equal(result.text.includes("denied-by-default"), false, `empty home should not lead with security posture: ${result.text}`);
   });
 });
+
+
+test("authenticated HTML includes CSP-compatible app shell stylesheet", async () => {
+  const calls: string[] = [];
+  await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["home"]);
+    assert.match(result.headers.get("content-security-policy") ?? "", /style-src 'sha256-[A-Za-z0-9+/=]+'/);
+    assert.equal(result.headers.get("content-security-policy")?.includes("unsafe-inline"), false);
+    assert.match(result.text, /<style>\n:root \{/);
+    assert.match(result.text, /max-width: min\(1120px, calc\(100% - 32px\)\)/);
+    assert.match(result.text, /overflow-wrap: anywhere/);
+    assert.match(result.text, /white-space: pre-wrap/);
+    assert.match(result.text, /min-height: 44px/);
+    assert.match(result.text, /@media \(max-width: 640px\)/);
+    assert.equal(result.text.includes("<link"), false);
+    assert.equal(result.text.includes('style="'), false);
+  });
+});
+
+test("home surfaces concrete owner attention from pending interactions without raw internals", async () => {
+  const calls: string[] = [];
+  const rows: WebReadonlyPendingInteractionViewRow[] = [
+    pendingInteractionFixture("pi_home_question", "cv_aaaaaaaaaaaaaaaa", "awaiting_user_input", "question", "Codex needs a product decision."),
+    pendingInteractionFixture("pi_home_approval", "cv_bbbbbbbbbbbbbbbb", "pending_approval", "codex_approval", "A safe change needs owner review.")
+  ];
+
+  await withServer({
+    provider: makeProvider(calls, { homePendingInteractions: rows }),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/`, token);
+    assert.equal(result.status, 200);
+    assert.deepEqual(calls, ["home"]);
+    assert.match(result.text, /Owner attention/);
+    assert.match(result.text, /2 items need owner attention/);
+    assert.match(result.text, /Codex needs a product decision\./);
+    assert.match(result.text, /A safe change needs owner review\./);
+    assert.match(result.text, /Needs answer/);
+    assert.match(result.text, /Approval needed/);
+    assertPendingSurfaceHasNoActionsOrInternals(result.text);
+    for (const raw of ["pi_home_question", "pi_home_approval", "awaiting_user_input", "pending_approval", "codex_approval"]) {
+      assert.equal(result.text.includes(raw), false, `home leaked raw pending value ${raw}: ${result.text}`);
+    }
+  });
+});
+
 
 test("authenticated conversation detail route uses only opaque handles and keeps security headers", async () => {
   const calls: string[] = [];

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -24,6 +24,7 @@ function makeProvider(
     homeConversations?: WebReadonlyConversationRow[];
     workspaceConversations?: WebReadonlyConversationRow[];
     detailAnswers?: WebReadonlyConversationResultViewModel["answers"];
+    detailStatus?: string;
     pendingInteractions?: WebReadonlyPendingInteractionViewRow[];
     homePendingInteractions?: WebReadonlyPendingInteractionViewRow[];
     detailPendingInteractions?: WebReadonlyPendingInteractionViewRow[];
@@ -147,7 +148,7 @@ function makeProvider(
           workspaceId: "wk_safe_1",
           title: "Readonly detail",
           workspaceLabel: "Console Core",
-          status: "completed",
+          status: options.detailStatus ?? "completed",
           failureReason: null,
           archived: false,
           createdAt: "2026-04-25T10:00:00.000Z",
@@ -776,6 +777,28 @@ test("send capability enables only the safe text composer with opaque conversati
     assert.equal(result.text.includes("chat-secret"), false);
     assert.equal(result.headers.get("content-security-policy")?.includes("form-action 'self'"), true);
     assert.deepEqual(submitted, []);
+  });
+});
+
+test("accepted and running conversation states expose safe refresh affordance", async () => {
+  const calls: string[] = [];
+  await withServer({
+    provider: makeProvider(calls, { detailStatus: "running" }),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    send: {
+      csrfToken: "csrf-safe-token",
+      submitTextMessage: () => ({ status: "accepted" })
+    }
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/conversations/cv_1234567890abcdef?send=accepted`, token);
+    assert.equal(result.status, 200);
+    assert.match(result.text, /Message accepted/);
+    assert.match(result.text, /Codex is running/);
+    assert.match(result.text, /href="\/conversations\/cv_1234567890abcdef"/);
+    assert.match(result.text, /Refresh thread/);
+    for (const forbidden of [token, "session-1", "chat-secret", "/tmp/", "/home/", "thread-1", "turn-1", "stack"]) {
+      assert.equal(result.text.includes(forbidden), false, `refresh affordance leaked ${forbidden}`);
+    }
   });
 });
 

--- a/src/web/readonly-http-server.ts
+++ b/src/web/readonly-http-server.ts
@@ -3,7 +3,6 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import type { WebReadonlyViewModelProvider } from "../service/web-readonly-view-model.js";
 import type { ReadonlyAccessGate } from "./readonly-access.js";
 import {
-  renderConversationArtifactCatalogPage,
   renderConversationResultPage,
   renderGenericErrorPage,
   renderGenericNotFoundPage,
@@ -80,39 +79,23 @@ function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider):
     return { status: 200, html: renderPendingInteractionsPage(provider.getPendingInteractionsViewModel()) };
   }
 
-  const artifactsMatch = /^\/sessions\/([^/]+)\/artifacts$/.exec(pathname);
-  if (artifactsMatch?.[1]) {
+  const conversationMatch = /^\/conversations\/(cv_[a-f0-9]{16})$/.exec(pathname);
+  if (conversationMatch?.[1]) {
     return {
       status: 200,
-      html: renderConversationArtifactCatalogPage(provider.getConversationArtifactCatalogViewModel(decodeRoutePart(artifactsMatch[1])))
+      html: renderConversationResultPage(provider.getConversationResultViewModel(conversationMatch[1]))
     };
   }
 
-  const sessionMatch = /^\/sessions\/([^/]+)$/.exec(pathname);
-  if (sessionMatch?.[1]) {
-    return {
-      status: 200,
-      html: renderConversationResultPage(provider.getConversationResultViewModel(decodeRoutePart(sessionMatch[1])))
-    };
-  }
-
-  const workspaceMatch = /^\/workspaces\/([^/]+)\/conversations$/.exec(pathname);
+  const workspaceMatch = /^\/workspaces\/(wk_[A-Za-z0-9_-]{1,80})\/conversations$/.exec(pathname);
   if (workspaceMatch?.[1]) {
     return {
       status: 200,
-      html: renderWorkspaceConversationListPage(provider.listWorkspaceConversationViewModels(decodeRoutePart(workspaceMatch[1])))
+      html: renderWorkspaceConversationListPage(provider.listWorkspaceConversationViewModels(workspaceMatch[1]))
     };
   }
 
   return { status: 404, html: renderGenericNotFoundPage() };
-}
-
-function decodeRoutePart(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
 }
 
 function send(response: ServerResponse, status: number, html: string, headOnly: boolean): void {

--- a/src/web/readonly-http-server.ts
+++ b/src/web/readonly-http-server.ts
@@ -24,6 +24,7 @@ export interface ReadonlyHttpServerOptions {
 
 type RouteResult = { status: number; html: string };
 type WebSubmitStatus = "accepted" | "blocked" | "rejected" | "unavailable";
+type WebPostRedirectStatus = WebSubmitStatus | "invalid" | "denied";
 
 export interface WebMessageSubmitRequest {
   conversationHandle: string;
@@ -126,8 +127,11 @@ async function handlePost(
 
 function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider, options: ReadonlyHttpServerOptions): RouteResult {
   let pathname = "/";
+  let searchParams = new URLSearchParams();
   try {
-    pathname = new URL(urlValue, "http://127.0.0.1").pathname;
+    const url = new URL(urlValue, "http://127.0.0.1");
+    pathname = url.pathname;
+    searchParams = url.searchParams;
   } catch {
     return { status: 404, html: renderGenericNotFoundPage() };
   }
@@ -152,7 +156,10 @@ function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider, 
   if (conversationMatch?.[1]) {
     return {
       status: 200,
-      html: renderConversationResultPage(provider.getConversationResultViewModel(conversationMatch[1]), renderOptions(options))
+      html: renderConversationResultPage(
+        provider.getConversationResultViewModel(conversationMatch[1]),
+        renderOptions(options, normalizedFlashStatus(searchParams.get("send")))
+      )
     };
   }
 
@@ -172,9 +179,12 @@ function send(response: ServerResponse, status: number, html: string, headOnly: 
   response.end(headOnly ? undefined : html);
 }
 
-function renderOptions(options: ReadonlyHttpServerOptions) {
+function renderOptions(options: ReadonlyHttpServerOptions, flashStatus: WebPostRedirectStatus | null = null) {
   const csrfToken = options.send ? currentCsrfToken(options.send) : null;
-  return csrfToken && options.send?.submitTextMessage ? { send: { csrfToken } } : {};
+  return {
+    ...(csrfToken && options.send?.submitTextMessage ? { send: { csrfToken } } : {}),
+    ...(flashStatus ? { flash: { status: flashStatus } } : {})
+  };
 }
 
 function sendEnabled(options: ReadonlyHttpServerOptions): boolean {
@@ -313,6 +323,17 @@ function drain(request: IncomingMessage): void {
 
 function normalizeSubmitStatus(status: string): WebSubmitStatus {
   return status === "accepted" || status === "blocked" || status === "unavailable" ? status : "rejected";
+}
+
+function normalizedFlashStatus(status: string | null): WebPostRedirectStatus | null {
+  return status === "accepted" ||
+    status === "blocked" ||
+    status === "rejected" ||
+    status === "unavailable" ||
+    status === "invalid" ||
+    status === "denied"
+    ? status
+    : null;
 }
 
 function sendPostOutcome(

--- a/src/web/readonly-http-server.ts
+++ b/src/web/readonly-http-server.ts
@@ -1,0 +1,121 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+
+import type { WebReadonlyViewModelProvider } from "../service/web-readonly-view-model.js";
+import type { ReadonlyAccessGate } from "./readonly-access.js";
+import {
+  renderConversationArtifactCatalogPage,
+  renderConversationResultPage,
+  renderGenericErrorPage,
+  renderGenericNotFoundPage,
+  renderHomePage,
+  renderPendingInteractionsPage,
+  renderReadinessPage,
+  renderRuntimePage,
+  renderWorkspaceConversationListPage,
+  renderWorkspaceListPage
+} from "./readonly-renderer.js";
+
+export interface ReadonlyHttpServerOptions {
+  provider: WebReadonlyViewModelProvider;
+  access: ReadonlyAccessGate;
+}
+
+type RouteResult = { status: number; html: string };
+
+const SECURITY_HEADERS = {
+  "Cache-Control": "no-store",
+  "Content-Security-Policy": "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+  "X-Content-Type-Options": "nosniff",
+  "Content-Type": "text/html; charset=utf-8"
+} as const;
+
+export function createReadonlyHttpServer(options: ReadonlyHttpServerOptions): Server {
+  return createServer((request, response) => {
+    void handleRequest(options, request, response);
+  });
+}
+
+async function handleRequest(
+  options: ReadonlyHttpServerOptions,
+  request: IncomingMessage,
+  response: ServerResponse
+): Promise<void> {
+  try {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return send(response, 404, renderGenericNotFoundPage(), request.method === "HEAD");
+    }
+
+    if (!options.access.authorize(request.headers)) {
+      return send(response, 404, renderGenericNotFoundPage(), request.method === "HEAD");
+    }
+
+    const route = resolveRoute(request.url ?? "/", options.provider);
+    return send(response, route.status, route.html, request.method === "HEAD");
+  } catch {
+    return send(response, 500, renderGenericErrorPage(), request.method === "HEAD");
+  }
+}
+
+function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider): RouteResult {
+  let pathname = "/";
+  try {
+    pathname = new URL(urlValue, "http://127.0.0.1").pathname;
+  } catch {
+    return { status: 404, html: renderGenericNotFoundPage() };
+  }
+
+  if (pathname === "/") {
+    return { status: 200, html: renderHomePage(provider.getHomeViewModel()) };
+  }
+  if (pathname === "/readiness") {
+    return { status: 200, html: renderReadinessPage(provider.getReadinessGuardrailViewModel()) };
+  }
+  if (pathname === "/runtime") {
+    return { status: 200, html: renderRuntimePage(provider.getRuntimeContextViewModel()) };
+  }
+  if (pathname === "/workspaces") {
+    return { status: 200, html: renderWorkspaceListPage(provider.listWorkspaceViewModels()) };
+  }
+  if (pathname === "/interactions") {
+    return { status: 200, html: renderPendingInteractionsPage(provider.getPendingInteractionsViewModel()) };
+  }
+
+  const artifactsMatch = /^\/sessions\/([^/]+)\/artifacts$/.exec(pathname);
+  if (artifactsMatch?.[1]) {
+    return {
+      status: 200,
+      html: renderConversationArtifactCatalogPage(provider.getConversationArtifactCatalogViewModel(decodeRoutePart(artifactsMatch[1])))
+    };
+  }
+
+  const sessionMatch = /^\/sessions\/([^/]+)$/.exec(pathname);
+  if (sessionMatch?.[1]) {
+    return {
+      status: 200,
+      html: renderConversationResultPage(provider.getConversationResultViewModel(decodeRoutePart(sessionMatch[1])))
+    };
+  }
+
+  const workspaceMatch = /^\/workspaces\/([^/]+)\/conversations$/.exec(pathname);
+  if (workspaceMatch?.[1]) {
+    return {
+      status: 200,
+      html: renderWorkspaceConversationListPage(provider.listWorkspaceConversationViewModels(decodeRoutePart(workspaceMatch[1])))
+    };
+  }
+
+  return { status: 404, html: renderGenericNotFoundPage() };
+}
+
+function decodeRoutePart(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function send(response: ServerResponse, status: number, html: string, headOnly: boolean): void {
+  response.writeHead(status, SECURITY_HEADERS);
+  response.end(headOnly ? undefined : html);
+}

--- a/src/web/readonly-http-server.ts
+++ b/src/web/readonly-http-server.ts
@@ -1,4 +1,5 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { createHash } from "node:crypto";
 
 import type { WebReadonlyViewModelProvider } from "../service/web-readonly-view-model.js";
 import type { ReadonlyAccessGate } from "./readonly-access.js";
@@ -11,7 +12,8 @@ import {
   renderReadinessPage,
   renderRuntimePage,
   renderWorkspaceConversationListPage,
-  renderWorkspaceListPage
+  renderWorkspaceListPage,
+  APP_CSS
 } from "./readonly-renderer.js";
 
 export interface ReadonlyHttpServerOptions {
@@ -23,10 +25,14 @@ type RouteResult = { status: number; html: string };
 
 const SECURITY_HEADERS = {
   "Cache-Control": "no-store",
-  "Content-Security-Policy": "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+  "Content-Security-Policy": `default-src 'none'; style-src 'sha256-${styleHash()}'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'`,
   "X-Content-Type-Options": "nosniff",
   "Content-Type": "text/html; charset=utf-8"
 } as const;
+
+function styleHash(): string {
+  return createHash("sha256").update(`\n${APP_CSS}\n`).digest("base64");
+}
 
 export function createReadonlyHttpServer(options: ReadonlyHttpServerOptions): Server {
   return createServer((request, response) => {

--- a/src/web/readonly-http-server.ts
+++ b/src/web/readonly-http-server.ts
@@ -69,7 +69,7 @@ function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider):
     return { status: 404, html: renderGenericNotFoundPage() };
   }
 
-  if (pathname === "/") {
+  if (pathname === "/" || pathname === "/chat") {
     return { status: 200, html: renderHomePage(provider.getHomeViewModel()) };
   }
   if (pathname === "/readiness") {

--- a/src/web/readonly-http-server.ts
+++ b/src/web/readonly-http-server.ts
@@ -19,15 +19,40 @@ import {
 export interface ReadonlyHttpServerOptions {
   provider: WebReadonlyViewModelProvider;
   access: ReadonlyAccessGate;
+  send?: WebMessageSendOptions;
 }
 
 type RouteResult = { status: number; html: string };
+type WebSubmitStatus = "accepted" | "blocked" | "rejected" | "unavailable";
+
+export interface WebMessageSubmitRequest {
+  conversationHandle: string;
+  text: string;
+  nonce: string | null;
+}
+
+export interface WebMessageSubmitResult {
+  status: WebSubmitStatus;
+}
+
+export interface WebMessageSendOptions {
+  csrfToken: string | (() => string | null | undefined);
+  submitTextMessage: (request: WebMessageSubmitRequest) => Promise<WebMessageSubmitResult> | WebMessageSubmitResult;
+}
+
+const MAX_MESSAGE_CHARS = 8_000;
+const MAX_POST_BODY_BYTES = 32 * 1024;
 
 const SECURITY_HEADERS = {
   "Cache-Control": "no-store",
   "Content-Security-Policy": `default-src 'none'; style-src 'sha256-${styleHash()}'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'`,
   "X-Content-Type-Options": "nosniff",
   "Content-Type": "text/html; charset=utf-8"
+} as const;
+
+const WRITE_SECURITY_HEADERS = {
+  ...SECURITY_HEADERS,
+  "Content-Security-Policy": `default-src 'none'; style-src 'sha256-${styleHash()}'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'`
 } as const;
 
 function styleHash(): string {
@@ -46,22 +71,60 @@ async function handleRequest(
   response: ServerResponse
 ): Promise<void> {
   try {
-    if (request.method !== "GET" && request.method !== "HEAD") {
-      return send(response, 404, renderGenericNotFoundPage(), request.method === "HEAD");
-    }
-
     if (!options.access.authorize(request.headers)) {
       return send(response, 404, renderGenericNotFoundPage(), request.method === "HEAD");
     }
 
-    const route = resolveRoute(request.url ?? "/", options.provider);
-    return send(response, route.status, route.html, request.method === "HEAD");
+    if (request.method === "POST") {
+      return await handlePost(options, request, response);
+    }
+
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return send(response, 404, renderGenericNotFoundPage(), request.method === "HEAD");
+    }
+
+    const route = resolveRoute(request.url ?? "/", options.provider, options);
+    return send(response, route.status, route.html, request.method === "HEAD", sendEnabled(options));
   } catch {
     return send(response, 500, renderGenericErrorPage(), request.method === "HEAD");
   }
 }
 
-function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider): RouteResult {
+async function handlePost(
+  options: ReadonlyHttpServerOptions,
+  request: IncomingMessage,
+  response: ServerResponse
+): Promise<void> {
+  const pathname = safePathname(request.url ?? "/");
+  const conversationMatch = /^\/conversations\/(cv_[a-f0-9]{16})\/messages$/.exec(pathname ?? "");
+  if (!conversationMatch?.[1] || !options.send) {
+    return send(response, 404, renderGenericNotFoundPage(), false, sendEnabled(options));
+  }
+
+  const csrfToken = currentCsrfToken(options.send);
+  const wantsJson = acceptsJson(request.headers.accept);
+  if (!csrfToken || !sameOriginAllowed(request) || !csrfHeaderAllowed(request, csrfToken)) {
+    return sendPostOutcome(response, conversationMatch[1], "denied", wantsJson);
+  }
+
+  const parsed = await readMessageBody(request, csrfToken);
+  if (!parsed.ok) {
+    return sendPostOutcome(response, conversationMatch[1], "invalid", wantsJson);
+  }
+
+  try {
+    const outcome = await options.send.submitTextMessage({
+      conversationHandle: conversationMatch[1],
+      text: parsed.text,
+      nonce: parsed.nonce
+    });
+    return sendPostOutcome(response, conversationMatch[1], normalizeSubmitStatus(outcome.status), wantsJson);
+  } catch {
+    return sendPostOutcome(response, conversationMatch[1], "unavailable", wantsJson);
+  }
+}
+
+function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider, options: ReadonlyHttpServerOptions): RouteResult {
   let pathname = "/";
   try {
     pathname = new URL(urlValue, "http://127.0.0.1").pathname;
@@ -70,7 +133,7 @@ function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider):
   }
 
   if (pathname === "/" || pathname === "/chat") {
-    return { status: 200, html: renderHomePage(provider.getHomeViewModel()) };
+    return { status: 200, html: renderHomePage(provider.getHomeViewModel(), renderOptions(options)) };
   }
   if (pathname === "/readiness") {
     return { status: 200, html: renderReadinessPage(provider.getReadinessGuardrailViewModel()) };
@@ -89,7 +152,7 @@ function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider):
   if (conversationMatch?.[1]) {
     return {
       status: 200,
-      html: renderConversationResultPage(provider.getConversationResultViewModel(conversationMatch[1]))
+      html: renderConversationResultPage(provider.getConversationResultViewModel(conversationMatch[1]), renderOptions(options))
     };
   }
 
@@ -104,7 +167,184 @@ function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider):
   return { status: 404, html: renderGenericNotFoundPage() };
 }
 
-function send(response: ServerResponse, status: number, html: string, headOnly: boolean): void {
-  response.writeHead(status, SECURITY_HEADERS);
+function send(response: ServerResponse, status: number, html: string, headOnly: boolean, writeEnabled = false): void {
+  response.writeHead(status, writeEnabled ? WRITE_SECURITY_HEADERS : SECURITY_HEADERS);
   response.end(headOnly ? undefined : html);
+}
+
+function renderOptions(options: ReadonlyHttpServerOptions) {
+  const csrfToken = options.send ? currentCsrfToken(options.send) : null;
+  return csrfToken && options.send?.submitTextMessage ? { send: { csrfToken } } : {};
+}
+
+function sendEnabled(options: ReadonlyHttpServerOptions): boolean {
+  return Boolean(options.send?.submitTextMessage && currentCsrfToken(options.send));
+}
+
+function currentCsrfToken(send: WebMessageSendOptions): string | null {
+  const value = typeof send.csrfToken === "function" ? send.csrfToken() : send.csrfToken;
+  const trimmed = String(value ?? "").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function safePathname(urlValue: string): string | null {
+  try {
+    return new URL(urlValue, "http://127.0.0.1").pathname;
+  } catch {
+    return null;
+  }
+}
+
+function acceptsJson(accept: string | string[] | undefined): boolean {
+  const value = Array.isArray(accept) ? accept.join(",") : accept ?? "";
+  return /\bapplication\/json\b/i.test(value);
+}
+
+function csrfHeaderAllowed(request: IncomingMessage, expectedToken: string): boolean {
+  const headerToken = firstHeader(request.headers["x-csrf-token"]);
+  return !headerToken || timingSafeEqualString(headerToken, expectedToken);
+}
+
+function sameOriginAllowed(request: IncomingMessage): boolean {
+  const source = firstHeader(request.headers.origin) || firstHeader(request.headers.referer);
+  if (!source) {
+    return true;
+  }
+  try {
+    const sourceUrl = new URL(source);
+    const host = firstHeader(request.headers["x-forwarded-host"]) || firstHeader(request.headers.host);
+    if (!host) {
+      return false;
+    }
+    const proto = firstHeader(request.headers["x-forwarded-proto"]) || "http";
+    const expected = new URL(`${proto}://${host}`);
+    return sourceUrl.protocol === expected.protocol && sourceUrl.host === expected.host;
+  } catch {
+    return false;
+  }
+}
+
+function firstHeader(value: string | string[] | undefined): string | null {
+  const text = Array.isArray(value) ? value[0] : value;
+  const trimmed = String(text ?? "").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function timingSafeEqualString(a: string, b: string): boolean {
+  return a.length === b.length && a === b;
+}
+
+type ParsedMessageBody =
+  | { ok: true; text: string; nonce: string | null }
+  | { ok: false };
+
+async function readMessageBody(request: IncomingMessage, csrfToken: string): Promise<ParsedMessageBody> {
+  const raw = await readBody(request);
+  if (!raw) {
+    return { ok: false };
+  }
+  const contentType = firstHeader(request.headers["content-type"])?.toLowerCase() ?? "";
+  let message: unknown;
+  let nonce: unknown;
+  let bodyToken: unknown;
+
+  if (contentType.includes("application/x-www-form-urlencoded")) {
+    const form = new URLSearchParams(raw.toString("utf-8"));
+    message = form.get("message") ?? form.get("text");
+    nonce = form.get("nonce") ?? form.get("idempotency") ?? form.get("idempotencyKey");
+    bodyToken = form.get("_csrf") ?? form.get("csrf");
+  } else if (contentType.includes("application/json")) {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(raw.toString("utf-8")) as Record<string, unknown>;
+    } catch {
+      return { ok: false };
+    }
+    if (parsed.attachments !== undefined || parsed.files !== undefined) {
+      return { ok: false };
+    }
+    message = parsed.message ?? parsed.text;
+    nonce = parsed.nonce ?? parsed.idempotency ?? parsed.idempotencyKey;
+    bodyToken = parsed._csrf ?? parsed.csrf;
+  } else {
+    return { ok: false };
+  }
+
+  if (typeof bodyToken !== "string" || !timingSafeEqualString(bodyToken, csrfToken)) {
+    return { ok: false };
+  }
+  if (typeof message !== "string") {
+    return { ok: false };
+  }
+  const text = message.trim();
+  if (!text || text.length > MAX_MESSAGE_CHARS) {
+    return { ok: false };
+  }
+  return {
+    ok: true,
+    text,
+    nonce: typeof nonce === "string" && nonce.trim() ? nonce.trim().slice(0, 128) : null
+  };
+}
+
+async function readBody(request: IncomingMessage): Promise<Buffer | null> {
+  const declaredLength = Number.parseInt(firstHeader(request.headers["content-length"]) ?? "0", 10);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_POST_BODY_BYTES) {
+    drain(request);
+    return null;
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.length;
+    if (total > MAX_POST_BODY_BYTES) {
+      drain(request);
+      return null;
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks);
+}
+
+function drain(request: IncomingMessage): void {
+  request.resume();
+}
+
+function normalizeSubmitStatus(status: string): WebSubmitStatus {
+  return status === "accepted" || status === "blocked" || status === "unavailable" ? status : "rejected";
+}
+
+function sendPostOutcome(
+  response: ServerResponse,
+  conversationHandle: string,
+  status: WebSubmitStatus | "invalid" | "denied",
+  wantsJson: boolean
+): void {
+  if (wantsJson) {
+    const httpStatus = status === "accepted"
+      ? 202
+      : status === "blocked"
+        ? 409
+        : status === "unavailable"
+          ? 503
+          : status === "denied"
+            ? 403
+            : 400;
+    const body = `${JSON.stringify({ status })}\n`;
+    response.writeHead(httpStatus, {
+      ...SECURITY_HEADERS,
+      "Content-Type": "application/json; charset=utf-8",
+      "Content-Length": Buffer.byteLength(body)
+    });
+    response.end(body);
+    return;
+  }
+
+  response.writeHead(303, {
+    ...WRITE_SECURITY_HEADERS,
+    Location: `/conversations/${conversationHandle}?send=${status}`,
+    "Content-Length": "0"
+  });
+  response.end();
 }

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -37,11 +37,10 @@ export function renderHomePage(vm: WebReadonlyHomeViewModel): string {
       (row) => workspaceCard(row),
       "Workspace data is unavailable in this read-only preview."
     ),
-    cardListSection(
+    conversationListSection(
       "home-recent-conversations",
       "Recent conversations",
       vm.recentConversations,
-      (row) => conversationCard(row),
       "No recent conversation/task data is available yet."
     ),
     cardListSection(
@@ -74,11 +73,10 @@ export function renderWorkspaceConversationListPage(vm: WebReadonlyWorkspaceConv
   return page("Workspace conversations", "workspaces", [
     hero("Workspace conversations", "Open a conversation/task detail page through an opaque Console handle."),
     summaryPanel("Conversation list status", [field("State", vm.state), field("Empty state", vm.emptyState ?? "—")]),
-    cardListSection(
+    conversationListSection(
       "workspace-conversations",
       "Conversations/tasks",
       vm.conversations,
-      (row) => conversationCard(row),
       vm.emptyState === "no_conversations" ? "No conversation/task rows are visible for this workspace." : "Conversation/task data is unavailable."
     ),
     warnings(vm.warnings)
@@ -91,7 +89,8 @@ export function renderConversationResultPage(vm: WebReadonlyConversationResultVi
   const statusRows = conversation
     ? [
       field("Workspace", conversation.workspaceLabel),
-      field("State", conversation.status),
+      field("State", statusLabel(conversation.status)),
+      field("Status note", statusCopy(conversation.status)),
       field("Archived", yesNo(conversation.archived)),
       field("Created", conversation.createdAt),
       field("Last activity", conversation.lastActivityAt)
@@ -234,6 +233,28 @@ function cardListSection<T>(id: string, title: string, rows: T[], render: (row: 
   return `<section class="console-section" aria-labelledby="${id}"><h2 id="${id}">${escapeHtml(title)}</h2>${body}</section>`;
 }
 
+function conversationListSection(id: string, title: string, rows: WebReadonlyConversationRow[], emptyCopy: string): string {
+  if (rows.length === 0) {
+    return `<section class="console-section" aria-labelledby="${id}"><h2 id="${id}">${escapeHtml(title)}</h2><p class="console-empty">${escapeHtml(emptyCopy)}</p></section>`;
+  }
+
+  const groups = [
+    { key: "attention", title: "Needs attention" },
+    { key: "running", title: "Running now" },
+    { key: "completed", title: "Recently completed" },
+    { key: "other", title: "Other/Older" }
+  ] as const;
+  const cards = groups.map((group) => {
+    const groupRows = rows.filter((row) => conversationGroup(row.status) === group.key);
+    if (groupRows.length === 0) {
+      return "";
+    }
+    return `<section class="console-card-group" aria-label="${escapeHtml(group.title)}"><h3>${escapeHtml(group.title)}</h3><div class="console-card-list">${groupRows.map((row) => conversationCard(row)).join("")}</div></section>`;
+  }).join("");
+
+  return `<section class="console-section" aria-labelledby="${id}"><h2 id="${id}">${escapeHtml(title)}</h2>${cards}</section>`;
+}
+
 function statusPanel(status: string): string {
   return `<section class="console-panel" aria-labelledby="status-heading"><h2 id="status-heading">Status</h2><p><span class="console-badge">${escapeHtml(statusLabel(status))}</span> ${escapeHtml(statusCopy(status))}</p></section>`;
 }
@@ -325,7 +346,8 @@ function runtimeTurnCard(row: WebReadonlyRuntimeTurnRow): string {
 function pendingInteractionCard(row: WebReadonlyPendingInteractionViewRow): string {
   const summary = row.summary.state === "available" ? row.summary.text : "Summary is unavailable from the safe read model.";
   return `<article class="console-card"><h3>${escapeHtml(pendingLabel(row.kind, row.status))}</h3><p>${escapeHtml(summary)}</p><div class="console-fields">${[
-    field("Status", row.status),
+    field("State", pendingLabel(row.kind, row.status)),
+    field("State note", statusCopy(row.status)),
     field("Kind", row.kind),
     field("Reason", row.blockingReason),
     field("Created", row.createdAt ?? "—"),
@@ -384,6 +406,15 @@ function isAttentionState(status: string): boolean {
   return /pending|blocked|question|approval|needs/i.test(status);
 }
 
+function conversationGroup(status: string): "attention" | "running" | "completed" | "other" {
+  const normalized = status.toLowerCase();
+  if (normalized.includes("unknown")) return "other";
+  if (/question|approval|pending|blocked|fail|degraded|unavailable|needs/.test(normalized)) return "attention";
+  if (/running|queued/.test(normalized)) return "running";
+  if (/complete|done/.test(normalized)) return "completed";
+  return "other";
+}
+
 function statusLabel(status: string): string {
   const normalized = status.toLowerCase();
   if (normalized.includes("running")) return "Running";
@@ -396,9 +427,10 @@ function statusLabel(status: string): string {
   if (normalized.includes("fail")) return "Failed";
   if (normalized.includes("degraded")) return "Degraded";
   if (normalized.includes("unavailable")) return "Unavailable";
+  if (normalized.includes("unknown")) return "Unavailable";
   if (normalized.includes("recover")) return "Recovered";
   if (normalized.includes("idle")) return "Idle";
-  return status;
+  return "Unavailable";
 }
 
 function statusCopy(status: string): string {
@@ -423,7 +455,7 @@ function statusCopy(status: string): string {
     case "Degraded":
       return "State is partial, stale, or missing a safe source.";
     case "Unavailable":
-      return "The required reader/source is not connected or authorized.";
+      return "The current state is unavailable or unknown from the safe reader.";
     case "Recovered":
       return "Runtime restarted or state was restored with caveats.";
     default:
@@ -463,7 +495,7 @@ function pendingCopy(state: string): string {
 }
 
 function conversationCopy(status: string, finalAnswerAvailable: boolean): string {
-  if (finalAnswerAvailable) {
+  if (finalAnswerAvailable && statusLabel(status) !== "Done") {
     return "Result metadata is available.";
   }
   return statusCopy(status);

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -21,27 +21,21 @@ interface SafeHtmlCell {
 type NavKey = "home" | "workspaces" | "pending" | "runtime" | "readiness" | "none";
 
 export function renderHomePage(vm: WebReadonlyHomeViewModel): string {
-  const continueRows = vm.recentConversations.filter((row) => conversationGroup(row.status) !== "completed");
   const resultRows = vm.recentConversations.filter((row) => row.finalAnswerAvailable || conversationGroup(row.status) === "completed");
-  return page("Home", "home", [
-    hero("Codex Console", "Your personal console for continuing Codex work, reviewing results, and browsing projects."),
+  return page("Web Chat", "home", [
+    hero("Web Chat", "Conversation work queue for Codex Bridge. Sending from Web is landing next; this slice is a safe read-only thread view."),
+    chatHomeSection(vm),
     homeOwnerAttentionSection(vm.pendingInteractions.state, vm.pendingInteractions.pendingInteractions),
-    conversationListSection(
-      "home-continue-working",
-      "Continue working",
-      continueRows,
-      "No active work needs attention right now."
-    ),
     cardListSection(
       "home-active-attention",
-      "Active / needs attention",
+      "Runtime summary",
       vm.runtime.activeTurns,
       (row) => runtimeTurnCard(row),
       "No active work needs attention right now."
     ),
     conversationListSection(
       "home-recent-results",
-      "Recent results",
+      "Recent results and artifacts",
       resultRows,
       "Recent results will appear here after Codex finishes work."
     ),
@@ -52,6 +46,7 @@ export function renderHomePage(vm: WebReadonlyHomeViewModel): string {
       (row) => workspaceCard(row),
       "Projects and workspaces will appear here once the bridge has recent workspace history."
     ),
+    utilityLinksPanel(),
     vm.warnings.length > 0 ? warnings(vm.warnings) : ""
   ]);
 }
@@ -97,8 +92,9 @@ export function renderConversationResultPage(vm: WebReadonlyConversationResultVi
     : [field("Status", "Unavailable"), field("Note", "This task is not available in the Web preview yet.")];
 
   return page("Task page", "none", [
-    hero("Task page", "Review the latest result, attention state, and activity for this conversation."),
-    `<section class="console-panel console-detail-heading" aria-labelledby="detail-heading"><p class="console-eyebrow">View-only preview</p><h2 id="detail-heading">${escapeHtml(title)}</h2><p><span class="console-badge">${escapeHtml(statusLabel(conversation?.status ?? vm.state))}</span> ${escapeHtml(statusCopy(conversation?.status ?? vm.state))}</p><div class="console-fields">${statusRows.join("")}</div></section>`,
+    hero("Conversation thread", "Read the selected Codex thread, latest result, attention state, and runtime summary."),
+    `<section class="console-panel console-detail-heading" aria-labelledby="detail-heading"><p class="console-eyebrow">Read-only thread</p><h2 id="detail-heading">${escapeHtml(title)}</h2><p><span class="console-badge">${escapeHtml(statusLabel(conversation?.status ?? vm.state))}</span> ${escapeHtml(statusCopy(conversation?.status ?? vm.state))}</p><div class="console-fields">${statusRows.join("")}</div></section>`,
+    disabledComposerPanel(vm.composer, conversation ? "This Web thread is read-only for Phase B." : "Choose an available conversation before sending from Web."),
     statusPanel(conversation?.status ?? vm.state),
     resultPanel(vm.answers),
     detailPendingPanel(vm.pendingInteractions.state, vm.pendingInteractions.pendingInteractions),
@@ -210,9 +206,9 @@ function page(title: string, active: NavKey, sections: string[]): string {
     "</head>",
     "<body class=\"console-shell\">",
     "<header class=\"console-shell__header\">",
-    "<div class=\"console-brand\"><p class=\"console-eyebrow\">Personal workspace</p><h1>Codex Console</h1><p class=\"console-posture\">View-only preview for continuing work and reviewing results.</p></div>",
+    "<div class=\"console-brand\"><p class=\"console-eyebrow\">Web Chat</p><h1>Codex Console</h1><p class=\"console-posture\">Chat-first, view-only preview for Codex Bridge work.</p></div>",
     "<nav class=\"console-shell__nav\" aria-label=\"Console navigation\">",
-    navLink("/", "Home", active === "home"),
+    navLink("/", "Chat", active === "home"),
     navLink("/workspaces", "Workspaces", active === "workspaces"),
     navLink("/interactions", "Pending", active === "pending"),
     navLink("/runtime", "Runtime", active === "runtime"),
@@ -353,6 +349,16 @@ a {
   display: grid;
   gap: 1rem;
 }
+.console-chat-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(min(100%, 320px), 0.85fr);
+  gap: 1rem;
+  align-items: start;
+}
+.console-thread-preview {
+  position: sticky;
+  top: 1rem;
+}
 .console-card-list {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
@@ -421,6 +427,27 @@ a {
   background: #101827;
   color: #eef4ff;
 }
+.console-composer {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.85rem;
+  border: 1px dashed rgba(36, 87, 214, 0.35);
+  border-radius: 18px;
+  background: var(--console-surface-soft);
+}
+.console-composer__box {
+  min-height: 4.25rem;
+  display: flex;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--console-border);
+  border-radius: 16px;
+  background: #ffffff;
+  color: var(--console-muted);
+}
+.console-composer p {
+  margin: 0;
+}
 .console-list {
   margin: 0;
   padding-left: 1.25rem;
@@ -440,6 +467,12 @@ a {
   .console-nav-link {
     flex: 1 1 auto;
     justify-content: center;
+  }
+  .console-chat-layout {
+    grid-template-columns: 1fr;
+  }
+  .console-thread-preview {
+    position: static;
   }
 }
 `.trim();
@@ -462,6 +495,42 @@ function cardListSection<T>(id: string, title: string, rows: T[], render: (row: 
     ? `<div class="console-card-list">${rows.map((row) => render(row)).join("")}</div>`
     : `<p class="console-empty">${escapeHtml(emptyCopy)}</p>`;
   return `<section class="console-section" aria-labelledby="${id}"><h2 id="${id}">${escapeHtml(title)}</h2>${body}</section>`;
+}
+
+function chatHomeSection(vm: WebReadonlyHomeViewModel): string {
+  const selected = vm.recentConversations[0] ?? null;
+  const queue = vm.recentConversations.length > 0
+    ? conversationListSection(
+      "chat-work-queue-list",
+      "Conversation work queue",
+      vm.recentConversations,
+      "No conversation threads are visible yet."
+    )
+    : `<section class="console-section" aria-labelledby="chat-work-queue-list"><h2 id="chat-work-queue-list">Conversation work queue</h2><p class="console-empty">No conversation threads are visible yet.</p></section>`;
+  const selectedPanel = selected
+    ? `<section class="console-panel console-thread-preview" aria-labelledby="selected-thread"><p class="console-eyebrow">Thread</p><h2 id="selected-thread">Selected thread preview</h2><article class="console-card"><h3>${cellHtml(conversationLink(selected.conversationHandle, selected.title))}</h3><p><span class="console-badge">${escapeHtml(statusLabel(selected.status))}</span> ${escapeHtml(conversationCopy(selected.status, selected.finalAnswerAvailable))}</p><div class="console-fields">${[
+      field("Last updated", selected.lastActivityAt),
+      field("Result", selected.finalAnswerAvailable ? "Available" : "Not ready yet"),
+      fieldHtml("Thread", cellHtml(conversationLink(selected.conversationHandle, "Open durable thread")))
+    ].join("")}</div></article>${disabledComposerPanel(vm.composer, "Open a thread to review more result, pending, and runtime details.")}</section>`
+    : `<section class="console-panel console-thread-preview" aria-labelledby="selected-thread"><p class="console-eyebrow">Thread</p><h2 id="selected-thread">Selected thread preview</h2><p class="console-empty">No thread selected. Conversation threads will appear here as Codex work is captured.</p>${disabledComposerPanel(vm.composer, "Choose a conversation when one is available.")}</section>`;
+
+  return `<section class="console-chat-layout" aria-label="Web Chat work queue">${queue}${selectedPanel}</section>`;
+}
+
+function disabledComposerPanel(
+  composer: WebReadonlyHomeViewModel["composer"],
+  note: string
+): string {
+  return `<section class="console-composer" aria-label="${escapeHtml(composer.label)}" aria-disabled="true"><div class="console-composer__box" role="textbox" aria-readonly="true" aria-disabled="true"><span>${escapeHtml(composer.placeholder)}</span></div><p><span class="console-badge">Read-only</span> ${escapeHtml(composer.disabledReason)} ${escapeHtml(note)}</p></section>`;
+}
+
+function utilityLinksPanel(): string {
+  return summaryPanel("Secondary utilities", [
+    fieldHtml("Runtime", '<a href="/runtime">Open runtime</a>'),
+    fieldHtml("Readiness", '<a href="/readiness">Open readiness</a>'),
+    fieldHtml("Pending", '<a href="/interactions">Open pending</a>')
+  ]);
 }
 
 function homeOwnerAttentionSection(state: string, rows: WebReadonlyPendingInteractionViewRow[]): string {

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -1,0 +1,258 @@
+import type {
+  WebReadonlyArtifactDescriptorRow,
+  WebReadonlyConversationArtifactCatalogViewModel,
+  WebReadonlyConversationResultViewModel,
+  WebReadonlyHomeViewModel,
+  WebReadonlyPendingInteractionViewRow,
+  WebReadonlyPendingInteractionsViewModel,
+  WebReadonlyReadinessGuardrailViewModel,
+  WebReadonlyRuntimeContextViewModel,
+  WebReadonlyWorkspaceConversationListViewModel,
+  WebReadonlyWorkspaceListViewModel
+} from "../service/web-readonly-view-model.js";
+
+export function renderHomePage(vm: WebReadonlyHomeViewModel): string {
+  return page("Codex Console Web prototype", [
+    section("Prototype", [
+      pair("Mode", "Read-only local prototype"),
+      pair("State", vm.state),
+      pair("Operator binding", vm.operator.binding),
+      pair("Runtime", vm.runtime.state),
+      pair("Readiness", vm.readiness.state)
+    ]),
+    table(
+      "Workspaces",
+      ["Workspace", "Conversations", "Pinned", "Last activity"],
+      vm.workspaces.map((row) => [row.label, String(row.conversationCount), yesNo(row.pinned), row.lastActivityAt ?? "—"])
+    ),
+    table(
+      "Recent conversations",
+      ["Conversation", "Status", "Last activity", "Final answer"],
+      vm.recentConversations.map((row) => [row.title, row.status, row.lastActivityAt, yesNo(row.finalAnswerAvailable)])
+    ),
+    table(
+      "Active turns",
+      ["Status", "Summary", "Blocked"],
+      vm.runtime.activeTurns.map((row) => [row.status, row.summary ?? "—", row.blockedReason ?? "—"])
+    ),
+    warnings(vm.warnings)
+  ]);
+}
+
+export function renderWorkspaceListPage(vm: WebReadonlyWorkspaceListViewModel): string {
+  return page("Workspaces", [
+    section("Read-only prototype", [pair("State", vm.state)]),
+    table(
+      "Workspaces",
+      ["Workspace", "Availability", "Conversations", "Pinned", "Last activity", "Source"],
+      vm.workspaces.map((row) => [
+        row.label,
+        row.availability,
+        String(row.conversationCount),
+        yesNo(row.pinned),
+        row.lastActivityAt ?? "—",
+        row.source
+      ])
+    ),
+    warnings(vm.warnings)
+  ]);
+}
+
+export function renderWorkspaceConversationListPage(vm: WebReadonlyWorkspaceConversationListViewModel): string {
+  return page("Workspace conversations", [
+    section("Read-only prototype", [pair("State", vm.state), pair("Empty state", vm.emptyState ?? "—")]),
+    table(
+      "Conversations",
+      ["Conversation", "Status", "Archived", "Created", "Last activity", "Final answer"],
+      vm.conversations.map((row) => [
+        row.title,
+        row.status,
+        yesNo(row.archived),
+        row.createdAt,
+        row.lastActivityAt,
+        yesNo(row.finalAnswerAvailable)
+      ])
+    ),
+    warnings(vm.warnings)
+  ]);
+}
+
+export function renderConversationResultPage(vm: WebReadonlyConversationResultViewModel): string {
+  const conversationRows = vm.conversation
+    ? [
+      pair("Conversation", vm.conversation.title),
+      pair("Workspace", vm.conversation.workspaceLabel),
+      pair("Status", vm.conversation.status),
+      pair("Archived", yesNo(vm.conversation.archived)),
+      pair("Created", vm.conversation.createdAt),
+      pair("Last activity", vm.conversation.lastActivityAt)
+    ]
+    : [pair("Conversation", "Unavailable")];
+
+  return page("Conversation result", [
+    section("Read-only prototype", [pair("State", vm.state), ...conversationRows]),
+    table(
+      "Final answers",
+      ["Kind", "Delivery", "Created", "Summary", "Body"],
+      vm.answers.map((answer) => [
+        answer.kind,
+        answer.deliveryState,
+        answer.createdAt,
+        answer.summary,
+        answer.body.state === "available" ? answer.body.text : answer.body.reason
+      ])
+    ),
+    warnings(vm.warnings)
+  ]);
+}
+
+export function renderConversationArtifactCatalogPage(vm: WebReadonlyConversationArtifactCatalogViewModel): string {
+  return page("Conversation artifacts", [
+    section("Read-only prototype", [pair("State", vm.state), pair("Empty state", vm.emptyState ?? "—")]),
+    table(
+      "Artifact descriptors",
+      ["Label", "Kind", "Type", "Size", "Availability", "Created"],
+      vm.artifacts.map((artifact) => artifactRow(artifact))
+    ),
+    vm.selectedArtifact ? section("Selected descriptor", [pair("Label", vm.selectedArtifact.label), pair("Availability", vm.selectedArtifact.availability)]) : "",
+    warnings(vm.warnings)
+  ]);
+}
+
+export function renderRuntimePage(vm: WebReadonlyRuntimeContextViewModel): string {
+  return page("Runtime", [
+    section("Read-only prototype", [pair("State", vm.state)]),
+    table(
+      "Active turns",
+      ["Status", "Summary", "Blocked"],
+      vm.activeTurns.map((row) => [row.status, row.summary ?? "—", row.blockedReason ?? "—"])
+    ),
+    warnings(vm.warnings)
+  ]);
+}
+
+export function renderPendingInteractionsPage(vm: WebReadonlyPendingInteractionsViewModel): string {
+  return page("Pending interactions", [
+    section("Read-only prototype", [pair("State", vm.state)]),
+    table(
+      "Pending interactions",
+      ["Status", "Kind", "Blocking reason", "Summary", "Created", "Availability"],
+      vm.pendingInteractions.map((row) => pendingInteractionRow(row))
+    ),
+    warnings(vm.warnings)
+  ]);
+}
+
+export function renderReadinessPage(vm: WebReadonlyReadinessGuardrailViewModel): string {
+  return page("Readiness", [
+    section("Read-only prototype", [pair("State", vm.state), pair("Checked at", vm.checkedAt ?? "—"), pair("Active pack", vm.activePack ?? "—")]),
+    table(
+      "Capabilities",
+      ["Capability", "Declared", "Configured", "Observed", "UX exposed"],
+      vm.capabilities.map((row) => [row.label, row.declared, row.configured, row.observed, row.uxExposed])
+    ),
+    list("Missing gates", vm.missingGates),
+    warnings(vm.warnings)
+  ]);
+}
+
+export function renderGenericNotFoundPage(): string {
+  return page("Not found", [section("Not found", ["The requested page is not available."])]);
+}
+
+export function renderGenericErrorPage(): string {
+  return page("Temporarily unavailable", [section("Temporarily unavailable", ["The read-only prototype could not render this page."])]);
+}
+
+export function escapeHtml(value: unknown): string {
+  return scrubText(String(value ?? ""))
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function page(title: string, sections: string[]): string {
+  return [
+    "<!doctype html>",
+    "<html lang=\"en\">",
+    "<head>",
+    "<meta charset=\"utf-8\">",
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
+    `<title>${escapeHtml(title)}</title>`,
+    "</head>",
+    "<body>",
+    `<h1>${escapeHtml(title)}</h1>`,
+    "<p>Local prototype · read-only · not a shipped or supported Web surface.</p>",
+    ...sections.filter(Boolean),
+    "</body>",
+    "</html>"
+  ].join("\n");
+}
+
+function section(title: string, rows: string[]): string {
+  return [`<section><h2>${escapeHtml(title)}</h2>`, ...rows.map((row) => `<p>${row}</p>`), "</section>"].join("\n");
+}
+
+function pair(label: string, value: unknown): string {
+  return `<strong>${escapeHtml(label)}:</strong> ${escapeHtml(value)}`;
+}
+
+function table(title: string, headings: string[], rows: unknown[][]): string {
+  const body = rows.length > 0
+    ? rows.map((row) => `<tr>${row.map((cell) => `<td>${escapeHtml(cell)}</td>`).join("")}</tr>`).join("\n")
+    : `<tr><td colspan="${headings.length}">${escapeHtml("No rows")}</td></tr>`;
+  return [
+    `<section><h2>${escapeHtml(title)}</h2>`,
+    "<table>",
+    `<thead><tr>${headings.map((heading) => `<th>${escapeHtml(heading)}</th>`).join("")}</tr></thead>`,
+    `<tbody>${body}</tbody>`,
+    "</table></section>"
+  ].join("\n");
+}
+
+function list(title: string, items: string[]): string {
+  const body = items.length > 0
+    ? items.map((item) => `<li>${escapeHtml(item)}</li>`).join("\n")
+    : `<li>${escapeHtml("None")}</li>`;
+  return `<section><h2>${escapeHtml(title)}</h2><ul>${body}</ul></section>`;
+}
+
+function warnings(items: string[]): string {
+  return list("Warnings", items);
+}
+
+function artifactRow(artifact: WebReadonlyArtifactDescriptorRow): string[] {
+  return [
+    artifact.label,
+    artifact.kind,
+    artifact.type ?? artifact.mediaType ?? "—",
+    artifact.sizeBytes === null ? "—" : String(artifact.sizeBytes),
+    artifact.availability,
+    artifact.createdAt ?? "—"
+  ];
+}
+
+function pendingInteractionRow(row: WebReadonlyPendingInteractionViewRow): string[] {
+  return [
+    row.status,
+    row.kind,
+    row.blockingReason,
+    row.summary.state === "available" ? row.summary.text : row.summary.reason,
+    row.createdAt ?? "—",
+    row.availability
+  ];
+}
+
+function yesNo(value: boolean): string {
+  return value ? "yes" : "no";
+}
+
+function scrubText(value: string): string {
+  return value
+    .replace(/\b(submit|approve|interrupt|upload|switch|resume)\b/gi, "[redacted]")
+    .replace(/\b(callback(?:_data)?|messageId|deliveryMessageId|telegramChatId|feishuChatId|chatId|threadId|token)\s*[:=]\s*[^\s<>"']+/gi, "[redacted]")
+    .replace(/\b[A-Z][A-Z0-9_]{2,}=\S+/g, "[redacted-env]")
+    .replace(/(?:^|\s)(\/(?:home|tmp|var|etc|root|Users|usr)\/[^\s<>"']*)/g, (match, path: string) => match.replace(path, "[redacted-path]"));
+}

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -21,49 +21,49 @@ interface SafeHtmlCell {
 type NavKey = "home" | "workspaces" | "pending" | "runtime" | "readiness" | "none";
 
 export function renderHomePage(vm: WebReadonlyHomeViewModel): string {
-  const pendingCount = vm.runtime.activeTurns.filter((row) => isAttentionState(row.status) || Boolean(row.blockedReason)).length;
+  const continueRows = vm.recentConversations.filter((row) => conversationGroup(row.status) !== "completed");
+  const resultRows = vm.recentConversations.filter((row) => row.finalAnswerAvailable || conversationGroup(row.status) === "completed");
   return page("Home", "home", [
-    hero("Owner preview", "Read-only prototype for understanding current workspace, conversation/task, runtime, pending, and readiness state."),
-    `<section class="console-section" aria-labelledby="home-orientation"><h2 id="home-orientation">Current state</h2><div class="console-card-grid">${[
-      metricCard("Runtime", vm.runtime.state, runtimeCopy(vm.runtime.state, vm.runtime.activeTurns.length)),
-      metricCard("Pending attention", String(pendingCount), pendingCount === 0 ? "No blocked task is visible in this read-only preview." : "One or more conversation/tasks may need owner attention."),
-      metricCard("Operator", vm.operator.binding, vm.operator.binding === "available" ? "Private owner binding is available for this preview." : "Owner binding is unavailable; visible data may be incomplete."),
-      metricCard("Readiness", vm.readiness.state, readinessCopy(vm.readiness.state, vm.readiness.missingGates.length))
-    ].join("")}</div></section>`,
-    cardListSection(
-      "home-workspaces",
-      "Workspaces",
-      vm.workspaces,
-      (row) => workspaceCard(row),
-      "Workspace data is unavailable in this read-only preview."
-    ),
+    hero("Codex Console", "Your personal console for continuing Codex work, reviewing results, and browsing projects."),
     conversationListSection(
-      "home-recent-conversations",
-      "Recent conversations",
-      vm.recentConversations,
-      "No recent conversation/task data is available yet."
+      "home-continue-working",
+      "Continue working",
+      continueRows,
+      "No active work needs attention right now."
     ),
     cardListSection(
-      "home-active-turns",
-      "Active turns",
+      "home-active-attention",
+      "Active / needs attention",
       vm.runtime.activeTurns,
       (row) => runtimeTurnCard(row),
-      "No active task is known."
+      "No active work needs attention right now."
     ),
-    warnings(vm.warnings)
+    conversationListSection(
+      "home-recent-results",
+      "Recent results",
+      resultRows,
+      "Recent results will appear here after Codex finishes work."
+    ),
+    cardListSection(
+      "home-workspaces",
+      "Projects / workspaces",
+      vm.workspaces,
+      (row) => workspaceCard(row),
+      "Projects and workspaces will appear here once the bridge has recent workspace history."
+    ),
+    vm.warnings.length > 0 ? warnings(vm.warnings) : ""
   ]);
 }
 
 export function renderWorkspaceListPage(vm: WebReadonlyWorkspaceListViewModel): string {
   return page("Workspaces", "workspaces", [
-    hero("Workspaces", "Browse safe workspace context. Opening a workspace only reads conversation/task state."),
-    summaryPanel("Workspace status", [field("State", vm.state), field("Posture", "Read-only owner preview")]),
+    hero("Projects / workspaces", "Browse projects with recent Codex conversations and open the work you want to review."),
     cardListSection(
       "workspace-list",
-      "Workspace list",
+      "Projects / workspaces",
       vm.workspaces,
       (row) => workspaceCard(row),
-      "Workspace data is unavailable or no workspaces are visible."
+      "Projects and workspaces will appear here once the bridge has recent workspace history."
     ),
     warnings(vm.warnings)
   ]);
@@ -71,13 +71,12 @@ export function renderWorkspaceListPage(vm: WebReadonlyWorkspaceListViewModel): 
 
 export function renderWorkspaceConversationListPage(vm: WebReadonlyWorkspaceConversationListViewModel): string {
   return page("Workspace conversations", "workspaces", [
-    hero("Workspace conversations", "Open a conversation/task detail page through an opaque Console handle."),
-    summaryPanel("Conversation list status", [field("State", vm.state), field("Empty state", vm.emptyState ?? "—")]),
+    hero("Workspace conversations", "Pick a task or recent result from this workspace."),
     conversationListSection(
       "workspace-conversations",
-      "Conversations/tasks",
+      "Conversations",
       vm.conversations,
-      vm.emptyState === "no_conversations" ? "No conversation/task rows are visible for this workspace." : "Conversation/task data is unavailable."
+      vm.emptyState === "no_conversations" ? "No conversations are visible for this workspace yet." : "Conversations will appear here when workspace history is available."
     ),
     warnings(vm.warnings)
   ]);
@@ -89,20 +88,19 @@ export function renderConversationResultPage(vm: WebReadonlyConversationResultVi
   const statusRows = conversation
     ? [
       field("Workspace", conversation.workspaceLabel),
-      field("State", statusLabel(conversation.status)),
-      field("Status note", statusCopy(conversation.status)),
-      field("Archived", yesNo(conversation.archived)),
+      field("Status", statusLabel(conversation.status)),
+      field("Last updated", conversation.lastActivityAt),
       field("Created", conversation.createdAt),
-      field("Last activity", conversation.lastActivityAt)
+      field("Archive", conversation.archived ? "Archived" : "Active")
     ]
-    : [field("State", "Unavailable"), field("Note", "Conversation/task data is unavailable from the safe read model.")];
+    : [field("Status", "Unavailable"), field("Note", "This task is not available in the Web preview yet.")];
 
-  return page("Conversation/task detail", "none", [
-    hero("Conversation/task detail", "Read-only owner preview. Result, pending state, runtime, readiness, and warnings are separated for safe review."),
-    `<section class="console-panel console-detail-heading" aria-labelledby="detail-heading"><h2 id="detail-heading">${escapeHtml(title)}</h2><div class="console-fields">${statusRows.join("")}</div></section>`,
+  return page("Task page", "none", [
+    hero("Task page", "Review the latest result, attention state, and activity for this conversation."),
+    `<section class="console-panel console-detail-heading" aria-labelledby="detail-heading"><p class="console-eyebrow">View-only preview</p><h2 id="detail-heading">${escapeHtml(title)}</h2><p><span class="console-badge">${escapeHtml(statusLabel(conversation?.status ?? vm.state))}</span> ${escapeHtml(statusCopy(conversation?.status ?? vm.state))}</p><div class="console-fields">${statusRows.join("")}</div></section>`,
     statusPanel(conversation?.status ?? vm.state),
     resultPanel(vm.answers),
-    pendingPanel(vm.pendingInteractions.state, vm.pendingInteractions.pendingInteractions),
+    detailPendingPanel(vm.pendingInteractions.state, vm.pendingInteractions.pendingInteractions),
     runtimePanel(vm.runtime.state, vm.runtime.activeTurns),
     readinessPanel(vm.readiness.state, vm.readiness.missingGates),
     warnings(vm.warnings)
@@ -210,7 +208,7 @@ function page(title: string, active: NavKey, sections: string[]): string {
     "</head>",
     "<body class=\"console-shell\">",
     "<header class=\"console-shell__header\">",
-    "<div class=\"console-brand\"><p class=\"console-eyebrow\">Owner preview · read-only prototype</p><h1>Codex Console</h1><p class=\"console-posture\">Private, denied-by-default Console preview. Runtime data is read-only. Actions are not enabled.</p></div>",
+    "<div class=\"console-brand\"><p class=\"console-eyebrow\">Personal workspace</p><h1>Codex Console</h1><p class=\"console-posture\">View-only preview for continuing work and reviewing results.</p></div>",
     "<nav class=\"console-shell__nav\" aria-label=\"Console navigation\">",
     navLink("/", "Home", active === "home"),
     navLink("/workspaces", "Workspaces", active === "workspaces"),
@@ -234,10 +232,6 @@ function navLink(href: string, label: string, active: boolean): string {
 
 function hero(label: string, body: string): string {
   return `<section class="console-hero" aria-labelledby="page-heading"><p class="console-eyebrow">${escapeHtml(label)}</p><h2 id="page-heading">${escapeHtml(label)}</h2><p>${escapeHtml(body)}</p></section>`;
-}
-
-function metricCard(label: string, value: string, body: string): string {
-  return `<article class="console-card"><p class="console-eyebrow">${escapeHtml(label)}</p><p class="console-metric">${escapeHtml(value)}</p><p>${escapeHtml(body)}</p></article>`;
 }
 
 function summaryPanel(title: string, rows: string[]): string {
@@ -279,28 +273,50 @@ function statusPanel(status: string): string {
 
 function resultPanel(answers: WebReadonlyConversationResultViewModel["answers"]): string {
   if (answers.length === 0) {
-    return `<section class="console-panel console-result" aria-labelledby="result-heading"><h2 id="result-heading">Final answer/result</h2><p class="console-empty">Final answer body unavailable: this run has no sanitized Web-readable answer source yet.</p></section>`;
+    return `<section class="console-panel console-result" aria-labelledby="result-heading"><h2 id="result-heading">Result</h2><p class="console-empty">No Web-ready final answer has been captured yet. When Codex finishes with a shareable result, it will appear in this panel.</p></section>`;
   }
 
   const cards = answers.map((answer) => {
     const body = answer.body.state === "available"
       ? `<pre class="console-result-body">${escapeHtml(answer.body.text)}</pre>`
       : `<p class="console-empty">${escapeHtml(finalAnswerUnavailableCopy(answer.body.reason))}</p>`;
-    return `<article class="console-card console-result-card"><h3>${escapeHtml(answer.kind)}</h3><div class="console-fields">${[
-      field("Delivery", answer.deliveryState),
+    return `<article class="console-card console-result-card"><h3>${escapeHtml(answerKindLabel(answer.kind))}</h3><div class="console-fields">${[
+      field("Delivery", deliveryLabel(answer.deliveryState)),
       field("Created", answer.createdAt),
-      field("Summary", answer.summary)
+      field("Summary", resultSummary(answer))
     ].join("")}</div>${body}</article>`;
   }).join("");
 
-  return `<section class="console-panel console-result" aria-labelledby="result-heading"><h2 id="result-heading">Final answer/result</h2><div class="console-card-list">${cards}</div></section>`;
+  return `<section class="console-panel console-result" aria-labelledby="result-heading"><h2 id="result-heading">Result</h2><div class="console-card-list">${cards}</div></section>`;
 }
 
 function finalAnswerUnavailableCopy(reason: string): string {
   if (reason === "unsafe_final_answer_body") {
-    return "Final answer body unavailable: supplied answer text was rejected by the Web safety filter.";
+    return "This result is available in the bridge conversation, but it is not shown in the Web preview yet.";
   }
-  return "Result metadata is available, but the answer text was not captured in a Web-safe format.";
+  return "Result metadata is available, but the answer text has not been captured for this Web preview yet.";
+}
+
+function answerKindLabel(kind: string): string {
+  const normalized = kind.toLowerCase();
+  if (normalized.includes("final")) return "Final answer";
+  if (normalized.includes("summary")) return "Summary";
+  return "Result";
+}
+
+function deliveryLabel(state: string): string {
+  const normalized = state.toLowerCase();
+  if (normalized.includes("deliver")) return "Delivered";
+  if (normalized.includes("pending")) return "Pending";
+  if (normalized.includes("fail")) return "Not delivered";
+  return statusLabel(state);
+}
+
+function resultSummary(answer: WebReadonlyConversationResultViewModel["answers"][number]): string {
+  if (answer.body.state === "unavailable") {
+    return "Result metadata was captured, but the answer text is only available outside this Web preview.";
+  }
+  return answer.summary;
 }
 
 function runtimePanel(state: string, rows: WebReadonlyRuntimeTurnRow[]): string {
@@ -315,6 +331,10 @@ function runtimePanel(state: string, rows: WebReadonlyRuntimeTurnRow[]): string 
 
 function pendingPanel(state: string, rows: WebReadonlyPendingInteractionViewRow[]): string {
   return pendingInteractionListSection("pending-heading", "Pending interactions", state, rows);
+}
+
+function detailPendingPanel(state: string, rows: WebReadonlyPendingInteractionViewRow[]): string {
+  return pendingInteractionListSection("attention-heading", "Needs attention", state, rows);
 }
 
 function readinessPanel(state: string, missingGates: string[]): string {
@@ -359,18 +379,28 @@ function listItems(items: string[], emptyCopy: string): string {
 
 function workspaceCard(row: WebReadonlyWorkspaceRow): string {
   return `<article class="console-card"><h3>${cellHtml(workspaceLink(row.workspaceId, row.label))}</h3><div class="console-fields">${[
-    field("Availability", row.availability),
+    field("Status", availabilityLabel(row.availability)),
     field("Conversations", String(row.conversationCount)),
     field("Pinned", yesNo(row.pinned)),
-    field("Last activity", row.lastActivityAt ?? "—")
+    field("Last updated", row.lastActivityAt ?? "—"),
+    fieldHtml("Open", cellHtml(workspaceLink(row.workspaceId, "Open")))
   ].join("")}</div></article>`;
+}
+
+function availabilityLabel(state: string): string {
+  const normalized = state.toLowerCase();
+  if (normalized.includes("available") || normalized === "present") return "Available";
+  if (normalized.includes("degraded") || normalized.includes("partial")) return "Partial";
+  if (normalized.includes("empty")) return "No recent work";
+  return "Unavailable";
 }
 
 function conversationCard(row: WebReadonlyConversationRow): string {
   return `<article class="console-card"><h3>${cellHtml(conversationLink(row.conversationHandle, row.title))}</h3><p><span class="console-badge">${escapeHtml(statusLabel(row.status))}</span> ${escapeHtml(conversationCopy(row.status, row.finalAnswerAvailable))}</p><div class="console-fields">${[
-    field("Last activity", row.lastActivityAt),
-    field("Final result", row.finalAnswerAvailable ? "available" : "unavailable"),
-    field("Archived", yesNo(row.archived))
+    field("Last updated", row.lastActivityAt),
+    field("Result", row.finalAnswerAvailable ? "Available" : "Not ready yet"),
+    field("Archive", row.archived ? "Archived" : "Active"),
+    fieldHtml("Open", cellHtml(conversationLink(row.conversationHandle, "Open")))
   ].join("")}</div></article>`;
 }
 
@@ -473,10 +503,6 @@ function warnings(items: string[]): string {
 
 function yesNo(value: boolean): string {
   return value ? "yes" : "no";
-}
-
-function isAttentionState(status: string): boolean {
-  return /pending|blocked|question|approval|needs/i.test(status);
 }
 
 function conversationGroup(status: string): "attention" | "running" | "completed" | "other" {

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -2,191 +2,175 @@ import type {
   WebReadonlyArtifactDescriptorRow,
   WebReadonlyConversationArtifactCatalogViewModel,
   WebReadonlyConversationResultViewModel,
+  WebReadonlyConversationRow,
   WebReadonlyHomeViewModel,
   WebReadonlyPendingInteractionViewRow,
   WebReadonlyPendingInteractionsViewModel,
   WebReadonlyReadinessGuardrailViewModel,
   WebReadonlyRuntimeContextViewModel,
+  WebReadonlyRuntimeTurnRow,
   WebReadonlyWorkspaceConversationListViewModel,
-  WebReadonlyWorkspaceListViewModel
+  WebReadonlyWorkspaceListViewModel,
+  WebReadonlyWorkspaceRow
 } from "../service/web-readonly-view-model.js";
 
 interface SafeHtmlCell {
   __safeHtml: string;
 }
 
+type NavKey = "home" | "workspaces" | "pending" | "runtime" | "readiness" | "none";
+
 export function renderHomePage(vm: WebReadonlyHomeViewModel): string {
-  return page("Codex Console Web prototype", [
-    section("Prototype", [
-      pair("Mode", "Read-only local prototype"),
-      pair("State", vm.state),
-      pair("Operator binding", vm.operator.binding),
-      pair("Runtime", vm.runtime.state),
-      pair("Readiness", vm.readiness.state)
-    ]),
-    table(
+  const pendingCount = vm.runtime.activeTurns.filter((row) => isAttentionState(row.status) || Boolean(row.blockedReason)).length;
+  return page("Home", "home", [
+    hero("Owner preview", "Read-only prototype for understanding current workspace, conversation/task, runtime, pending, and readiness state."),
+    `<section class="console-section" aria-labelledby="home-orientation"><h2 id="home-orientation">Current state</h2><div class="console-card-grid">${[
+      metricCard("Runtime", vm.runtime.state, runtimeCopy(vm.runtime.state, vm.runtime.activeTurns.length)),
+      metricCard("Pending attention", String(pendingCount), pendingCount === 0 ? "No blocked task is visible in this read-only preview." : "One or more conversation/tasks may need owner attention."),
+      metricCard("Operator", vm.operator.binding, vm.operator.binding === "available" ? "Private owner binding is available for this preview." : "Owner binding is unavailable; visible data may be incomplete."),
+      metricCard("Readiness", vm.readiness.state, readinessCopy(vm.readiness.state, vm.readiness.missingGates.length))
+    ].join("")}</div></section>`,
+    cardListSection(
+      "home-workspaces",
       "Workspaces",
-      ["Workspace", "Conversations", "Pinned", "Last activity"],
-      vm.workspaces.map((row) => [
-        workspaceLink(row.workspaceId, row.label),
-        String(row.conversationCount),
-        yesNo(row.pinned),
-        row.lastActivityAt ?? "—"
-      ])
+      vm.workspaces,
+      (row) => workspaceCard(row),
+      "Workspace data is unavailable in this read-only preview."
     ),
-    table(
+    cardListSection(
+      "home-recent-conversations",
       "Recent conversations",
-      ["Conversation", "Status", "Last activity", "Final answer"],
-      vm.recentConversations.map((row) => [
-        conversationLink(row.conversationHandle, row.title),
-        row.status,
-        row.lastActivityAt,
-        yesNo(row.finalAnswerAvailable)
-      ])
+      vm.recentConversations,
+      (row) => conversationCard(row),
+      "No recent conversation/task data is available yet."
     ),
-    table(
+    cardListSection(
+      "home-active-turns",
       "Active turns",
-      ["Status", "Summary", "Blocked"],
-      vm.runtime.activeTurns.map((row) => [row.status, row.summary ?? "—", row.blockedReason ?? "—"])
+      vm.runtime.activeTurns,
+      (row) => runtimeTurnCard(row),
+      "No active task is known."
     ),
     warnings(vm.warnings)
   ]);
 }
 
 export function renderWorkspaceListPage(vm: WebReadonlyWorkspaceListViewModel): string {
-  return page("Workspaces", [
-    section("Read-only prototype", [pair("State", vm.state)]),
-    table(
-      "Workspaces",
-      ["Workspace", "Availability", "Conversations", "Pinned", "Last activity", "Source"],
-      vm.workspaces.map((row) => [
-        workspaceLink(row.workspaceId, row.label),
-        row.availability,
-        String(row.conversationCount),
-        yesNo(row.pinned),
-        row.lastActivityAt ?? "—",
-        row.source
-      ])
+  return page("Workspaces", "workspaces", [
+    hero("Workspaces", "Browse safe workspace context. Opening a workspace only reads conversation/task state."),
+    summaryPanel("Workspace status", [field("State", vm.state), field("Posture", "Read-only owner preview")]),
+    cardListSection(
+      "workspace-list",
+      "Workspace list",
+      vm.workspaces,
+      (row) => workspaceCard(row),
+      "Workspace data is unavailable or no workspaces are visible."
     ),
     warnings(vm.warnings)
   ]);
 }
 
 export function renderWorkspaceConversationListPage(vm: WebReadonlyWorkspaceConversationListViewModel): string {
-  return page("Workspace conversations", [
-    section("Read-only prototype", [pair("State", vm.state), pair("Empty state", vm.emptyState ?? "—")]),
-    table(
-      "Conversations",
-      ["Conversation", "Status", "Archived", "Created", "Last activity", "Final answer"],
-      vm.conversations.map((row) => [
-        conversationLink(row.conversationHandle, row.title),
-        row.status,
-        yesNo(row.archived),
-        row.createdAt,
-        row.lastActivityAt,
-        yesNo(row.finalAnswerAvailable)
-      ])
+  return page("Workspace conversations", "workspaces", [
+    hero("Workspace conversations", "Open a conversation/task detail page through an opaque Console handle."),
+    summaryPanel("Conversation list status", [field("State", vm.state), field("Empty state", vm.emptyState ?? "—")]),
+    cardListSection(
+      "workspace-conversations",
+      "Conversations/tasks",
+      vm.conversations,
+      (row) => conversationCard(row),
+      vm.emptyState === "no_conversations" ? "No conversation/task rows are visible for this workspace." : "Conversation/task data is unavailable."
     ),
     warnings(vm.warnings)
   ]);
 }
 
 export function renderConversationResultPage(vm: WebReadonlyConversationResultViewModel): string {
-  const conversationRows = vm.conversation
+  const conversation = vm.conversation;
+  const title = conversation?.title ?? "Conversation unavailable";
+  const statusRows = conversation
     ? [
-      pair("Conversation", vm.conversation.title),
-      pair("Workspace", vm.conversation.workspaceLabel),
-      pair("Status", vm.conversation.status),
-      pair("Archived", yesNo(vm.conversation.archived)),
-      pair("Created", vm.conversation.createdAt),
-      pair("Last activity", vm.conversation.lastActivityAt)
+      field("Workspace", conversation.workspaceLabel),
+      field("State", conversation.status),
+      field("Archived", yesNo(conversation.archived)),
+      field("Created", conversation.createdAt),
+      field("Last activity", conversation.lastActivityAt)
     ]
-    : [pair("Conversation", "Unavailable")];
+    : [field("State", "Unavailable"), field("Note", "Conversation/task data is unavailable from the safe read model.")];
 
-  return page("Conversation result", [
-    section("Read-only prototype", [pair("State", vm.state), ...conversationRows]),
-    table(
-      "Final answers",
-      ["Kind", "Delivery", "Created", "Summary", "Body"],
-      vm.answers.map((answer) => [
-        answer.kind,
-        answer.deliveryState,
-        answer.createdAt,
-        answer.summary,
-        answer.body.state === "available" ? answer.body.text : answer.body.reason
-      ])
-    ),
-    table(
-      "Runtime",
-      ["Status", "Summary", "Blocked"],
-      vm.runtime.activeTurns.map((row) => [row.status, row.summary ?? "—", row.blockedReason ?? "—"])
-    ),
-    table(
-      "Pending interactions",
-      ["Status", "Kind", "Blocking reason", "Summary", "Created", "Availability"],
-      vm.pendingInteractions.pendingInteractions.map((row) => pendingInteractionRow(row))
-    ),
-    list("Readiness missing gates", vm.readiness.missingGates),
+  return page("Conversation/task detail", "none", [
+    hero("Conversation/task detail", "Read-only owner preview. Result, pending state, runtime, readiness, and warnings are separated for safe review."),
+    `<section class="console-panel console-detail-heading" aria-labelledby="detail-heading"><h2 id="detail-heading">${escapeHtml(title)}</h2><div class="console-fields">${statusRows.join("")}</div></section>`,
+    statusPanel(conversation?.status ?? vm.state),
+    resultPanel(vm.answers),
+    pendingPanel(vm.pendingInteractions.state, vm.pendingInteractions.pendingInteractions),
+    runtimePanel(vm.runtime.state, vm.runtime.activeTurns),
+    readinessPanel(vm.readiness.state, vm.readiness.missingGates),
     warnings(vm.warnings)
   ]);
 }
 
 export function renderConversationArtifactCatalogPage(vm: WebReadonlyConversationArtifactCatalogViewModel): string {
-  return page("Conversation artifacts", [
-    section("Read-only prototype", [pair("State", vm.state), pair("Empty state", vm.emptyState ?? "—")]),
-    table(
+  return page("Conversation artifacts", "none", [
+    hero("Artifact descriptors", "Descriptor-only artifact availability. This preview does not expose file content."),
+    summaryPanel("Artifact status", [field("State", vm.state), field("Empty state", vm.emptyState ?? "—")]),
+    cardListSection(
+      "artifact-descriptors",
       "Artifact descriptors",
-      ["Label", "Kind", "Type", "Size", "Availability", "Created"],
-      vm.artifacts.map((artifact) => artifactRow(artifact))
+      vm.artifacts,
+      (artifact) => artifactCard(artifact),
+      "No artifact descriptors are available."
     ),
-    vm.selectedArtifact ? section("Selected descriptor", [pair("Label", vm.selectedArtifact.label), pair("Availability", vm.selectedArtifact.availability)]) : "",
+    vm.selectedArtifact ? summaryPanel("Selected descriptor", [field("Label", vm.selectedArtifact.label), field("Availability", vm.selectedArtifact.availability)]) : "",
     warnings(vm.warnings)
   ]);
 }
 
 export function renderRuntimePage(vm: WebReadonlyRuntimeContextViewModel): string {
-  return page("Runtime", [
-    section("Read-only prototype", [pair("State", vm.state)]),
-    table(
-      "Active turns",
-      ["Status", "Summary", "Blocked"],
-      vm.activeTurns.map((row) => [row.status, row.summary ?? "—", row.blockedReason ?? "—"])
-    ),
+  return page("Runtime", "runtime", [
+    hero("Runtime", "Read-only runtime state. Use it to understand whether Codex is idle, running, blocked, degraded, or unavailable."),
+    summaryPanel("Runtime status", [field("State", vm.state), field("Active turns", String(vm.activeTurns.length))]),
+    runtimePanel(vm.state, vm.activeTurns),
     warnings(vm.warnings)
   ]);
 }
 
 export function renderPendingInteractionsPage(vm: WebReadonlyPendingInteractionsViewModel): string {
-  return page("Pending interactions", [
-    section("Read-only prototype", [pair("State", vm.state)]),
-    table(
-      "Pending interactions",
-      ["Status", "Kind", "Blocking reason", "Summary", "Created", "Availability"],
-      vm.pendingInteractions.map((row) => pendingInteractionRow(row))
-    ),
+  return page("Pending", "pending", [
+    hero("Pending", "Read-only view of approvals, questions, and other owner attention states. Responses are not enabled in this preview."),
+    summaryPanel("Pending status", [field("State", vm.state), field("Visible items", String(vm.pendingInteractions.length))]),
+    pendingPanel(vm.state, vm.pendingInteractions),
     warnings(vm.warnings)
   ]);
 }
 
 export function renderReadinessPage(vm: WebReadonlyReadinessGuardrailViewModel): string {
-  return page("Readiness", [
-    section("Read-only prototype", [pair("State", vm.state), pair("Checked at", vm.checkedAt ?? "—"), pair("Active pack", vm.activePack ?? "—")]),
-    table(
+  return page("Readiness", "readiness", [
+    hero("Readiness", "Guardrail state for this private Console preview. Readiness is not a public support claim."),
+    summaryPanel("Readiness status", [field("State", vm.state), field("Checked at", vm.checkedAt ?? "—"), field("Active pack", vm.activePack ?? "—")]),
+    cardListSection(
+      "readiness-capabilities",
       "Capabilities",
-      ["Capability", "Declared", "Configured", "Observed", "UX exposed"],
-      vm.capabilities.map((row) => [row.label, row.declared, row.configured, row.observed, row.uxExposed])
+      vm.capabilities,
+      (row) => `<article class="console-card"><h3>${escapeHtml(row.label)}</h3><div class="console-fields">${[
+        field("Declared", row.declared),
+        field("Configured", row.configured),
+        field("Observed", row.observed),
+        field("UX exposed", row.uxExposed)
+      ].join("")}</div></article>`,
+      "No capability rows are available."
     ),
-    list("Missing gates", vm.missingGates),
+    listPanel("Missing gates", vm.missingGates, "No missing gates are visible."),
     warnings(vm.warnings)
   ]);
 }
 
 export function renderGenericNotFoundPage(): string {
-  return page("Not found", [section("Not found", ["The requested page is not available."])]);
+  return page("Not found", "none", [summaryPanel("Not found", ["The requested page is not available."])]);
 }
 
 export function renderGenericErrorPage(): string {
-  return page("Temporarily unavailable", [section("Temporarily unavailable", ["The read-only prototype could not render this page."])]);
+  return page("Temporarily unavailable", "none", [summaryPanel("Temporarily unavailable", ["The read-only Console preview could not render this page."])]);
 }
 
 export function escapeHtml(value: unknown): string {
@@ -198,43 +182,162 @@ export function escapeHtml(value: unknown): string {
     .replaceAll("'", "&#39;");
 }
 
-function page(title: string, sections: string[]): string {
+function page(title: string, active: NavKey, sections: string[]): string {
   return [
     "<!doctype html>",
     "<html lang=\"en\">",
     "<head>",
     "<meta charset=\"utf-8\">",
     "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
-    `<title>${escapeHtml(title)}</title>`,
+    `<title>${escapeHtml(title)} · Codex Console</title>`,
     "</head>",
-    "<body>",
-    `<h1>${escapeHtml(title)}</h1>`,
-    "<p>Local prototype · read-only · not a shipped or supported Web surface.</p>",
+    "<body class=\"console-shell\">",
+    "<header class=\"console-shell__header\">",
+    "<div class=\"console-brand\"><p class=\"console-eyebrow\">Owner preview · read-only prototype</p><h1>Codex Console</h1><p class=\"console-posture\">Private, denied-by-default Console preview. Runtime data is read-only and action lanes are not enabled.</p></div>",
+    "<nav class=\"console-shell__nav\" aria-label=\"Console navigation\">",
+    navLink("/", "Home", active === "home"),
+    navLink("/workspaces", "Workspaces", active === "workspaces"),
+    navLink("/interactions", "Pending", active === "pending"),
+    navLink("/runtime", "Runtime", active === "runtime"),
+    navLink("/readiness", "Readiness", active === "readiness"),
+    "</nav>",
+    "</header>",
+    "<main class=\"console-shell__main\">",
     ...sections.filter(Boolean),
+    "</main>",
     "</body>",
     "</html>"
   ].join("\n");
 }
 
-function section(title: string, rows: string[]): string {
-  return [`<section><h2>${escapeHtml(title)}</h2>`, ...rows.map((row) => `<p>${row}</p>`), "</section>"].join("\n");
+function navLink(href: string, label: string, active: boolean): string {
+  const current = active ? " aria-current=\"page\"" : "";
+  return `<a class="console-nav-link" href="${href}"${current}>${escapeHtml(label)}</a>`;
 }
 
-function pair(label: string, value: unknown): string {
-  return `<strong>${escapeHtml(label)}:</strong> ${escapeHtml(value)}`;
+function hero(label: string, body: string): string {
+  return `<section class="console-hero" aria-labelledby="page-heading"><p class="console-eyebrow">${escapeHtml(label)}</p><h2 id="page-heading">${escapeHtml(label)}</h2><p>${escapeHtml(body)}</p></section>`;
 }
 
-function table(title: string, headings: string[], rows: Array<Array<unknown | SafeHtmlCell>>): string {
+function metricCard(label: string, value: string, body: string): string {
+  return `<article class="console-card"><p class="console-eyebrow">${escapeHtml(label)}</p><p class="console-metric">${escapeHtml(value)}</p><p>${escapeHtml(body)}</p></article>`;
+}
+
+function summaryPanel(title: string, rows: string[]): string {
+  return `<section class="console-panel" aria-labelledby="${slug(title)}"><h2 id="${slug(title)}">${escapeHtml(title)}</h2><div class="console-fields">${rows.map((row) => `<p>${row}</p>`).join("")}</div></section>`;
+}
+
+function cardListSection<T>(id: string, title: string, rows: T[], render: (row: T) => string, emptyCopy: string): string {
   const body = rows.length > 0
-    ? rows.map((row) => `<tr>${row.map((cell) => `<td>${cellHtml(cell)}</td>`).join("")}</tr>`).join("\n")
-    : `<tr><td colspan="${headings.length}">${escapeHtml("No rows")}</td></tr>`;
-  return [
-    `<section><h2>${escapeHtml(title)}</h2>`,
-    "<table>",
-    `<thead><tr>${headings.map((heading) => `<th>${escapeHtml(heading)}</th>`).join("")}</tr></thead>`,
-    `<tbody>${body}</tbody>`,
-    "</table></section>"
-  ].join("\n");
+    ? `<div class="console-card-list">${rows.map((row) => render(row)).join("")}</div>`
+    : `<p class="console-empty">${escapeHtml(emptyCopy)}</p>`;
+  return `<section class="console-section" aria-labelledby="${id}"><h2 id="${id}">${escapeHtml(title)}</h2>${body}</section>`;
+}
+
+function statusPanel(status: string): string {
+  return `<section class="console-panel" aria-labelledby="status-heading"><h2 id="status-heading">Status</h2><p><span class="console-badge">${escapeHtml(statusLabel(status))}</span> ${escapeHtml(statusCopy(status))}</p></section>`;
+}
+
+function resultPanel(answers: WebReadonlyConversationResultViewModel["answers"]): string {
+  if (answers.length === 0) {
+    return `<section class="console-panel console-result" aria-labelledby="result-heading"><h2 id="result-heading">Final answer/result</h2><p class="console-empty">Final answer body unavailable: this run has no sanitized Web-readable answer source yet.</p></section>`;
+  }
+
+  const cards = answers.map((answer) => {
+    const body = answer.body.state === "available"
+      ? `<pre class="console-result-body">${escapeHtml(answer.body.text)}</pre>`
+      : `<p class="console-empty">Result metadata is available, but the answer text was not captured in a Web-safe format.</p>`;
+    return `<article class="console-card console-result-card"><h3>${escapeHtml(answer.kind)}</h3><div class="console-fields">${[
+      field("Delivery", answer.deliveryState),
+      field("Created", answer.createdAt),
+      field("Summary", answer.summary)
+    ].join("")}</div>${body}</article>`;
+  }).join("");
+
+  return `<section class="console-panel console-result" aria-labelledby="result-heading"><h2 id="result-heading">Final answer/result</h2><div class="console-card-list">${cards}</div></section>`;
+}
+
+function runtimePanel(state: string, rows: WebReadonlyRuntimeTurnRow[]): string {
+  return cardListSection(
+    "runtime-heading",
+    "Runtime",
+    rows,
+    (row) => runtimeTurnCard(row),
+    runtimeCopy(state, rows.length)
+  );
+}
+
+function pendingPanel(state: string, rows: WebReadonlyPendingInteractionViewRow[]): string {
+  return cardListSection(
+    "pending-heading",
+    "Pending interactions",
+    rows,
+    (row) => pendingInteractionCard(row),
+    pendingCopy(state)
+  );
+}
+
+function readinessPanel(state: string, missingGates: string[]): string {
+  return `<section class="console-panel" aria-labelledby="readiness-heading"><h2 id="readiness-heading">Readiness</h2><p><span class="console-badge">${escapeHtml(state)}</span> ${escapeHtml(readinessCopy(state, missingGates.length))}</p>${listItems(missingGates, "No missing gates are visible.")}</section>`;
+}
+
+function listPanel(title: string, items: string[], emptyCopy: string): string {
+  return `<section class="console-panel" aria-labelledby="${slug(title)}"><h2 id="${slug(title)}">${escapeHtml(title)}</h2>${listItems(items, emptyCopy)}</section>`;
+}
+
+function listItems(items: string[], emptyCopy: string): string {
+  if (items.length === 0) {
+    return `<p class="console-empty">${escapeHtml(emptyCopy)}</p>`;
+  }
+  return `<ul class="console-list">${items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`;
+}
+
+function workspaceCard(row: WebReadonlyWorkspaceRow): string {
+  return `<article class="console-card"><h3>${cellHtml(workspaceLink(row.workspaceId, row.label))}</h3><div class="console-fields">${[
+    field("Availability", row.availability),
+    field("Conversations", String(row.conversationCount)),
+    field("Pinned", yesNo(row.pinned)),
+    field("Last activity", row.lastActivityAt ?? "—")
+  ].join("")}</div></article>`;
+}
+
+function conversationCard(row: WebReadonlyConversationRow): string {
+  return `<article class="console-card"><h3>${cellHtml(conversationLink(row.conversationHandle, row.title))}</h3><p><span class="console-badge">${escapeHtml(statusLabel(row.status))}</span> ${escapeHtml(conversationCopy(row.status, row.finalAnswerAvailable))}</p><div class="console-fields">${[
+    field("Last activity", row.lastActivityAt),
+    field("Final result", row.finalAnswerAvailable ? "available" : "unavailable"),
+    field("Archived", yesNo(row.archived))
+  ].join("")}</div></article>`;
+}
+
+function runtimeTurnCard(row: WebReadonlyRuntimeTurnRow): string {
+  return `<article class="console-card"><h3>${escapeHtml(statusLabel(row.status))}</h3><p>${escapeHtml(row.summary ?? statusCopy(row.status))}</p><div class="console-fields">${[
+    field("Blocked", row.blockedReason ?? "—")
+  ].join("")}</div></article>`;
+}
+
+function pendingInteractionCard(row: WebReadonlyPendingInteractionViewRow): string {
+  const summary = row.summary.state === "available" ? row.summary.text : "Summary is unavailable from the safe read model.";
+  return `<article class="console-card"><h3>${escapeHtml(pendingLabel(row.kind, row.status))}</h3><p>${escapeHtml(summary)}</p><div class="console-fields">${[
+    field("Status", row.status),
+    field("Kind", row.kind),
+    field("Reason", row.blockingReason),
+    field("Created", row.createdAt ?? "—"),
+    field("Availability", row.availability)
+  ].join("")}</div><p class="console-muted">Read-only preview: responses are not enabled here.</p></article>`;
+}
+
+function artifactCard(artifact: WebReadonlyArtifactDescriptorRow): string {
+  return `<article class="console-card"><h3>${escapeHtml(artifact.label)}</h3><div class="console-fields">${[
+    field("Kind", artifact.kind),
+    field("Type", artifact.type ?? artifact.mediaType ?? "—"),
+    field("Size", artifact.sizeBytes === null ? "—" : String(artifact.sizeBytes)),
+    field("Availability", artifact.availability),
+    field("Created", artifact.createdAt ?? "—")
+  ].join("")}</div></article>`;
+}
+
+function field(label: string, value: unknown): string {
+  return `<span class="console-field"><strong>${escapeHtml(label)}:</strong> ${escapeHtml(value)}</span>`;
 }
 
 function cellHtml(value: unknown | SafeHtmlCell): string {
@@ -262,41 +365,112 @@ function workspaceLink(workspaceId: string, label: string): SafeHtmlCell {
   return { __safeHtml: `<a href="/workspaces/${workspaceId}/conversations">${escapeHtml(label)}</a>` };
 }
 
-function list(title: string, items: string[]): string {
-  const body = items.length > 0
-    ? items.map((item) => `<li>${escapeHtml(item)}</li>`).join("\n")
-    : `<li>${escapeHtml("None")}</li>`;
-  return `<section><h2>${escapeHtml(title)}</h2><ul>${body}</ul></section>`;
-}
-
 function warnings(items: string[]): string {
-  return list("Warnings", items);
-}
-
-function artifactRow(artifact: WebReadonlyArtifactDescriptorRow): string[] {
-  return [
-    artifact.label,
-    artifact.kind,
-    artifact.type ?? artifact.mediaType ?? "—",
-    artifact.sizeBytes === null ? "—" : String(artifact.sizeBytes),
-    artifact.availability,
-    artifact.createdAt ?? "—"
-  ];
-}
-
-function pendingInteractionRow(row: WebReadonlyPendingInteractionViewRow): string[] {
-  return [
-    row.status,
-    row.kind,
-    row.blockingReason,
-    row.summary.state === "available" ? row.summary.text : row.summary.reason,
-    row.createdAt ?? "—",
-    row.availability
-  ];
+  return listPanel("Warnings", items, "No warnings are visible.");
 }
 
 function yesNo(value: boolean): string {
   return value ? "yes" : "no";
+}
+
+function isAttentionState(status: string): boolean {
+  return /pending|blocked|question|approval|needs/i.test(status);
+}
+
+function statusLabel(status: string): string {
+  const normalized = status.toLowerCase();
+  if (normalized.includes("running")) return "Running";
+  if (normalized.includes("queued")) return "Queued";
+  if (normalized.includes("question")) return "Needs answer";
+  if (normalized.includes("approval")) return "Approval needed";
+  if (normalized.includes("pending")) return "Needs attention";
+  if (normalized.includes("blocked")) return "Blocked";
+  if (normalized.includes("complete") || normalized.includes("done")) return "Done";
+  if (normalized.includes("fail")) return "Failed";
+  if (normalized.includes("degraded")) return "Degraded";
+  if (normalized.includes("unavailable")) return "Unavailable";
+  if (normalized.includes("recover")) return "Recovered";
+  if (normalized.includes("idle")) return "Idle";
+  return status;
+}
+
+function statusCopy(status: string): string {
+  const label = statusLabel(status);
+  switch (label) {
+    case "Running":
+      return "Codex is working; result will appear here when complete.";
+    case "Queued":
+      return "A task is waiting to start.";
+    case "Needs answer":
+      return "Codex asked a question; the answer lane is read-only until enabled.";
+    case "Approval needed":
+      return "Codex requested an approval; the approval lane is read-only until enabled.";
+    case "Needs attention":
+      return "Owner attention may be needed, but responses are not enabled in this preview.";
+    case "Blocked":
+      return "Progress is stopped until required owner interaction is resolved.";
+    case "Done":
+      return "Completion metadata or a final result is available.";
+    case "Failed":
+      return "The task ended without a usable final result in this preview.";
+    case "Degraded":
+      return "State is partial, stale, or missing a safe source.";
+    case "Unavailable":
+      return "The required reader/source is not connected or authorized.";
+    case "Recovered":
+      return "Runtime restarted or state was restored with caveats.";
+    default:
+      return "Read-only state is shown exactly as exposed by the safe view model.";
+  }
+}
+
+function runtimeCopy(state: string, activeCount: number): string {
+  if (activeCount > 0) {
+    return `${activeCount} active turn${activeCount === 1 ? "" : "s"} visible in the safe read model.`;
+  }
+  const label = statusLabel(state);
+  if (label === "Degraded" || label === "Unavailable") {
+    return "Runtime data is partial or unavailable in this preview.";
+  }
+  return "No active task is known.";
+}
+
+function readinessCopy(state: string, missingCount: number): string {
+  if (missingCount > 0) {
+    return `${missingCount} readiness gate${missingCount === 1 ? "" : "s"} need attention before broader support claims.`;
+  }
+  if (/degraded|unavailable/i.test(state)) {
+    return "Readiness data is partial or unavailable.";
+  }
+  return "No missing readiness gates are visible.";
+}
+
+function pendingCopy(state: string): string {
+  if (/unavailable/i.test(state)) {
+    return "Pending interaction data is unavailable in this preview.";
+  }
+  if (/degraded/i.test(state)) {
+    return "Pending interaction data is partial or stale.";
+  }
+  return "No pending owner interaction is visible.";
+}
+
+function conversationCopy(status: string, finalAnswerAvailable: boolean): string {
+  if (finalAnswerAvailable) {
+    return "Result metadata is available.";
+  }
+  return statusCopy(status);
+}
+
+function pendingLabel(kind: string, status: string): string {
+  const loweredKind = kind.toLowerCase();
+  if (loweredKind.includes("question")) return "Needs answer";
+  if (loweredKind.includes("approval")) return "Approval needed";
+  return statusLabel(status);
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "section";
 }
 
 function scrubText(value: string): string {

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -11,6 +11,10 @@ import type {
   WebReadonlyWorkspaceListViewModel
 } from "../service/web-readonly-view-model.js";
 
+interface SafeHtmlCell {
+  __safeHtml: string;
+}
+
 export function renderHomePage(vm: WebReadonlyHomeViewModel): string {
   return page("Codex Console Web prototype", [
     section("Prototype", [
@@ -23,12 +27,22 @@ export function renderHomePage(vm: WebReadonlyHomeViewModel): string {
     table(
       "Workspaces",
       ["Workspace", "Conversations", "Pinned", "Last activity"],
-      vm.workspaces.map((row) => [row.label, String(row.conversationCount), yesNo(row.pinned), row.lastActivityAt ?? "—"])
+      vm.workspaces.map((row) => [
+        workspaceLink(row.workspaceId, row.label),
+        String(row.conversationCount),
+        yesNo(row.pinned),
+        row.lastActivityAt ?? "—"
+      ])
     ),
     table(
       "Recent conversations",
       ["Conversation", "Status", "Last activity", "Final answer"],
-      vm.recentConversations.map((row) => [row.title, row.status, row.lastActivityAt, yesNo(row.finalAnswerAvailable)])
+      vm.recentConversations.map((row) => [
+        conversationLink(row.conversationHandle, row.title),
+        row.status,
+        row.lastActivityAt,
+        yesNo(row.finalAnswerAvailable)
+      ])
     ),
     table(
       "Active turns",
@@ -46,7 +60,7 @@ export function renderWorkspaceListPage(vm: WebReadonlyWorkspaceListViewModel): 
       "Workspaces",
       ["Workspace", "Availability", "Conversations", "Pinned", "Last activity", "Source"],
       vm.workspaces.map((row) => [
-        row.label,
+        workspaceLink(row.workspaceId, row.label),
         row.availability,
         String(row.conversationCount),
         yesNo(row.pinned),
@@ -65,7 +79,7 @@ export function renderWorkspaceConversationListPage(vm: WebReadonlyWorkspaceConv
       "Conversations",
       ["Conversation", "Status", "Archived", "Created", "Last activity", "Final answer"],
       vm.conversations.map((row) => [
-        row.title,
+        conversationLink(row.conversationHandle, row.title),
         row.status,
         yesNo(row.archived),
         row.createdAt,
@@ -102,6 +116,17 @@ export function renderConversationResultPage(vm: WebReadonlyConversationResultVi
         answer.body.state === "available" ? answer.body.text : answer.body.reason
       ])
     ),
+    table(
+      "Runtime",
+      ["Status", "Summary", "Blocked"],
+      vm.runtime.activeTurns.map((row) => [row.status, row.summary ?? "—", row.blockedReason ?? "—"])
+    ),
+    table(
+      "Pending interactions",
+      ["Status", "Kind", "Blocking reason", "Summary", "Created", "Availability"],
+      vm.pendingInteractions.pendingInteractions.map((row) => pendingInteractionRow(row))
+    ),
+    list("Readiness missing gates", vm.readiness.missingGates),
     warnings(vm.warnings)
   ]);
 }
@@ -199,9 +224,9 @@ function pair(label: string, value: unknown): string {
   return `<strong>${escapeHtml(label)}:</strong> ${escapeHtml(value)}`;
 }
 
-function table(title: string, headings: string[], rows: unknown[][]): string {
+function table(title: string, headings: string[], rows: Array<Array<unknown | SafeHtmlCell>>): string {
   const body = rows.length > 0
-    ? rows.map((row) => `<tr>${row.map((cell) => `<td>${escapeHtml(cell)}</td>`).join("")}</tr>`).join("\n")
+    ? rows.map((row) => `<tr>${row.map((cell) => `<td>${cellHtml(cell)}</td>`).join("")}</tr>`).join("\n")
     : `<tr><td colspan="${headings.length}">${escapeHtml("No rows")}</td></tr>`;
   return [
     `<section><h2>${escapeHtml(title)}</h2>`,
@@ -210,6 +235,31 @@ function table(title: string, headings: string[], rows: unknown[][]): string {
     `<tbody>${body}</tbody>`,
     "</table></section>"
   ].join("\n");
+}
+
+function cellHtml(value: unknown | SafeHtmlCell): string {
+  if (isSafeHtmlCell(value)) {
+    return value.__safeHtml;
+  }
+  return escapeHtml(value);
+}
+
+function isSafeHtmlCell(value: unknown): value is SafeHtmlCell {
+  return typeof value === "object" && value !== null && typeof (value as SafeHtmlCell).__safeHtml === "string";
+}
+
+function conversationLink(handle: string, label: string): SafeHtmlCell {
+  if (!/^cv_[a-f0-9]{16}$/.test(handle)) {
+    return { __safeHtml: escapeHtml(label) };
+  }
+  return { __safeHtml: `<a href="/conversations/${handle}">${escapeHtml(label)}</a>` };
+}
+
+function workspaceLink(workspaceId: string, label: string): SafeHtmlCell {
+  if (!/^wk_[A-Za-z0-9_-]{1,80}$/.test(workspaceId)) {
+    return { __safeHtml: escapeHtml(label) };
+  }
+  return { __safeHtml: `<a href="/workspaces/${workspaceId}/conversations">${escapeHtml(label)}</a>` };
 }
 
 function list(title: string, items: string[]): string {

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -35,8 +35,14 @@ type WebSendFlashStatus = "accepted" | "blocked" | "rejected" | "unavailable" | 
 
 export function renderHomePage(vm: WebReadonlyHomeViewModel, options: WebReadonlyRenderOptions = {}): string {
   const resultRows = vm.recentConversations.filter((row) => row.finalAnswerAvailable || conversationGroup(row.status) === "completed");
+  const sendReady = Boolean(options.send?.csrfToken);
   return page("Web Chat", "home", [
-    hero("Web Chat", "Conversation work queue for Codex Bridge. Sending from Web is landing next; this slice is a safe read-only thread view."),
+    hero(
+      "Web Chat",
+      sendReady
+        ? "Conversation work queue for Codex Bridge. Send text from the browser and refresh the thread to watch runtime and result state."
+        : "Conversation work queue for Codex Bridge. Sending from Web is landing next; this slice is a safe read-only thread view."
+    ),
     chatHomeSection(vm, options),
     homeOwnerAttentionSection(vm.pendingInteractions.state, vm.pendingInteractions.pendingInteractions),
     cardListSection(
@@ -94,6 +100,7 @@ export function renderWorkspaceConversationListPage(vm: WebReadonlyWorkspaceConv
 export function renderConversationResultPage(vm: WebReadonlyConversationResultViewModel, options: WebReadonlyRenderOptions = {}): string {
   const conversation = vm.conversation;
   const title = conversation?.title ?? "Conversation unavailable";
+  const sendReady = Boolean(options.send?.csrfToken);
   const statusRows = conversation
     ? [
       field("Workspace", conversation.workspaceLabel),
@@ -105,8 +112,13 @@ export function renderConversationResultPage(vm: WebReadonlyConversationResultVi
     : [field("Status", "Unavailable"), field("Note", "This task is not available in the Web preview yet.")];
 
   return page("Task page", "none", [
-    hero("Conversation thread", "Read the selected Codex thread, latest result, attention state, and runtime summary."),
-    `<section class="console-panel console-detail-heading" aria-labelledby="detail-heading"><p class="console-eyebrow">Read-only thread</p><h2 id="detail-heading">${escapeHtml(title)}</h2><p><span class="console-badge">${escapeHtml(statusLabel(conversation?.status ?? vm.state))}</span> ${escapeHtml(statusCopy(conversation?.status ?? vm.state))}</p><div class="console-fields">${statusRows.join("")}</div></section>`,
+    hero(
+      "Conversation thread",
+      sendReady
+        ? "Read and continue the selected Codex thread, then refresh for runtime, attention, and result updates."
+        : "Read the selected Codex thread, latest result, attention state, and runtime summary. Sending from Web is landing next."
+    ),
+    `<section class="console-panel console-detail-heading" aria-labelledby="detail-heading"><p class="console-eyebrow">${sendReady ? "Live thread" : "Read-only thread"}</p><h2 id="detail-heading">${escapeHtml(title)}</h2><p><span class="console-badge">${escapeHtml(statusLabel(conversation?.status ?? vm.state))}</span> ${escapeHtml(statusCopy(conversation?.status ?? vm.state))}</p><div class="console-fields">${statusRows.join("")}</div></section>`,
     refreshPanel(conversation?.conversationHandle ?? null, conversation?.status ?? vm.state, options.flash?.status ?? null),
     composerPanel(
       vm.composer,
@@ -225,7 +237,7 @@ function page(title: string, active: NavKey, sections: string[]): string {
     "</head>",
     "<body class=\"console-shell\">",
     "<header class=\"console-shell__header\">",
-    "<div class=\"console-brand\"><p class=\"console-eyebrow\">Web Chat</p><h1>Codex Console</h1><p class=\"console-posture\">Chat-first, view-only preview for Codex Bridge work.</p></div>",
+    "<div class=\"console-brand\"><p class=\"console-eyebrow\">Web Chat</p><h1>Codex Console</h1><p class=\"console-posture\">Chat-first owner preview for Codex Bridge work.</p></div>",
     "<nav class=\"console-shell__nav\" aria-label=\"Console navigation\">",
     navLink("/", "Chat", active === "home"),
     navLink("/workspaces", "Workspaces", active === "workspaces"),

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -26,7 +26,12 @@ export interface WebSendRenderCapability {
 
 export interface WebReadonlyRenderOptions {
   send?: WebSendRenderCapability | null;
+  flash?: {
+    status: WebSendFlashStatus;
+  } | null;
 }
+
+type WebSendFlashStatus = "accepted" | "blocked" | "rejected" | "unavailable" | "invalid" | "denied";
 
 export function renderHomePage(vm: WebReadonlyHomeViewModel, options: WebReadonlyRenderOptions = {}): string {
   const resultRows = vm.recentConversations.filter((row) => row.finalAnswerAvailable || conversationGroup(row.status) === "completed");
@@ -102,6 +107,7 @@ export function renderConversationResultPage(vm: WebReadonlyConversationResultVi
   return page("Task page", "none", [
     hero("Conversation thread", "Read the selected Codex thread, latest result, attention state, and runtime summary."),
     `<section class="console-panel console-detail-heading" aria-labelledby="detail-heading"><p class="console-eyebrow">Read-only thread</p><h2 id="detail-heading">${escapeHtml(title)}</h2><p><span class="console-badge">${escapeHtml(statusLabel(conversation?.status ?? vm.state))}</span> ${escapeHtml(statusCopy(conversation?.status ?? vm.state))}</p><div class="console-fields">${statusRows.join("")}</div></section>`,
+    refreshPanel(conversation?.conversationHandle ?? null, conversation?.status ?? vm.state, options.flash?.status ?? null),
     composerPanel(
       vm.composer,
       conversation?.conversationHandle ?? null,
@@ -570,6 +576,40 @@ function composerPanel(
     return `<section class="console-composer" aria-label="${escapeHtml(composer.label)}"><form method="post" action="${escapeHtml(action)}"><input type="hidden" name="_csrf" value="${escapeHtml(options.send.csrfToken)}"><label class="console-composer__label" for="web-message-${escapeHtml(conversationHandle)}">${escapeHtml(composer.label)}</label><textarea id="web-message-${escapeHtml(conversationHandle)}" name="message" maxlength="8000" required placeholder="${escapeHtml(composer.placeholder)}"></textarea><button type="submit">Send message</button></form><p><span class="console-badge">Text only</span> Send a short text message to Codex for this conversation.</p></section>`;
   }
   return `<section class="console-composer" aria-label="${escapeHtml(composer.label)}" aria-disabled="true"><div class="console-composer__box" role="textbox" aria-readonly="true" aria-disabled="true"><span>${escapeHtml(composer.placeholder)}</span></div><p><span class="console-badge">Read-only</span> ${escapeHtml(composer.disabledReason)} ${escapeHtml(note)}</p></section>`;
+}
+
+function refreshPanel(conversationHandle: string | null, status: string, flashStatus: WebSendFlashStatus | null): string {
+  if (!conversationHandle || !isSafeConversationHandle(conversationHandle)) {
+    return "";
+  }
+  const refreshHref = `/conversations/${conversationHandle}`;
+  const flashCopy = flashStatus ? sendStatusCopy(flashStatus) : null;
+  const statusCopyText = conversationGroup(status) === "running"
+    ? "Codex is running. Refresh this thread to check for new runtime or result state."
+    : "Refresh this thread to check for updated runtime, attention, or result state.";
+  const fields = [
+    flashCopy ? field("Last send", flashCopy) : "",
+    fieldHtml("Refresh", `<a href="${escapeHtml(refreshHref)}">Refresh thread</a>`),
+    field("Note", statusCopyText)
+  ].filter(Boolean);
+  return `<section class="console-panel console-refresh" aria-labelledby="refresh-heading"><h2 id="refresh-heading">Thread refresh</h2><div class="console-fields">${fields.join("")}</div></section>`;
+}
+
+function sendStatusCopy(status: WebSendFlashStatus): string {
+  switch (status) {
+    case "accepted":
+      return "Message accepted. Refresh to watch running or final result state.";
+    case "blocked":
+      return "Message was blocked by current conversation state. Refresh and check pending attention.";
+    case "unavailable":
+      return "Message could not be submitted right now. Refresh before retrying.";
+    case "denied":
+      return "Message was denied by owner safety checks.";
+    case "invalid":
+      return "Message was not sent because the request was invalid.";
+    case "rejected":
+      return "Message was not accepted for this conversation.";
+  }
 }
 
 function isSafeConversationHandle(value: string): boolean {

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -20,11 +20,19 @@ interface SafeHtmlCell {
 
 type NavKey = "home" | "workspaces" | "pending" | "runtime" | "readiness" | "none";
 
-export function renderHomePage(vm: WebReadonlyHomeViewModel): string {
+export interface WebSendRenderCapability {
+  csrfToken: string;
+}
+
+export interface WebReadonlyRenderOptions {
+  send?: WebSendRenderCapability | null;
+}
+
+export function renderHomePage(vm: WebReadonlyHomeViewModel, options: WebReadonlyRenderOptions = {}): string {
   const resultRows = vm.recentConversations.filter((row) => row.finalAnswerAvailable || conversationGroup(row.status) === "completed");
   return page("Web Chat", "home", [
     hero("Web Chat", "Conversation work queue for Codex Bridge. Sending from Web is landing next; this slice is a safe read-only thread view."),
-    chatHomeSection(vm),
+    chatHomeSection(vm, options),
     homeOwnerAttentionSection(vm.pendingInteractions.state, vm.pendingInteractions.pendingInteractions),
     cardListSection(
       "home-active-attention",
@@ -78,7 +86,7 @@ export function renderWorkspaceConversationListPage(vm: WebReadonlyWorkspaceConv
   ]);
 }
 
-export function renderConversationResultPage(vm: WebReadonlyConversationResultViewModel): string {
+export function renderConversationResultPage(vm: WebReadonlyConversationResultViewModel, options: WebReadonlyRenderOptions = {}): string {
   const conversation = vm.conversation;
   const title = conversation?.title ?? "Conversation unavailable";
   const statusRows = conversation
@@ -94,7 +102,12 @@ export function renderConversationResultPage(vm: WebReadonlyConversationResultVi
   return page("Task page", "none", [
     hero("Conversation thread", "Read the selected Codex thread, latest result, attention state, and runtime summary."),
     `<section class="console-panel console-detail-heading" aria-labelledby="detail-heading"><p class="console-eyebrow">Read-only thread</p><h2 id="detail-heading">${escapeHtml(title)}</h2><p><span class="console-badge">${escapeHtml(statusLabel(conversation?.status ?? vm.state))}</span> ${escapeHtml(statusCopy(conversation?.status ?? vm.state))}</p><div class="console-fields">${statusRows.join("")}</div></section>`,
-    disabledComposerPanel(vm.composer, conversation ? "This Web thread is read-only for Phase B." : "Choose an available conversation before sending from Web."),
+    composerPanel(
+      vm.composer,
+      conversation?.conversationHandle ?? null,
+      options,
+      conversation ? "This Web thread is read-only until sending is enabled." : "Choose an available conversation before sending from Web."
+    ),
     statusPanel(conversation?.status ?? vm.state),
     resultPanel(vm.answers),
     detailPendingPanel(vm.pendingInteractions.state, vm.pendingInteractions.pendingInteractions),
@@ -448,6 +461,34 @@ a {
 .console-composer p {
   margin: 0;
 }
+.console-composer form {
+  display: grid;
+  gap: 0.65rem;
+}
+.console-composer__label {
+  font-weight: 800;
+}
+.console-composer textarea {
+  min-height: 6rem;
+  resize: vertical;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--console-border);
+  border-radius: 16px;
+  background: #ffffff;
+  color: var(--console-text);
+  font: inherit;
+}
+.console-composer button {
+  min-height: 44px;
+  justify-self: start;
+  padding: 0.65rem 1rem;
+  border: 0;
+  border-radius: 999px;
+  background: var(--console-primary);
+  color: #ffffff;
+  font: inherit;
+  font-weight: 800;
+}
 .console-list {
   margin: 0;
   padding-left: 1.25rem;
@@ -497,7 +538,7 @@ function cardListSection<T>(id: string, title: string, rows: T[], render: (row: 
   return `<section class="console-section" aria-labelledby="${id}"><h2 id="${id}">${escapeHtml(title)}</h2>${body}</section>`;
 }
 
-function chatHomeSection(vm: WebReadonlyHomeViewModel): string {
+function chatHomeSection(vm: WebReadonlyHomeViewModel, options: WebReadonlyRenderOptions): string {
   const selected = vm.recentConversations[0] ?? null;
   const queue = vm.recentConversations.length > 0
     ? conversationListSection(
@@ -512,17 +553,27 @@ function chatHomeSection(vm: WebReadonlyHomeViewModel): string {
       field("Last updated", selected.lastActivityAt),
       field("Result", selected.finalAnswerAvailable ? "Available" : "Not ready yet"),
       fieldHtml("Thread", cellHtml(conversationLink(selected.conversationHandle, "Open durable thread")))
-    ].join("")}</div></article>${disabledComposerPanel(vm.composer, "Open a thread to review more result, pending, and runtime details.")}</section>`
-    : `<section class="console-panel console-thread-preview" aria-labelledby="selected-thread"><p class="console-eyebrow">Thread</p><h2 id="selected-thread">Selected thread preview</h2><p class="console-empty">No thread selected. Conversation threads will appear here as Codex work is captured.</p>${disabledComposerPanel(vm.composer, "Choose a conversation when one is available.")}</section>`;
+    ].join("")}</div></article>${composerPanel(vm.composer, selected.conversationHandle, options, "Open a thread to review more result, pending, and runtime details.")}</section>`
+    : `<section class="console-panel console-thread-preview" aria-labelledby="selected-thread"><p class="console-eyebrow">Thread</p><h2 id="selected-thread">Selected thread preview</h2><p class="console-empty">No thread selected. Conversation threads will appear here as Codex work is captured.</p>${composerPanel(vm.composer, null, options, "Choose a conversation when one is available.")}</section>`;
 
   return `<section class="console-chat-layout" aria-label="Web Chat work queue">${queue}${selectedPanel}</section>`;
 }
 
-function disabledComposerPanel(
+function composerPanel(
   composer: WebReadonlyHomeViewModel["composer"],
+  conversationHandle: string | null,
+  options: WebReadonlyRenderOptions,
   note: string
 ): string {
+  if (conversationHandle && isSafeConversationHandle(conversationHandle) && options.send?.csrfToken) {
+    const action = `/conversations/${conversationHandle}/messages`;
+    return `<section class="console-composer" aria-label="${escapeHtml(composer.label)}"><form method="post" action="${escapeHtml(action)}"><input type="hidden" name="_csrf" value="${escapeHtml(options.send.csrfToken)}"><label class="console-composer__label" for="web-message-${escapeHtml(conversationHandle)}">${escapeHtml(composer.label)}</label><textarea id="web-message-${escapeHtml(conversationHandle)}" name="message" maxlength="8000" required placeholder="${escapeHtml(composer.placeholder)}"></textarea><button type="submit">Send message</button></form><p><span class="console-badge">Text only</span> Send a short text message to Codex for this conversation.</p></section>`;
+  }
   return `<section class="console-composer" aria-label="${escapeHtml(composer.label)}" aria-disabled="true"><div class="console-composer__box" role="textbox" aria-readonly="true" aria-disabled="true"><span>${escapeHtml(composer.placeholder)}</span></div><p><span class="console-badge">Read-only</span> ${escapeHtml(composer.disabledReason)} ${escapeHtml(note)}</p></section>`;
+}
+
+function isSafeConversationHandle(value: string): boolean {
+  return /^cv_[a-f0-9]{16}$/.test(value);
 }
 
 function utilityLinksPanel(): string {

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -25,6 +25,7 @@ export function renderHomePage(vm: WebReadonlyHomeViewModel): string {
   const resultRows = vm.recentConversations.filter((row) => row.finalAnswerAvailable || conversationGroup(row.status) === "completed");
   return page("Home", "home", [
     hero("Codex Console", "Your personal console for continuing Codex work, reviewing results, and browsing projects."),
+    homeOwnerAttentionSection(vm.pendingInteractions.state, vm.pendingInteractions.pendingInteractions),
     conversationListSection(
       "home-continue-working",
       "Continue working",
@@ -205,6 +206,7 @@ function page(title: string, active: NavKey, sections: string[]): string {
     "<meta charset=\"utf-8\">",
     "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
     `<title>${escapeHtml(title)} · Codex Console</title>`,
+    `<style>\n${APP_CSS}\n</style>`,
     "</head>",
     "<body class=\"console-shell\">",
     "<header class=\"console-shell__header\">",
@@ -225,6 +227,223 @@ function page(title: string, active: NavKey, sections: string[]): string {
   ].join("\n");
 }
 
+export const APP_CSS = `
+:root {
+  color-scheme: light;
+  --console-bg: #f4f7fb;
+  --console-surface: #ffffff;
+  --console-surface-soft: #eef4ff;
+  --console-border: #d9e3f0;
+  --console-text: #162033;
+  --console-muted: #62708a;
+  --console-primary: #2457d6;
+  --console-primary-soft: #e8efff;
+  --console-shadow: 0 18px 50px rgba(22, 32, 51, 0.10);
+}
+* {
+  box-sizing: border-box;
+}
+html {
+  background: var(--console-bg);
+}
+body.console-shell {
+  margin: 0;
+  min-width: 0;
+  overflow-x: hidden;
+  color: var(--console-text);
+  background: linear-gradient(135deg, rgba(36, 87, 214, 0.12), rgba(244, 247, 251, 0) 32rem), var(--console-bg);
+  font: 16px/1.55 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  overflow-wrap: anywhere;
+}
+a {
+  color: var(--console-primary);
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.16em;
+}
+.console-shell__header,
+.console-shell__main {
+  width: 100%;
+  max-width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+}
+.console-shell__header {
+  display: grid;
+  gap: 1rem;
+  padding: 28px 0 16px;
+}
+.console-brand,
+.console-hero,
+.console-panel,
+.console-section {
+  border: 1px solid var(--console-border);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: var(--console-shadow);
+}
+.console-brand,
+.console-hero,
+.console-panel,
+.console-section {
+  padding: 1.25rem;
+}
+.console-brand h1,
+.console-hero h2,
+.console-section h2,
+.console-panel h2,
+.console-card h3 {
+  margin: 0;
+  line-height: 1.18;
+}
+.console-brand h1 {
+  font-size: clamp(2rem, 7vw, 4.25rem);
+  letter-spacing: -0.06em;
+}
+.console-posture,
+.console-hero p,
+.console-card p,
+.console-empty,
+.console-muted {
+  color: var(--console-muted);
+}
+.console-eyebrow {
+  margin: 0 0 0.35rem;
+  color: var(--console-primary);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.console-shell__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+.console-nav-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0.65rem 0.95rem;
+  border: 1px solid var(--console-border);
+  border-radius: 999px;
+  background: var(--console-surface);
+  color: var(--console-text);
+  font-weight: 700;
+  text-decoration: none;
+}
+.console-nav-link[aria-current="page"] {
+  border-color: rgba(36, 87, 214, 0.35);
+  background: var(--console-primary-soft);
+  color: var(--console-primary);
+}
+.console-shell__main {
+  display: grid;
+  gap: 1rem;
+  padding: 0 0 40px;
+}
+.console-hero {
+  padding: clamp(1.25rem, 4vw, 2rem);
+  background: linear-gradient(135deg, #ffffff, #eef4ff);
+}
+.console-hero h2 {
+  font-size: clamp(1.8rem, 5vw, 3.3rem);
+  letter-spacing: -0.04em;
+}
+.console-section,
+.console-panel {
+  display: grid;
+  gap: 1rem;
+}
+.console-card-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
+  gap: 0.85rem;
+  min-width: 0;
+}
+.console-card-group {
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+}
+.console-card-group h3 {
+  margin: 0;
+  color: var(--console-muted);
+  font-size: 0.95rem;
+}
+.console-card {
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid var(--console-border);
+  border-radius: 18px;
+  background: var(--console-surface);
+}
+.console-card h3 a,
+.console-field a {
+  overflow-wrap: anywhere;
+}
+.console-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  min-width: 0;
+}
+.console-field,
+.console-badge {
+  display: inline-flex;
+  max-width: 100%;
+  border-radius: 999px;
+  overflow-wrap: anywhere;
+}
+.console-field {
+  padding: 0.4rem 0.65rem;
+  background: #f6f8fc;
+  color: var(--console-muted);
+}
+.console-field strong {
+  margin-right: 0.25rem;
+  color: var(--console-text);
+}
+.console-badge {
+  align-items: center;
+  padding: 0.22rem 0.55rem;
+  background: var(--console-primary-soft);
+  color: var(--console-primary);
+  font-weight: 800;
+  font-size: 0.82rem;
+}
+.console-result-body {
+  max-width: 100%;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  padding: 1rem;
+  border-radius: 16px;
+  background: #101827;
+  color: #eef4ff;
+}
+.console-list {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+@media (max-width: 640px) {
+  .console-shell__header,
+  .console-shell__main {
+    max-width: min(100% - 20px, 1120px);
+  }
+  .console-brand,
+  .console-hero,
+  .console-panel,
+  .console-section {
+    border-radius: 18px;
+    padding: 1rem;
+  }
+  .console-nav-link {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+}
+`.trim();
+
 function navLink(href: string, label: string, active: boolean): string {
   const current = active ? " aria-current=\"page\"" : "";
   return `<a class="console-nav-link" href="${href}"${current}>${escapeHtml(label)}</a>`;
@@ -243,6 +462,32 @@ function cardListSection<T>(id: string, title: string, rows: T[], render: (row: 
     ? `<div class="console-card-list">${rows.map((row) => render(row)).join("")}</div>`
     : `<p class="console-empty">${escapeHtml(emptyCopy)}</p>`;
   return `<section class="console-section" aria-labelledby="${id}"><h2 id="${id}">${escapeHtml(title)}</h2>${body}</section>`;
+}
+
+function homeOwnerAttentionSection(state: string, rows: WebReadonlyPendingInteractionViewRow[]): string {
+  const attentionRows = rows.filter((row) => pendingGroup(row) === "attention").slice(0, 3);
+  if (attentionRows.length === 0) {
+    return "";
+  }
+
+  const count = attentionRows.length;
+  const summary = `${count} item${count === 1 ? "" : "s"} need owner attention`;
+  const cards = attentionRows.map((row) => homePendingAttentionCard(row)).join("");
+  const stateCopy = /degraded/i.test(state) ? "Pending state may be partial or stale." : "Safe read-only summary from pending interactions.";
+  return `<section class="console-section console-owner-attention" aria-labelledby="home-owner-attention"><p class="console-eyebrow">Owner attention</p><h2 id="home-owner-attention">Owner attention</h2><p><span class="console-badge">${escapeHtml(summary)}</span> ${escapeHtml(stateCopy)}</p><div class="console-card-list">${cards}</div></section>`;
+}
+
+function homePendingAttentionCard(row: WebReadonlyPendingInteractionViewRow): string {
+  const label = pendingInteractionLabel(row);
+  const summary = row.summary.state === "available" ? row.summary.text : pendingInteractionCopy(row);
+  const source = row.conversationId && /^cv_[a-f0-9]{16}$/.test(row.conversationId)
+    ? fieldHtml("Source", cellHtml(conversationLink(row.conversationId, "Open conversation/task")))
+    : field("Source", "Conversation/task unavailable");
+  return `<article class="console-card"><h3><span class="console-badge">${escapeHtml(label)}</span></h3><p>${escapeHtml(summary)}</p><div class="console-fields">${[
+    field("Kind", pendingKindLabel(row.kind)),
+    source,
+    field("Note", "Responses are not enabled in this preview.")
+  ].join("")}</div></article>`;
 }
 
 function conversationListSection(id: string, title: string, rows: WebReadonlyConversationRow[], emptyCopy: string): string {

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -246,7 +246,7 @@ function resultPanel(answers: WebReadonlyConversationResultViewModel["answers"])
   const cards = answers.map((answer) => {
     const body = answer.body.state === "available"
       ? `<pre class="console-result-body">${escapeHtml(answer.body.text)}</pre>`
-      : `<p class="console-empty">Result metadata is available, but the answer text was not captured in a Web-safe format.</p>`;
+      : `<p class="console-empty">${escapeHtml(finalAnswerUnavailableCopy(answer.body.reason))}</p>`;
     return `<article class="console-card console-result-card"><h3>${escapeHtml(answer.kind)}</h3><div class="console-fields">${[
       field("Delivery", answer.deliveryState),
       field("Created", answer.createdAt),
@@ -255,6 +255,13 @@ function resultPanel(answers: WebReadonlyConversationResultViewModel["answers"])
   }).join("");
 
   return `<section class="console-panel console-result" aria-labelledby="result-heading"><h2 id="result-heading">Final answer/result</h2><div class="console-card-list">${cards}</div></section>`;
+}
+
+function finalAnswerUnavailableCopy(reason: string): string {
+  if (reason === "unsafe_final_answer_body") {
+    return "Final answer body unavailable: supplied answer text was rejected by the Web safety filter.";
+  }
+  return "Result metadata is available, but the answer text was not captured in a Web-safe format.";
 }
 
 function runtimePanel(state: string, rows: WebReadonlyRuntimeTurnRow[]): string {

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -127,9 +127,21 @@ export function renderConversationArtifactCatalogPage(vm: WebReadonlyConversatio
 
 export function renderRuntimePage(vm: WebReadonlyRuntimeContextViewModel): string {
   return page("Runtime", "runtime", [
-    hero("Runtime", "Read-only runtime state. Use it to understand whether Codex is idle, running, blocked, degraded, or unavailable."),
-    summaryPanel("Runtime status", [field("State", vm.state), field("Active turns", String(vm.activeTurns.length))]),
-    runtimePanel(vm.state, vm.activeTurns),
+    hero("Runtime", "Read-only owner view of whether Codex is idle, running, blocked, degraded, or unavailable."),
+    summaryPanel("Current operating state", [
+      field("State", runtimeStateLabel(vm.state, vm.activeTurns.length)),
+      field("Active turns", String(vm.activeTurns.length)),
+      field("Owner guidance", runtimeCopy(vm.state, vm.activeTurns.length))
+    ]),
+    cardListSection(
+      "runtime-active-turns",
+      "Active conversation/task turns",
+      vm.activeTurns,
+      (row) => runtimeTurnCard(row),
+      runtimeCopy(vm.state, vm.activeTurns.length)
+    ),
+    runtimeReadinessGuidancePanel(),
+    accessPosturePanel("Settings / access posture"),
     warnings(vm.warnings)
   ]);
 }
@@ -145,21 +157,27 @@ export function renderPendingInteractionsPage(vm: WebReadonlyPendingInteractions
 
 export function renderReadinessPage(vm: WebReadonlyReadinessGuardrailViewModel): string {
   return page("Readiness", "readiness", [
-    hero("Readiness", "Guardrail state for this private Console preview. Readiness is not a public support claim."),
-    summaryPanel("Readiness status", [field("State", vm.state), field("Checked at", vm.checkedAt ?? "—"), field("Active pack", vm.activePack ?? "—")]),
+    hero("Readiness", "Baseline capability/readiness matrix for this private Console preview. It is not a public support claim; public support is not claimed."),
+    summaryPanel("Readiness status", [
+      field("State", readinessStateLabel(vm.state)),
+      field("Checked at", vm.checkedAt ?? "—"),
+      field("Active pack", vm.activePack ?? "—")
+    ]),
+    accessPosturePanel("Setup / access posture"),
     cardListSection(
       "readiness-capabilities",
-      "Capabilities",
+      "Baseline capability/readiness matrix",
       vm.capabilities,
       (row) => `<article class="console-card"><h3>${escapeHtml(row.label)}</h3><div class="console-fields">${[
-        field("Declared", row.declared),
-        field("Configured", row.configured),
-        field("Observed", row.observed),
-        field("UX exposed", row.uxExposed)
+        field("Declared", observedCopy(row.declared)),
+        field("Configured", observedCopy(row.configured)),
+        field("Observed", observedCopy(row.observed)),
+        field("UX exposed", observedCopy(row.uxExposed))
       ].join("")}</div></article>`,
       "No capability rows are available."
     ),
-    listPanel("Missing gates", vm.missingGates, "No missing gates are visible."),
+    listPanel("Setup needed", vm.missingGates, "No setup gaps are visible."),
+    supportClaimGuardrailPanel(),
     warnings(vm.warnings)
   ]);
 }
@@ -192,7 +210,7 @@ function page(title: string, active: NavKey, sections: string[]): string {
     "</head>",
     "<body class=\"console-shell\">",
     "<header class=\"console-shell__header\">",
-    "<div class=\"console-brand\"><p class=\"console-eyebrow\">Owner preview · read-only prototype</p><h1>Codex Console</h1><p class=\"console-posture\">Private, denied-by-default Console preview. Runtime data is read-only and action lanes are not enabled.</p></div>",
+    "<div class=\"console-brand\"><p class=\"console-eyebrow\">Owner preview · read-only prototype</p><h1>Codex Console</h1><p class=\"console-posture\">Private, denied-by-default Console preview. Runtime data is read-only. Actions are not enabled.</p></div>",
     "<nav class=\"console-shell__nav\" aria-label=\"Console navigation\">",
     navLink("/", "Home", active === "home"),
     navLink("/workspaces", "Workspaces", active === "workspaces"),
@@ -301,6 +319,31 @@ function pendingPanel(state: string, rows: WebReadonlyPendingInteractionViewRow[
 
 function readinessPanel(state: string, missingGates: string[]): string {
   return `<section class="console-panel" aria-labelledby="readiness-heading"><h2 id="readiness-heading">Readiness</h2><p><span class="console-badge">${escapeHtml(state)}</span> ${escapeHtml(readinessCopy(state, missingGates.length))}</p>${listItems(missingGates, "No missing gates are visible.")}</section>`;
+}
+
+function runtimeReadinessGuidancePanel(): string {
+  return summaryPanel("Degraded / unavailable guidance", [
+    field("Degraded", "State is partial, stale, or missing a safe source."),
+    field("Unavailable", "The safe reader cannot show current runtime state yet."),
+    field("Setup needed", "Use existing bridge setup and diagnostics outside this Web preview if a required source is missing.")
+  ]);
+}
+
+function accessPosturePanel(title: string): string {
+  return summaryPanel(title, [
+    field("Access", "Owner/private"),
+    field("Mode", "Read-only preview"),
+    field("Default", "Denied by default"),
+    field("Controls", "Actions are not enabled"),
+    field("Rollback posture", "Kill-switch and rollback readiness are status-only here; no destructive controls are exposed.")
+  ]);
+}
+
+function supportClaimGuardrailPanel(): string {
+  return summaryPanel("Support-claim guardrail", [
+    "This readiness view is not a public support claim.",
+    "Private owner preview only; public support is not claimed from this page."
+  ]);
 }
 
 function listPanel(title: string, items: string[], emptyCopy: string): string {
@@ -463,6 +506,25 @@ function statusLabel(status: string): string {
   return "Unavailable";
 }
 
+function runtimeStateLabel(state: string, activeCount: number): string {
+  if (activeCount > 0) {
+    return statusLabel(state);
+  }
+  const normalized = state.toLowerCase();
+  if (normalized === "available" || normalized.includes("idle")) {
+    return "Idle";
+  }
+  return statusLabel(state);
+}
+
+function readinessStateLabel(state: string): string {
+  const normalized = state.toLowerCase();
+  if (normalized.includes("ready") || normalized === "available") return "Ready";
+  if (normalized.includes("degraded")) return "Degraded";
+  if (normalized.includes("unavailable") || normalized.includes("unknown")) return "Unavailable";
+  return statusLabel(state);
+}
+
 function statusCopy(status: string): string {
   const label = statusLabel(status);
   switch (label) {
@@ -512,6 +574,13 @@ function readinessCopy(state: string, missingCount: number): string {
     return "Readiness data is partial or unavailable.";
   }
   return "No missing readiness gates are visible.";
+}
+
+function observedCopy(state: string): string {
+  const normalized = state.toLowerCase();
+  if (normalized === "present") return "Present";
+  if (normalized === "missing") return "Missing";
+  return "Unknown";
 }
 
 function pendingCopy(state: string): string {
@@ -604,5 +673,7 @@ function scrubText(value: string): string {
     .replace(/\b(submit|approve|interrupt|upload|switch|resume)\b/gi, "[redacted]")
     .replace(/\b(callback(?:_data)?|messageId|deliveryMessageId|telegramChatId|feishuChatId|chatId|threadId|token)\s*[:=]\s*[^\s<>"']+/gi, "[redacted]")
     .replace(/\b[A-Z][A-Z0-9_]{2,}=\S+/g, "[redacted-env]")
+    .replace(/\/sessions\/[A-Za-z0-9._/-]+/g, "[redacted-session]")
+    .replace(/\bsession-[A-Za-z0-9._-]+\b/g, "[redacted-session]")
     .replace(/(?:^|\s)(\/(?:home|tmp|var|etc|root|Users|usr)\/[^\s<>"']*)/g, (match, path: string) => match.replace(path, "[redacted-path]"));
 }

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -135,8 +135,8 @@ export function renderRuntimePage(vm: WebReadonlyRuntimeContextViewModel): strin
 }
 
 export function renderPendingInteractionsPage(vm: WebReadonlyPendingInteractionsViewModel): string {
-  return page("Pending", "pending", [
-    hero("Pending", "Read-only view of approvals, questions, and other owner attention states. Responses are not enabled in this preview."),
+  return page("Pending/Approvals", "pending", [
+    hero("Pending/Approvals", "Read-only view of approvals, questions, and other owner attention states. Responses are not enabled in this preview."),
     summaryPanel("Pending status", [field("State", vm.state), field("Visible items", String(vm.pendingInteractions.length))]),
     pendingPanel(vm.state, vm.pendingInteractions),
     warnings(vm.warnings)
@@ -296,13 +296,7 @@ function runtimePanel(state: string, rows: WebReadonlyRuntimeTurnRow[]): string 
 }
 
 function pendingPanel(state: string, rows: WebReadonlyPendingInteractionViewRow[]): string {
-  return cardListSection(
-    "pending-heading",
-    "Pending interactions",
-    rows,
-    (row) => pendingInteractionCard(row),
-    pendingCopy(state)
-  );
+  return pendingInteractionListSection("pending-heading", "Pending interactions", state, rows);
 }
 
 function readinessPanel(state: string, missingGates: string[]): string {
@@ -337,6 +331,33 @@ function conversationCard(row: WebReadonlyConversationRow): string {
   ].join("")}</div></article>`;
 }
 
+function pendingInteractionListSection(
+  id: string,
+  title: string,
+  state: string,
+  rows: WebReadonlyPendingInteractionViewRow[]
+): string {
+  if (rows.length === 0) {
+    return `<section class="console-section" aria-labelledby="${id}"><h2 id="${id}">${escapeHtml(title)}</h2><p class="console-empty">${escapeHtml(pendingCopy(state))}</p></section>`;
+  }
+
+  const groups = [
+    { key: "attention", title: "Needs owner attention" },
+    { key: "resolved", title: "Resolved or duplicate" },
+    { key: "stale", title: "Stale or expired" },
+    { key: "failed", title: "Unavailable or failed" }
+  ] as const;
+  const cards = groups.map((group) => {
+    const groupRows = rows.filter((row) => pendingGroup(row) === group.key);
+    if (groupRows.length === 0) {
+      return "";
+    }
+    return `<section class="console-card-group" aria-label="${escapeHtml(group.title)}"><h3>${escapeHtml(group.title)}</h3><div class="console-card-list">${groupRows.map((row) => pendingInteractionCard(row)).join("")}</div></section>`;
+  }).join("");
+
+  return `<section class="console-section" aria-labelledby="${id}"><h2 id="${id}">${escapeHtml(title)}</h2>${cards}</section>`;
+}
+
 function runtimeTurnCard(row: WebReadonlyRuntimeTurnRow): string {
   return `<article class="console-card"><h3>${escapeHtml(statusLabel(row.status))}</h3><p>${escapeHtml(row.summary ?? statusCopy(row.status))}</p><div class="console-fields">${[
     field("Blocked", row.blockedReason ?? "—")
@@ -344,15 +365,20 @@ function runtimeTurnCard(row: WebReadonlyRuntimeTurnRow): string {
 }
 
 function pendingInteractionCard(row: WebReadonlyPendingInteractionViewRow): string {
+  const label = pendingInteractionLabel(row);
   const summary = row.summary.state === "available" ? row.summary.text : "Summary is unavailable from the safe read model.";
-  return `<article class="console-card"><h3>${escapeHtml(pendingLabel(row.kind, row.status))}</h3><p>${escapeHtml(summary)}</p><div class="console-fields">${[
-    field("State", pendingLabel(row.kind, row.status)),
-    field("State note", statusCopy(row.status)),
-    field("Kind", row.kind),
+  const source = row.conversationId && /^cv_[a-f0-9]{16}$/.test(row.conversationId)
+    ? fieldHtml("Source", cellHtml(conversationLink(row.conversationId, "Open conversation/task")))
+    : field("Source", "Conversation/task unavailable");
+  return `<article class="console-card"><h3><span class="console-badge">${escapeHtml(label)}</span></h3><p>${escapeHtml(summary)}</p><div class="console-fields">${[
+    field("State", label),
+    field("State note", pendingInteractionCopy(row)),
+    field("Kind", pendingKindLabel(row.kind)),
+    source,
     field("Reason", row.blockingReason),
     field("Created", row.createdAt ?? "—"),
     field("Availability", row.availability)
-  ].join("")}</div><p class="console-muted">Read-only preview: responses are not enabled here.</p></article>`;
+  ].join("")}</div><p class="console-muted">Read-only preview: Responses are not enabled in this preview.</p></article>`;
 }
 
 function artifactCard(artifact: WebReadonlyArtifactDescriptorRow): string {
@@ -367,6 +393,10 @@ function artifactCard(artifact: WebReadonlyArtifactDescriptorRow): string {
 
 function field(label: string, value: unknown): string {
   return `<span class="console-field"><strong>${escapeHtml(label)}:</strong> ${escapeHtml(value)}</span>`;
+}
+
+function fieldHtml(label: string, valueHtml: string): string {
+  return `<span class="console-field"><strong>${escapeHtml(label)}:</strong> ${valueHtml}</span>`;
 }
 
 function cellHtml(value: unknown | SafeHtmlCell): string {
@@ -506,6 +536,63 @@ function pendingLabel(kind: string, status: string): string {
   if (loweredKind.includes("question")) return "Needs answer";
   if (loweredKind.includes("approval")) return "Approval needed";
   return statusLabel(status);
+}
+
+function pendingInteractionLabel(row: WebReadonlyPendingInteractionViewRow): string {
+  const normalizedStatus = row.status.toLowerCase();
+  if (/resolved|complete|done/.test(normalizedStatus)) return "Resolved";
+  if (/expired|timed?_?out/.test(normalizedStatus)) return "Expired";
+  if (/stale/.test(normalizedStatus)) return "Stale";
+  if (/duplicate/.test(normalizedStatus)) return "Duplicate";
+  if (/fail|error/.test(normalizedStatus)) return "Failed";
+  if (/unavailable|unknown|missing|source/.test(normalizedStatus) || row.availability === "unavailable") return "Unavailable";
+  return pendingLabel(row.kind, row.status);
+}
+
+function pendingInteractionCopy(row: WebReadonlyPendingInteractionViewRow): string {
+  switch (pendingInteractionLabel(row)) {
+    case "Needs answer":
+      return "Codex asked a question; responses are not enabled in this preview.";
+    case "Approval needed":
+      return "Codex requested an approval; responses are not enabled in this preview.";
+    case "Resolved":
+      return "This owner interaction is already resolved; no Web action is available.";
+    case "Expired":
+      return "This owner interaction expired or is no longer current; refresh or use the current bridge chat if needed.";
+    case "Stale":
+      return "This owner interaction may be stale; refresh before relying on it.";
+    case "Duplicate":
+      return "This owner interaction appears to duplicate another item; use the current item in the bridge chat if needed.";
+    case "Failed":
+      return "This owner interaction could not be read safely; use the current bridge chat if needed.";
+    case "Unavailable":
+      return "Pending interaction data is unavailable from the safe reader.";
+    default:
+      return "Owner attention may be needed, but responses are not enabled in this preview.";
+  }
+}
+
+function pendingKindLabel(kind: string): string {
+  const loweredKind = kind.toLowerCase();
+  if (loweredKind.includes("question")) return "Question";
+  if (loweredKind.includes("approval")) return "Approval";
+  return "Owner interaction";
+}
+
+function pendingGroup(row: WebReadonlyPendingInteractionViewRow): "attention" | "resolved" | "stale" | "failed" {
+  switch (pendingInteractionLabel(row)) {
+    case "Resolved":
+    case "Duplicate":
+      return "resolved";
+    case "Expired":
+    case "Stale":
+      return "stale";
+    case "Failed":
+    case "Unavailable":
+      return "failed";
+    default:
+      return "attention";
+  }
 }
 
 function slug(value: string): string {


### PR DESCRIPTION
## Summary
- Lands Web as a first-class, owner-only Codex Bridge chat surface: browser Home/conversation views, enabled composer, authenticated POST submit, live bridge wiring, refresh/status/result affordances.
- Browser text messages now enter the live BridgeService submit seam instead of the standalone read-only harness; the standalone `ctb web readonly` path remains read-only.
- Adds/updates managed owner preview operations for live mode behind the cookie proxy and Cloudflare tunnel, with no public unauthenticated bridge state.
- Keeps the scope personal and practical: one owner, opaque Web conversation handles, no raw chat/session/thread/turn ids, no local path/secret exposure, no multi-user auth expansion.

## Owner URL
- `https://codex.guicheng.xyz`
- Current managed preview mode: live Web Chat upstream from the bridge service, behind owner login.
- Managed preview commands:
  - `npm run web:preview:start`
  - `npm run web:preview:status`
  - `npm run web:preview:smoke`
  - `npm run web:preview:rotate`
  - `npm run web:preview:stop`

## Verification
- `npx tsx --test src/web/readonly-http-server.test.ts src/service-web-submit.test.ts`
- `npm run check`
- `git diff --check`
- `bash -n scripts/web-preview-start.sh`
- `python3 scripts/web-owner-cookie-proxy.py --self-test`
- `npm run web:preview:status`
- `npm run web:preview:smoke`
- Public URL smoke: owner login + authenticated Home + conversation detail + enabled composer present.
- Live POST proof: harmless Web message submitted through the composer path returned `202 {"status":"accepted"}` from the live bridge submit endpoint.
- Safety smoke: unauthenticated public root shows only owner login; direct upstream without bearer is denied; smoke responses checked for no bearer/session/owner secrets, raw chat/session/thread/turn ids, local paths, stack traces, or app-server payloads.

## CI note
Ubuntu checks are merge-gating for this Web work. Windows failures are currently treated as out of scope/baseline per owner direction unless a new Web-specific regression appears.
