### PR TITLE
feat: rebuild Codex Console Web UI

### DIFF
--- a/docs/plans/2026-05-01-codex-console-web-api-contract.md
+++ b/docs/plans/2026-05-01-codex-console-web-api-contract.md
@@ -1,0 +1,104 @@
+# Codex Console Web API Contract — Phase 3
+
+## Goal
+
+Define the minimal product-shaped API boundary for the rebuilt Codex Console Web UI. This phase defines types, endpoint shapes, and safety rules only. It does not wire real Bridge state, persistence, route handlers, auth changes, or preview scripts.
+
+Boundary:
+
+```text
+Bridge internals -> ConsoleBridgeAdapter -> Web Console API -> Frontend
+```
+
+The adapter is responsible for translating Bridge-owned records into opaque Web Console records and for stripping platform/runtime internals before data reaches the Web API.
+
+## Identifier and safety rules
+
+The Web Console contract uses only opaque web IDs:
+
+- projects: `prj_...`
+- sessions: `ses_...`
+- messages: `msg_...`
+- runs: `run_...`
+- approvals: `apr_...`
+- artifacts: `art_...`
+
+The adapter must not expose raw Telegram IDs, Feishu IDs, callback IDs, chat IDs, local filesystem paths, tokens, process IDs, raw terminal logs, or raw persisted session IDs. File names shown in the UI are display labels only; they must not be absolute server paths.
+
+## Contract objects
+
+The TypeScript contract defines the minimal objects needed by the accepted fake-data UI:
+
+- `ConsoleBootstrap`
+- `ConsoleCapabilities`
+- `ConsoleProject`
+- `ConsoleSessionSummary`
+- `ConsoleSessionDetail`
+- `ConsoleMessage`
+- `ConsoleRunState`
+- `ConsoleRunStep`
+- `ConsoleDiffSummary`
+- `ConsoleApprovalRequest`
+- `ConsoleApprovalAnswerRequest`
+- `ConsoleArtifactSummary`
+- `ConsoleSendMessageRequest`
+- `ConsoleSendMessageResult`
+- `ConsoleEvent`
+- `ConsoleApiError`
+
+Capability states are part of the response body so the frontend can keep the same UI contract while disabling or degrading archive, create-session, send-message, approval, upload, event-stream, or artifact actions.
+
+## Minimal endpoints
+
+### `GET /api/console/bootstrap`
+
+Returns `ConsoleBootstrap` with owner viewer info, global capabilities, project drawer data, selected project/session IDs, command/model/mode options, and degraded-state cards.
+
+### `GET /api/projects`
+
+Returns `ConsoleProject[]` for the project drawer/sidebar. Archived projects may be omitted by default unless a later query option is added.
+
+### `POST /api/projects/:projectId/archive`
+
+Archives a project by opaque `prj_...` ID. Requires `archiveProject.state === "enabled"`. Returns the updated `ConsoleProject` or `ConsoleApiError` with `code: "capability_disabled"` when disabled.
+
+### `GET /api/projects/:projectId/sessions`
+
+Returns `ConsoleSessionSummary[]` under a project by opaque `prj_...` ID.
+
+### `POST /api/projects/:projectId/sessions`
+
+Creates a new empty session under a project by opaque `prj_...` ID. Requires `createSession.state === "enabled"`. Returns `ConsoleSessionDetail`.
+
+### `GET /api/sessions/:sessionId`
+
+Returns `ConsoleSessionDetail` by opaque `ses_...` ID, including messages, current run state, diff summaries, approval requests, artifact summaries, and the session event URL.
+
+### `POST /api/sessions/:sessionId/messages`
+
+Accepts `ConsoleSendMessageRequest` with text plus optional model, mode, and opaque artifact attachments. Requires `sendMessage.state === "enabled"`. Returns `ConsoleSendMessageResult` with the accepted user message and optional started run state.
+
+### `GET /api/sessions/:sessionId/events`
+
+SSE-first event stream for live session updates. Event payloads are `ConsoleEvent` JSON. The defined event families cover message, run, diff, approval, artifact, session, and error updates. A later fallback polling endpoint may be added without changing these event payloads.
+
+### `POST /api/approvals/:approvalId/answer`
+
+Accepts `ConsoleApprovalAnswerRequest` for an opaque `apr_...` ID. Requires `answerApproval.state === "enabled"`. Returns an approval answer result or a `ConsoleApiError`.
+
+### `GET /api/artifacts/:artifactId`
+
+Returns artifact metadata and safe preview/download data by opaque `art_...` ID. Requires `fetchArtifacts.state !== "disabled"`. It must never reveal server-local paths or raw logs.
+
+## Auth and write expectations
+
+- Owner-only auth is assumed for this phase.
+- POST routes are same-origin only and are expected to use CSRF protection before real write integration.
+- API errors use `ConsoleApiError` with safe messages and retry/capability hints.
+
+## Out of scope for Phase 3
+
+- No real Bridge integration.
+- No HTTP route handlers.
+- No persistence.
+- No auth or preview-script changes.

--- a/src/service-web-submit.test.ts
+++ b/src/service-web-submit.test.ts
@@ -172,3 +172,77 @@ test("live web chat server renders enabled composer and POST invokes BridgeServi
     }]);
   });
 });
+
+test("live web chat server wires Console API text send through BridgeService submit seam", async () => {
+  const session = sessionFixture();
+  const service = Object.create(BridgeService.prototype) as BridgeService;
+  const rawService = service as any;
+  const submitted: unknown[] = [];
+  rawService.config = { activePack: "feishu" };
+  rawService.snapshot = null;
+  rawService.store = {
+    listChatBindings: () => [{ chatId: "chat-1" }],
+    listRecentProjects: () => [],
+    listSessionProjectStats: () => [{ projectPath: session.projectPath, sessionCount: 1, lastUsedAt: session.lastUsedAt }],
+    listSessions: (chatId: string, options?: { archived?: boolean }) =>
+      [session].filter((row) => row.chatId === chatId && Boolean(row.archived) === Boolean(options?.archived)),
+    getSessionById: (sessionId: string) => sessionId === session.sessionId ? session : null,
+    listFinalAnswerViews: () => [],
+    getReadinessSnapshot: () => null,
+    listPendingInteractionsByChat: () => []
+  };
+  rawService.listActiveTurns = () => [];
+  rawService.submitWebTextMessage = async (request: unknown) => {
+    submitted.push(request);
+    return { status: "accepted" };
+  };
+
+  const csrfToken = "csrf-safe-token";
+  const server = service.createWebChatHttpServer({ token: "owner-token", csrfToken });
+  await withListeningServer(server, async (baseUrl) => {
+    const bootstrapResponse = await fetch(`${baseUrl}/api/console/bootstrap`, {
+      headers: { Authorization: "Bearer owner-token" }
+    });
+    const bootstrap = await bootstrapResponse.json() as {
+      activeSessionId?: string;
+      capabilities: {
+        sendMessage: { state: string };
+        archiveProject: { state: string };
+        createSession: { state: string };
+        answerApproval: { state: string };
+      };
+    };
+    assert.equal(bootstrapResponse.status, 200);
+    assert.equal(bootstrap.capabilities.sendMessage.state, "enabled");
+    assert.equal(bootstrap.capabilities.archiveProject.state, "disabled");
+    assert.equal(bootstrap.capabilities.createSession.state, "disabled");
+    assert.equal(bootstrap.capabilities.answerApproval.state, "disabled");
+    assert.ok(bootstrap.activeSessionId);
+
+    const response = await fetch(`${baseUrl}/api/sessions/${bootstrap.activeSessionId}/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer owner-token",
+        "Content-Type": "application/json",
+        "X-CSRF-Token": csrfToken,
+        Host: "127.0.0.1"
+      },
+      body: JSON.stringify({ text: " live Console hello " }),
+      redirect: "manual"
+    });
+    const body = await response.json() as { accepted: true; sessionId: string; message: { text: string } };
+
+    assert.equal(response.status, 202);
+    assert.equal(body.accepted, true);
+    assert.equal(body.sessionId, bootstrap.activeSessionId);
+    assert.equal(body.message.text, "live Console hello");
+    assert.deepEqual(submitted, [{
+      conversationHandle: conversationHandleForSessionId(session.sessionId),
+      text: "live Console hello",
+      nonce: null
+    }]);
+    for (const forbidden of [session.sessionId, session.chatId, session.threadId, session.projectPath, conversationHandleForSessionId(session.sessionId)]) {
+      assert.equal(JSON.stringify(body).includes(String(forbidden)), false, `Console API leaked ${forbidden}`);
+    }
+  });
+});

--- a/src/web/console-api-contract.test.ts
+++ b/src/web/console-api-contract.test.ts
@@ -1,0 +1,381 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CONSOLE_API_VERSION,
+  CONSOLE_EVENT_TYPES,
+  assertConsoleOpaqueId,
+  assertConsoleSafeString,
+  isConsoleOpaqueId
+} from "./console-api-contract.js";
+import type {
+  ConsoleApprovalAnswerRequest,
+  ConsoleApprovalRequest,
+  ConsoleArtifactSummary,
+  ConsoleBootstrap,
+  ConsoleCapabilities,
+  ConsoleDiffSummary,
+  ConsoleEvent,
+  ConsoleMessage,
+  ConsoleOpaqueIdKind,
+  ConsoleRunState,
+  ConsoleSendMessageRequest,
+  ConsoleSendMessageResult,
+  ConsoleSessionDetail,
+  ConsoleSessionSummary
+} from "./console-api-contract.js";
+
+const enabledCapabilities: ConsoleCapabilities = {
+  archiveProject: { state: "enabled" },
+  createSession: { state: "enabled" },
+  sendMessage: { state: "enabled" },
+  answerApproval: { state: "enabled" },
+  uploadFiles: { state: "enabled" },
+  streamEvents: { state: "enabled" },
+  fetchArtifacts: { state: "enabled" }
+};
+
+const disabledCapabilities: ConsoleCapabilities = {
+  archiveProject: { state: "disabled", reason: "Project archive is temporarily unavailable" },
+  createSession: { state: "disabled", reason: "Session creation is paused" },
+  sendMessage: { state: "disabled", reason: "Bridge is reconnecting" },
+  answerApproval: { state: "disabled", reason: "Approvals are read-only" },
+  uploadFiles: { state: "disabled", reason: "Uploads are not enabled for this phase" },
+  streamEvents: { state: "degraded", reason: "SSE reconnect is active" },
+  fetchArtifacts: { state: "enabled" }
+};
+
+const run: ConsoleRunState = {
+  runId: "run_6d2Vt8Wx4Dd",
+  sessionId: "ses_8h4Lm2Np6Bb",
+  title: "Refactoring auth middleware",
+  status: "running",
+  progressLabel: "2/5 steps",
+  progressPercent: 42,
+  steps: [
+    { order: 1, label: "Analyze current middleware", state: "done" },
+    { order: 2, label: "Refactor to async/await", state: "active" }
+  ],
+  updatedAt: "2026-05-01T00:00:00.000Z"
+};
+
+const message: ConsoleMessage = {
+  messageId: "msg_3k9Pq1Rs7Cc",
+  sessionId: "ses_8h4Lm2Np6Bb",
+  role: "user",
+  text: "Refactor auth middleware and keep behavior identical.",
+  format: "plain_text",
+  status: "complete",
+  createdAt: "2026-05-01T00:00:00.000Z",
+  runId: "run_6d2Vt8Wx4Dd"
+};
+
+const diff: ConsoleDiffSummary = {
+  sessionId: "ses_8h4Lm2Np6Bb",
+  runId: "run_6d2Vt8Wx4Dd",
+  title: "Pending file changes",
+  status: "preview",
+  totals: { changedFiles: 1, added: 23, removed: 17 },
+  files: [{ displayName: "src/web/App.tsx", status: "modified", added: 23, removed: 17 }]
+};
+
+const approval: ConsoleApprovalRequest = {
+  approvalId: "apr_5n7Yb3Za8Ee",
+  sessionId: "ses_8h4Lm2Np6Bb",
+  runId: "run_6d2Vt8Wx4Dd",
+  title: "Run tests",
+  body: "Codex wants to run the targeted web test suite.",
+  kind: "command",
+  status: "pending",
+  requestedAt: "2026-05-01T00:00:00.000Z",
+  options: [
+    { answer: "approve", label: "Approve", style: "primary" },
+    { answer: "deny", label: "Deny", style: "secondary" }
+  ]
+};
+
+const artifact: ConsoleArtifactSummary = {
+  artifactId: "art_2m6Bc4De9Ff",
+  sessionId: "ses_8h4Lm2Np6Bb",
+  runId: "run_6d2Vt8Wx4Dd",
+  kind: "run_summary",
+  status: "ready",
+  title: "Run summary",
+  displayName: "run-summary.md",
+  mediaType: "text/markdown",
+  sizeBytes: 2048,
+  url: "/api/artifacts/art_2m6Bc4De9Ff",
+  files: [{ displayName: "src/web/App.tsx", status: "modified", added: 23, removed: 17 }]
+};
+
+const sessionSummary: ConsoleSessionSummary = {
+  sessionId: "ses_8h4Lm2Np6Bb",
+  projectId: "prj_7f3Kp9Qm2Aa",
+  title: "Refactor auth middleware",
+  status: "running",
+  archived: false,
+  createdAt: "2026-05-01T00:00:00.000Z",
+  lastActivityAt: "2026-05-01T00:01:00.000Z",
+  lastMessagePreview: "Refactor auth middleware and keep behavior identical.",
+  activeRunId: "run_6d2Vt8Wx4Dd",
+  pendingApprovalCount: 1,
+  artifactCount: 1
+};
+
+const sessionDetail: ConsoleSessionDetail = {
+  ...sessionSummary,
+  messages: [message],
+  activeRun: run,
+  diffs: [diff],
+  approvals: [approval],
+  artifacts: [artifact],
+  eventsUrl: "/api/sessions/ses_8h4Lm2Np6Bb/events"
+};
+
+const bootstrap: ConsoleBootstrap = {
+  apiVersion: CONSOLE_API_VERSION,
+  generatedAt: "2026-05-01T00:00:00.000Z",
+  viewer: { role: "owner", displayName: "Workspace owner" },
+  capabilities: enabledCapabilities,
+  projects: [
+    {
+      projectId: "prj_7f3Kp9Qm2Aa",
+      title: "acme/web",
+      branch: "main",
+      hint: "apps:web",
+      archived: false,
+      sessionCount: 3,
+      activeSessionId: "ses_8h4Lm2Np6Bb",
+      lastActivityAt: "2026-05-01T00:01:00.000Z"
+    }
+  ],
+  activeProjectId: "prj_7f3Kp9Qm2Aa",
+  activeSessionId: "ses_8h4Lm2Np6Bb",
+  commands: [
+    { name: "/code", label: "Code", enabled: true },
+    { name: "/review", label: "Review", enabled: true }
+  ],
+  models: [{ value: "gpt-5.5-xhigh", label: "GPT-5.5 xhigh", enabled: true }],
+  modes: [{ value: "auto", label: "Auto", enabled: true }],
+  degradedStates: []
+};
+
+const sendMessageRequest: ConsoleSendMessageRequest = {
+  text: "Please continue the refactor.",
+  model: "gpt-5.5-xhigh",
+  mode: "auto",
+  attachmentArtifactIds: ["art_2m6Bc4De9Ff"]
+};
+
+const sendMessageResult: ConsoleSendMessageResult = {
+  accepted: true,
+  sessionId: "ses_8h4Lm2Np6Bb",
+  message: {
+    ...message,
+    messageId: "msg_7c1Uv5Wx2Gg",
+    text: sendMessageRequest.text
+  },
+  run
+};
+
+const approvalAnswerRequest: ConsoleApprovalAnswerRequest = {
+  answer: "approve",
+  scope: "single",
+  reason: "Run the targeted tests."
+};
+
+test("sample valid contract objects use only opaque console ids and safe strings", () => {
+  const validObjects = [
+    bootstrap,
+    sessionSummary,
+    sessionDetail,
+    message,
+    run,
+    diff,
+    approval,
+    approvalAnswerRequest,
+    artifact,
+    sendMessageRequest,
+    sendMessageResult
+  ];
+
+  for (const value of validObjects) {
+    assertOpaqueIdsInShape(value);
+    assertSafeStringsInShape(value);
+    assertNoPlatformSpecificKeys(value);
+  }
+});
+
+test("invalid or raw ids are rejected by helper validators", () => {
+  const invalidIds: Array<[ConsoleOpaqueIdKind, unknown]> = [
+    ["project", "project-1"],
+    ["project", "prj_/home/ubuntu/app"],
+    ["session", "session-raw-1"],
+    ["session", "1234567890123"],
+    ["message", "telegram_message_123"],
+    ["run", "pid=12345"],
+    ["approval", "callback:approve:123"],
+    ["artifact", "art_tmp/file"],
+    ["artifact", null]
+  ];
+
+  for (const [kind, value] of invalidIds) {
+    assert.equal(isConsoleOpaqueId(kind, value), false, `${String(value)} should not be a ${kind} id`);
+  }
+
+  assert.equal(isConsoleOpaqueId("project", "prj_7f3Kp9Qm2Aa"), true);
+  assert.equal(assertConsoleOpaqueId("artifact", "art_2m6Bc4De9Ff"), "art_2m6Bc4De9Ff");
+  assert.throws(() => assertConsoleOpaqueId("approval", "callback_data=approve", "approvalId"), /opaque approval/);
+
+  for (const unsafe of [
+    "telegram chat_id=123456789",
+    "feishu open_id=ou_123",
+    "callback_data=approve:123",
+    "/home/ubuntu/secret-project",
+    "token=abc123",
+    "pid=4242",
+    "\u001b[31mraw terminal\u001b[0m",
+    "1234567890123"
+  ]) {
+    assert.throws(() => assertConsoleSafeString(unsafe), TypeError, `${unsafe} should be unsafe`);
+  }
+});
+
+test("event types cover message, run, diff, approval, artifact, session, and error families", () => {
+  const categories = new Set(CONSOLE_EVENT_TYPES.map((type) => (type === "error" ? "error" : type.split(".")[0])));
+
+  assert.deepEqual([...categories].sort(), ["approval", "artifact", "diff", "error", "message", "run", "session"]);
+
+  const events: ConsoleEvent[] = [
+    { type: "message.created", sequence: 1, createdAt: "2026-05-01T00:00:00.000Z", sessionId: "ses_8h4Lm2Np6Bb", message },
+    { type: "run.updated", sequence: 2, createdAt: "2026-05-01T00:00:01.000Z", sessionId: "ses_8h4Lm2Np6Bb", run },
+    { type: "diff.updated", sequence: 3, createdAt: "2026-05-01T00:00:02.000Z", sessionId: "ses_8h4Lm2Np6Bb", diff },
+    { type: "approval.requested", sequence: 4, createdAt: "2026-05-01T00:00:03.000Z", sessionId: "ses_8h4Lm2Np6Bb", approval },
+    { type: "artifact.created", sequence: 5, createdAt: "2026-05-01T00:00:04.000Z", sessionId: "ses_8h4Lm2Np6Bb", artifact },
+    { type: "session.updated", sequence: 6, createdAt: "2026-05-01T00:00:05.000Z", session: sessionSummary },
+    {
+      type: "error",
+      sequence: 7,
+      createdAt: "2026-05-01T00:00:06.000Z",
+      sessionId: "ses_8h4Lm2Np6Bb",
+      error: { code: "bridge_unavailable", message: "Live updates are reconnecting", retryable: true }
+    }
+  ];
+
+  for (const event of events) {
+    assertOpaqueIdsInShape(event);
+    assertSafeStringsInShape(event);
+  }
+});
+
+test("capabilities can disable archive, create, send, approve, and upload without changing contract shape", () => {
+  assert.deepEqual(Object.keys(disabledCapabilities).sort(), Object.keys(enabledCapabilities).sort());
+
+  for (const key of ["archiveProject", "createSession", "sendMessage", "answerApproval", "uploadFiles"] as const) {
+    assert.equal(disabledCapabilities[key].state, "disabled");
+    assert.equal(typeof disabledCapabilities[key].reason, "string");
+  }
+
+  const degradedBootstrap: ConsoleBootstrap = {
+    ...bootstrap,
+    capabilities: disabledCapabilities,
+    degradedStates: [
+      {
+        code: "bridge_reconnecting",
+        title: "Connection needs attention",
+        body: "Live updates may be delayed.",
+        ownerAction: "Check the bridge service before starting a long run."
+      }
+    ]
+  };
+
+  assert.equal(degradedBootstrap.capabilities.streamEvents.state, "degraded");
+  assertSafeStringsInShape(degradedBootstrap);
+});
+
+test("contract samples do not require platform-specific or raw bridge identifier fields", () => {
+  const allSamples = { bootstrap, sessionDetail, sendMessageRequest, sendMessageResult, approvalAnswerRequest };
+
+  assertNoPlatformSpecificKeys(allSamples);
+  assert.doesNotMatch(JSON.stringify(allSamples), /(?:chat_id|callback_data|open_id|union_id|telegram|feishu|processId|pid|token)/i);
+});
+
+const idFieldKinds = {
+  projectId: "project",
+  activeProjectId: "project",
+  sessionId: "session",
+  activeSessionId: "session",
+  messageId: "message",
+  runId: "run",
+  activeRunId: "run",
+  approvalId: "approval",
+  artifactId: "artifact"
+} as const satisfies Record<string, ConsoleOpaqueIdKind>;
+
+const listIdFieldKinds = {
+  approvalIds: "approval",
+  artifactIds: "artifact",
+  attachmentArtifactIds: "artifact"
+} as const satisfies Record<string, ConsoleOpaqueIdKind>;
+
+function assertOpaqueIdsInShape(value: unknown): void {
+  visitShape(value, (node, key) => {
+    if (!key) {
+      return;
+    }
+
+    const idKind = idFieldKinds[key as keyof typeof idFieldKinds];
+    if (idKind) {
+      assert.equal(isConsoleOpaqueId(idKind, node), true, `${key} must be an opaque ${idKind} id`);
+      return;
+    }
+
+    const listIdKind = listIdFieldKinds[key as keyof typeof listIdFieldKinds];
+    if (listIdKind) {
+      assert.ok(Array.isArray(node), `${key} must be an array`);
+      for (const item of node) {
+        assert.equal(isConsoleOpaqueId(listIdKind, item), true, `${key} item must be an opaque ${listIdKind} id`);
+      }
+    }
+  });
+}
+
+function assertSafeStringsInShape(value: unknown): void {
+  visitShape(value, (node, key) => {
+    if (typeof node === "string") {
+      assertConsoleSafeString(node, key ?? "value");
+    }
+  });
+}
+
+function assertNoPlatformSpecificKeys(value: unknown): void {
+  visitShape(value, (_node, key) => {
+    if (!key) {
+      return;
+    }
+    assert.doesNotMatch(
+      key,
+      /(?:telegram|feishu|chat|callback|process|pid|token|filesystem|localPath|rawSession|persistedSession|stdout|stderr|terminalLog)/i,
+      `platform-specific field leaked into contract: ${key}`
+    );
+  });
+}
+
+function visitShape(value: unknown, visitor: (node: unknown, key?: string) => void, key?: string): void {
+  visitor(value, key);
+
+  if (!value || typeof value !== "object") {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitShape(item, visitor);
+    }
+    return;
+  }
+
+  for (const [childKey, childValue] of Object.entries(value)) {
+    visitShape(childValue, visitor, childKey);
+  }
+}

--- a/src/web/console-api-contract.ts
+++ b/src/web/console-api-contract.ts
@@ -88,6 +88,15 @@ export interface ConsoleProject {
   lastActivityAt?: string;
 }
 
+export interface ConsoleArchiveProjectRequest {
+  projectId: ConsoleProjectId;
+}
+
+export interface ConsoleCreateSessionRequest {
+  projectId: ConsoleProjectId;
+  title?: string;
+}
+
 export type ConsoleSessionStatus =
   | "empty"
   | "idle"

--- a/src/web/console-api-contract.ts
+++ b/src/web/console-api-contract.ts
@@ -1,0 +1,398 @@
+export const CONSOLE_API_VERSION = "2026-05-01.phase3" as const;
+
+export const CONSOLE_OPAQUE_ID_PREFIXES = {
+  project: "prj",
+  session: "ses",
+  message: "msg",
+  run: "run",
+  approval: "apr",
+  artifact: "art"
+} as const;
+
+export type ConsoleOpaqueIdKind = keyof typeof CONSOLE_OPAQUE_ID_PREFIXES;
+type ConsoleOpaqueIdPrefix<K extends ConsoleOpaqueIdKind> = (typeof CONSOLE_OPAQUE_ID_PREFIXES)[K];
+export type ConsoleOpaqueIdFor<K extends ConsoleOpaqueIdKind> = `${ConsoleOpaqueIdPrefix<K>}_${string}`;
+
+export type ConsoleProjectId = ConsoleOpaqueIdFor<"project">;
+export type ConsoleSessionId = ConsoleOpaqueIdFor<"session">;
+export type ConsoleMessageId = ConsoleOpaqueIdFor<"message">;
+export type ConsoleRunId = ConsoleOpaqueIdFor<"run">;
+export type ConsoleApprovalId = ConsoleOpaqueIdFor<"approval">;
+export type ConsoleArtifactId = ConsoleOpaqueIdFor<"artifact">;
+
+export type ConsoleCapabilityState = "enabled" | "disabled" | "degraded";
+
+export interface ConsoleCapability {
+  state: ConsoleCapabilityState;
+  reason?: string;
+  ownerAction?: string;
+}
+
+export interface ConsoleCapabilities {
+  archiveProject: ConsoleCapability;
+  createSession: ConsoleCapability;
+  sendMessage: ConsoleCapability;
+  answerApproval: ConsoleCapability;
+  uploadFiles: ConsoleCapability;
+  streamEvents: ConsoleCapability;
+  fetchArtifacts: ConsoleCapability;
+}
+
+export interface ConsoleDegradedState {
+  code: string;
+  title: string;
+  body: string;
+  ownerAction?: string;
+  since?: string;
+}
+
+export interface ConsoleBootstrap {
+  apiVersion: typeof CONSOLE_API_VERSION;
+  generatedAt: string;
+  viewer: ConsoleViewer;
+  capabilities: ConsoleCapabilities;
+  projects: ConsoleProject[];
+  activeProjectId?: ConsoleProjectId;
+  activeSessionId?: ConsoleSessionId;
+  commands: ConsoleCommandSummary[];
+  models: ConsoleSelectorOption[];
+  modes: ConsoleSelectorOption[];
+  degradedStates: ConsoleDegradedState[];
+}
+
+export interface ConsoleViewer {
+  role: "owner";
+  displayName?: string;
+}
+
+export interface ConsoleCommandSummary {
+  name: string;
+  label: string;
+  enabled: boolean;
+}
+
+export interface ConsoleSelectorOption {
+  value: string;
+  label: string;
+  enabled: boolean;
+}
+
+export interface ConsoleProject {
+  projectId: ConsoleProjectId;
+  title: string;
+  branch?: string;
+  hint?: string;
+  archived: boolean;
+  sessionCount: number;
+  activeSessionId?: ConsoleSessionId;
+  lastActivityAt?: string;
+}
+
+export type ConsoleSessionStatus =
+  | "empty"
+  | "idle"
+  | "running"
+  | "waiting_for_approval"
+  | "completed"
+  | "failed"
+  | "archived";
+
+export interface ConsoleSessionSummary {
+  sessionId: ConsoleSessionId;
+  projectId: ConsoleProjectId;
+  title: string;
+  status: ConsoleSessionStatus;
+  archived: boolean;
+  createdAt: string;
+  lastActivityAt?: string;
+  lastMessagePreview?: string;
+  activeRunId?: ConsoleRunId;
+  pendingApprovalCount: number;
+  artifactCount: number;
+}
+
+export interface ConsoleSessionDetail extends ConsoleSessionSummary {
+  messages: ConsoleMessage[];
+  activeRun?: ConsoleRunState;
+  diffs: ConsoleDiffSummary[];
+  approvals: ConsoleApprovalRequest[];
+  artifacts: ConsoleArtifactSummary[];
+  eventsUrl: `/api/sessions/${ConsoleSessionId}/events`;
+}
+
+export type ConsoleMessageRole = "user" | "assistant" | "system";
+export type ConsoleMessageFormat = "plain_text" | "markdown";
+export type ConsoleMessageStatus = "pending" | "streaming" | "complete" | "failed";
+
+export interface ConsoleMessage {
+  messageId: ConsoleMessageId;
+  sessionId: ConsoleSessionId;
+  role: ConsoleMessageRole;
+  text: string;
+  format: ConsoleMessageFormat;
+  status: ConsoleMessageStatus;
+  createdAt: string;
+  updatedAt?: string;
+  runId?: ConsoleRunId;
+  approvalIds?: ConsoleApprovalId[];
+  artifactIds?: ConsoleArtifactId[];
+}
+
+export type ConsoleRunStatus =
+  | "queued"
+  | "running"
+  | "waiting_for_approval"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export interface ConsoleRunState {
+  runId: ConsoleRunId;
+  sessionId: ConsoleSessionId;
+  title: string;
+  status: ConsoleRunStatus;
+  progressLabel?: string;
+  progressPercent?: number;
+  steps: ConsoleRunStep[];
+  startedAt?: string;
+  updatedAt: string;
+  completedAt?: string;
+}
+
+export type ConsoleRunStepState = "pending" | "active" | "done" | "failed" | "skipped";
+
+export interface ConsoleRunStep {
+  order: number;
+  label: string;
+  state: ConsoleRunStepState;
+  summary?: string;
+}
+
+export interface ConsoleDiffSummary {
+  sessionId: ConsoleSessionId;
+  runId?: ConsoleRunId;
+  title: string;
+  status: "preview" | "applied" | "discarded";
+  totals: ConsoleDiffTotals;
+  files: ConsoleDiffFileSummary[];
+}
+
+export interface ConsoleDiffTotals {
+  changedFiles: number;
+  added: number;
+  removed: number;
+}
+
+export interface ConsoleDiffFileSummary {
+  displayName: string;
+  status: "created" | "modified" | "deleted" | "renamed";
+  added: number;
+  removed: number;
+}
+
+export type ConsoleApprovalStatus = "pending" | "approved" | "denied" | "expired";
+export type ConsoleApprovalKind = "command" | "file_change" | "network" | "external_action" | "other";
+export type ConsoleApprovalAnswer = "approve" | "deny";
+
+export interface ConsoleApprovalRequest {
+  approvalId: ConsoleApprovalId;
+  sessionId: ConsoleSessionId;
+  runId?: ConsoleRunId;
+  title: string;
+  body: string;
+  kind: ConsoleApprovalKind;
+  status: ConsoleApprovalStatus;
+  requestedAt: string;
+  expiresAt?: string;
+  options: ConsoleApprovalOption[];
+}
+
+export interface ConsoleApprovalOption {
+  answer: ConsoleApprovalAnswer;
+  label: string;
+  style: "primary" | "secondary" | "danger";
+}
+
+export interface ConsoleApprovalAnswerRequest {
+  answer: ConsoleApprovalAnswer;
+  scope?: "single" | "all_pending_in_session";
+  reason?: string;
+}
+
+export interface ConsoleApprovalAnswerResult {
+  approvalId: ConsoleApprovalId;
+  sessionId: ConsoleSessionId;
+  status: "approved" | "denied";
+  answeredAt: string;
+}
+
+export type ConsoleArtifactKind = "changed_file" | "generated_file" | "diff" | "run_summary" | "attachment";
+export type ConsoleArtifactStatus = "pending" | "ready" | "failed";
+
+export interface ConsoleArtifactSummary {
+  artifactId: ConsoleArtifactId;
+  sessionId: ConsoleSessionId;
+  runId?: ConsoleRunId;
+  kind: ConsoleArtifactKind;
+  status: ConsoleArtifactStatus;
+  title: string;
+  displayName: string;
+  mediaType?: string;
+  sizeBytes?: number;
+  url: `/api/artifacts/${ConsoleArtifactId}`;
+  files?: ConsoleArtifactFileSummary[];
+}
+
+export interface ConsoleArtifactFileSummary {
+  displayName: string;
+  status: "created" | "modified" | "deleted" | "generated";
+  added?: number;
+  removed?: number;
+}
+
+export interface ConsoleArtifactDetail extends ConsoleArtifactSummary {
+  textPreview?: string;
+}
+
+export interface ConsoleSendMessageRequest {
+  text: string;
+  model?: string;
+  mode?: string;
+  attachmentArtifactIds?: ConsoleArtifactId[];
+}
+
+export interface ConsoleSendMessageResult {
+  accepted: true;
+  sessionId: ConsoleSessionId;
+  message: ConsoleMessage;
+  run?: ConsoleRunState;
+  warnings?: ConsoleApiError[];
+}
+
+export const CONSOLE_EVENT_TYPES = [
+  "message.created",
+  "message.updated",
+  "run.started",
+  "run.updated",
+  "run.completed",
+  "run.failed",
+  "diff.updated",
+  "approval.requested",
+  "approval.answered",
+  "artifact.created",
+  "artifact.updated",
+  "session.created",
+  "session.updated",
+  "session.archived",
+  "error"
+] as const;
+
+export type ConsoleEventType = (typeof CONSOLE_EVENT_TYPES)[number];
+
+interface ConsoleEventBase {
+  type: ConsoleEventType;
+  sequence: number;
+  createdAt: string;
+}
+
+export type ConsoleEvent =
+  | (ConsoleEventBase & {
+      type: "message.created" | "message.updated";
+      sessionId: ConsoleSessionId;
+      message: ConsoleMessage;
+    })
+  | (ConsoleEventBase & {
+      type: "run.started" | "run.updated" | "run.completed" | "run.failed";
+      sessionId: ConsoleSessionId;
+      run: ConsoleRunState;
+    })
+  | (ConsoleEventBase & {
+      type: "diff.updated";
+      sessionId: ConsoleSessionId;
+      diff: ConsoleDiffSummary;
+    })
+  | (ConsoleEventBase & {
+      type: "approval.requested" | "approval.answered";
+      sessionId: ConsoleSessionId;
+      approval: ConsoleApprovalRequest;
+    })
+  | (ConsoleEventBase & {
+      type: "artifact.created" | "artifact.updated";
+      sessionId: ConsoleSessionId;
+      artifact: ConsoleArtifactSummary;
+    })
+  | (ConsoleEventBase & {
+      type: "session.created" | "session.updated" | "session.archived";
+      session: ConsoleSessionSummary;
+    })
+  | (ConsoleEventBase & {
+      type: "error";
+      sessionId?: ConsoleSessionId;
+      error: ConsoleApiError;
+    });
+
+export interface ConsoleApiError {
+  code:
+    | "bad_request"
+    | "unauthorized"
+    | "forbidden"
+    | "not_found"
+    | "capability_disabled"
+    | "conflict"
+    | "rate_limited"
+    | "bridge_unavailable"
+    | "internal_error";
+  message: string;
+  retryable: boolean;
+  capability?: keyof ConsoleCapabilities;
+}
+
+export function isConsoleOpaqueId<K extends ConsoleOpaqueIdKind>(
+  kind: K,
+  value: unknown
+): value is ConsoleOpaqueIdFor<K> {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const prefix = CONSOLE_OPAQUE_ID_PREFIXES[kind];
+  const pattern = new RegExp(`^${prefix}_(?=[A-Za-z0-9_-]{6,128}$)(?=.*[A-Za-z])(?=.*\\d)[A-Za-z0-9][A-Za-z0-9_-]*$`);
+  const rawIdMarker = /\b(?:telegram|feishu|callback|chat|open_id|union_id|tenant|pid|process|raw)\b/i;
+  return pattern.test(value) && !rawIdMarker.test(value);
+}
+
+export function assertConsoleOpaqueId<K extends ConsoleOpaqueIdKind>(
+  kind: K,
+  value: unknown,
+  fieldName = "id"
+): ConsoleOpaqueIdFor<K> {
+  if (!isConsoleOpaqueId(kind, value)) {
+    throw new TypeError(`${fieldName} must be an opaque ${kind} console id`);
+  }
+  return value as ConsoleOpaqueIdFor<K>;
+}
+
+const unsafeConsoleStringPatterns: Array<{ label: string; pattern: RegExp }> = [
+  { label: "absolute local path", pattern: /(^|[\s"'(])(?:\/(?:home|tmp|var|etc|root|Users)\/|[A-Za-z]:\\)/ },
+  {
+    label: "secret-bearing string",
+    pattern: /\b(?:token|authorization|bearer|api[_-]?key|secret|password)\s*[:=]|\b(?:sk|xox[baprs])-[A-Za-z0-9_-]{8,}/i
+  },
+  {
+    label: "platform-specific identifier",
+    pattern:
+      /\b(?:(?:telegram|feishu)[_-]?(?:chat|message|user|open|union|tenant)?[_-]?id|chat[_-]?id|callback[_-]?data|open[_-]?id|union[_-]?id|tenant[_-]?key)\b/i
+  },
+  { label: "process identifier", pattern: /\b(?:pid|process[_-]?id)\s*[:=]?\s*\d{2,}\b/i },
+  { label: "terminal escape sequence", pattern: /\x1b\[[0-9;?]*[ -/]*[@-~]/ },
+  { label: "raw numeric identifier", pattern: /^-?\d{8,}$/ }
+];
+
+export function assertConsoleSafeString(value: string, fieldName = "value"): string {
+  for (const { label, pattern } of unsafeConsoleStringPatterns) {
+    if (pattern.test(value)) {
+      throw new TypeError(`${fieldName} contains ${label}`);
+    }
+  }
+  return value;
+}

--- a/src/web/console-api-http.test.ts
+++ b/src/web/console-api-http.test.ts
@@ -6,7 +6,14 @@ import type { AddressInfo } from "node:net";
 import { createReadonlyAccessGate } from "./readonly-access.js";
 import { createReadonlyHttpServer } from "./readonly-http-server.js";
 import { createConsoleBridgeReadAdapter, type ConsoleBridgeReadAdapter } from "./console-bridge-read-adapter.js";
+import type { ConsoleApiWriteAdapter } from "./console-api-http.js";
 import { isConsoleOpaqueId, type ConsoleApiError, type ConsoleOpaqueIdKind } from "./console-api-contract.js";
+import type {
+  ConsoleApprovalAnswerResult,
+  ConsoleProject,
+  ConsoleSendMessageResult,
+  ConsoleSessionDetail
+} from "./console-api-contract.js";
 import type {
   WebReadonlyConversationResultViewModel,
   WebReadonlyViewModelProvider
@@ -241,6 +248,53 @@ function conversationDetail(conversationHandle: string): WebReadonlyConversation
   };
 }
 
+const validProject: ConsoleProject = {
+  projectId: "prj_7f3Kp9Qm2Aa",
+  title: "Console Core",
+  archived: true,
+  sessionCount: 1,
+  activeSessionId: "ses_8h4Lm2Np6Bb",
+  lastActivityAt: fixedNow
+};
+
+const validSession: ConsoleSessionDetail = {
+  sessionId: "ses_8h4Lm2Np6Bb",
+  projectId: "prj_7f3Kp9Qm2Aa",
+  title: "Implement API wiring",
+  status: "idle",
+  archived: false,
+  createdAt: fixedNow,
+  lastActivityAt: fixedNow,
+  pendingApprovalCount: 0,
+  artifactCount: 0,
+  messages: [],
+  diffs: [],
+  approvals: [],
+  artifacts: [],
+  eventsUrl: "/api/sessions/ses_8h4Lm2Np6Bb/events"
+};
+
+const validSendResult: ConsoleSendMessageResult = {
+  accepted: true,
+  sessionId: "ses_8h4Lm2Np6Bb",
+  message: {
+    messageId: "msg_3k9Pq1Rs7Cc",
+    sessionId: "ses_8h4Lm2Np6Bb",
+    role: "user",
+    text: "Continue the safe API wiring.",
+    format: "plain_text",
+    status: "pending",
+    createdAt: fixedNow
+  }
+};
+
+const validApprovalAnswer: ConsoleApprovalAnswerResult = {
+  approvalId: "apr_5n7Yb3Za8Ee",
+  sessionId: "ses_8h4Lm2Np6Bb",
+  status: "approved",
+  answeredAt: fixedNow
+};
+
 async function withServer<T>(
   options: Parameters<typeof createReadonlyHttpServer>[0],
   run: (baseUrl: string) => Promise<T>
@@ -257,19 +311,39 @@ async function withServer<T>(
 
 async function request(
   url: string,
-  options: { bearer?: string; method?: string } = {}
+  options: { bearer?: string; method?: string; body?: string; headers?: Record<string, string> } = {}
 ): Promise<{ status: number; text: string; headers: Headers }> {
+  const headers: Record<string, string> = { ...(options.headers ?? {}) };
+  if (options.bearer) {
+    headers.Authorization = `Bearer ${options.bearer}`;
+  }
   const init: RequestInit = {
     method: options.method ?? "GET",
-    redirect: "manual"
+    redirect: "manual",
+    headers,
+    ...(options.body !== undefined ? { body: options.body } : {})
   };
-  if (options.bearer) {
-    init.headers = { Authorization: `Bearer ${options.bearer}` };
-  }
   const response = await fetch(url, {
     ...init
   });
   return { status: response.status, text: await response.text(), headers: response.headers };
+}
+
+function jsonPost(
+  baseUrl: string,
+  path: string,
+  body: unknown,
+  options: { bearer?: string; headers?: Record<string, string> } = {}
+): Promise<{ status: number; text: string; headers: Headers }> {
+  return request(`${baseUrl}${path}`, {
+    bearer: options.bearer ?? token,
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers ?? {})
+    }
+  });
 }
 
 test("unauthenticated API request returns generic JSON denial and does not invoke provider or adapter", async () => {
@@ -433,6 +507,301 @@ test("unsupported POST API routes remain denied/not found and do not invoke read
     assert.equal(result.status, 404);
     assert.deepEqual(JSON.parse(result.text), { code: "not_found", message: "Not found.", retryable: false });
     assert.deepEqual(calls, []);
+  });
+});
+
+test("unauthenticated POST API is denied and does not call write handlers", async () => {
+  const calls: string[] = [];
+  const writeCalls: string[] = [];
+  const writeAdapter: ConsoleApiWriteAdapter = {
+    sendMessage() {
+      writeCalls.push("send");
+      return validSendResult;
+    },
+    answerApproval() {
+      writeCalls.push("approval");
+      return validApprovalAnswer;
+    }
+  };
+
+  await withServer({
+    provider: makeProvider(calls),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    consoleWriteAdapter: writeAdapter,
+    send: {
+      csrfToken: "csrf-safe-token",
+      submitTextMessage: () => ({ status: "accepted" })
+    }
+  }, async (baseUrl) => {
+    const result = await request(`${baseUrl}/api/sessions/ses_8h4Lm2Np6Bb/messages`, {
+      method: "POST",
+      body: JSON.stringify({ text: "hello" }),
+      headers: { "Content-Type": "application/json" }
+    });
+
+    assert.equal(result.status, 404);
+    assert.match(result.headers.get("content-type") ?? "", /^application\/json; charset=utf-8/);
+    assert.equal(result.headers.get("cache-control"), "no-store");
+    assert.deepEqual(JSON.parse(result.text), { code: "not_found", message: "Not found.", retryable: false });
+    assert.deepEqual(writeCalls, []);
+    assert.deepEqual(calls, []);
+  });
+});
+
+test("POST archive and create session are capability-disabled without handlers", async () => {
+  await withServer({
+    provider: makeProvider(),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const archive = await jsonPost(baseUrl, "/api/projects/prj_7f3Kp9Qm2Aa/archive", {});
+    const create = await jsonPost(baseUrl, "/api/projects/prj_7f3Kp9Qm2Aa/sessions", {});
+
+    assert.equal(archive.status, 409);
+    assert.equal(archive.headers.get("cache-control"), "no-store");
+    assert.match(archive.headers.get("content-type") ?? "", /^application\/json; charset=utf-8/);
+    assert.deepEqual(JSON.parse(archive.text), {
+      code: "capability_disabled",
+      message: "Console write capability is disabled.",
+      retryable: false,
+      capability: "archiveProject"
+    });
+
+    assert.equal(create.status, 409);
+    assert.deepEqual(JSON.parse(create.text), {
+      code: "capability_disabled",
+      message: "Console write capability is disabled.",
+      retryable: false,
+      capability: "createSession"
+    });
+  });
+});
+
+test("POST archive and create session respect disabled injected capabilities", async () => {
+  const writeCalls: string[] = [];
+  const writeAdapter: ConsoleApiWriteAdapter = {
+    capabilities: {
+      archiveProject: { state: "disabled" },
+      createSession: { state: "disabled" }
+    },
+    archiveProject() {
+      writeCalls.push("archive");
+      return validProject;
+    },
+    createSession() {
+      writeCalls.push("create");
+      return validSession;
+    }
+  };
+
+  await withServer({
+    provider: makeProvider(),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    consoleWriteAdapter: writeAdapter,
+    send: {
+      csrfToken: "csrf-safe-token",
+      submitTextMessage: () => ({ status: "accepted" })
+    }
+  }, async (baseUrl) => {
+    const archive = await jsonPost(baseUrl, "/api/projects/prj_7f3Kp9Qm2Aa/archive", {}, {
+      headers: { "X-CSRF-Token": "csrf-safe-token" }
+    });
+    const create = await jsonPost(baseUrl, "/api/projects/prj_7f3Kp9Qm2Aa/sessions", {}, {
+      headers: { "X-CSRF-Token": "csrf-safe-token" }
+    });
+
+    assert.equal(archive.status, 409);
+    assert.equal(JSON.parse(archive.text).capability, "archiveProject");
+    assert.equal(create.status, 409);
+    assert.equal(JSON.parse(create.text).capability, "createSession");
+    assert.deepEqual(writeCalls, []);
+  });
+});
+
+test("POST send message rejects invalid/raw IDs, blank or oversize text, and malformed JSON", async () => {
+  const submitted: unknown[] = [];
+  await withServer({
+    provider: makeProvider(),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    consoleWriteAdapter: {
+      sendMessage(sessionId, request) {
+        submitted.push({ sessionId, request });
+        return validSendResult;
+      }
+    },
+    send: {
+      csrfToken: "csrf-safe-token",
+      submitTextMessage: () => ({ status: "accepted" })
+    }
+  }, async (baseUrl) => {
+    const headers = { "X-CSRF-Token": "csrf-safe-token" };
+    for (const rawId of ["cv_1111222233334444", "session-1", "%2Ftmp%2Fsecret", "ses_callback_data_123"]) {
+      const result = await jsonPost(baseUrl, `/api/sessions/${rawId}/messages`, { text: "hello" }, { headers });
+      assert.equal(result.status, 400, rawId);
+      assert.equal(result.text.includes(rawId), false);
+      assertNoForbiddenConsoleData(JSON.parse(result.text));
+    }
+
+    const blank = await jsonPost(baseUrl, "/api/sessions/ses_8h4Lm2Np6Bb/messages", { text: "   " }, { headers });
+    assert.equal(blank.status, 400);
+
+    const oversize = await jsonPost(baseUrl, "/api/sessions/ses_8h4Lm2Np6Bb/messages", { text: "a".repeat(8001) }, { headers });
+    assert.equal(oversize.status, 400);
+
+    const malformed = await request(`${baseUrl}/api/sessions/ses_8h4Lm2Np6Bb/messages`, {
+      bearer: token,
+      method: "POST",
+      body: "{",
+      headers: { "Content-Type": "application/json", "X-CSRF-Token": "csrf-safe-token" }
+    });
+    assert.equal(malformed.status, 400);
+
+    const wrongCsrf = await jsonPost(baseUrl, "/api/sessions/ses_8h4Lm2Np6Bb/messages", { text: "hello" }, {
+      headers: { "X-CSRF-Token": "wrong-token" }
+    });
+    assert.equal(wrongCsrf.status, 403);
+
+    assert.deepEqual(submitted, []);
+  });
+});
+
+test("POST send message calls injected handler exactly once with ConsoleSendMessageRequest", async () => {
+  const submitted: unknown[] = [];
+  await withServer({
+    provider: makeProvider(),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    consoleWriteAdapter: {
+      sendMessage(sessionId, request) {
+        submitted.push({ sessionId, request });
+        return validSendResult;
+      }
+    },
+    send: {
+      csrfToken: "csrf-safe-token",
+      submitTextMessage: () => ({ status: "accepted" })
+    }
+  }, async (baseUrl) => {
+    const result = await jsonPost(baseUrl, "/api/sessions/ses_8h4Lm2Np6Bb/messages", {
+      text: "  Continue the safe API wiring.  ",
+      model: "gpt-5.5",
+      mode: "auto",
+      attachmentArtifactIds: ["art_2m6Bc4De9Ff"]
+    }, {
+      headers: { "X-CSRF-Token": "csrf-safe-token" }
+    });
+    const body = JSON.parse(result.text) as ConsoleSendMessageResult;
+
+    assert.equal(result.status, 202);
+    assert.equal(result.headers.get("cache-control"), "no-store");
+    assert.match(result.headers.get("content-type") ?? "", /^application\/json; charset=utf-8/);
+    assert.deepEqual(submitted, [{
+      sessionId: "ses_8h4Lm2Np6Bb",
+      request: {
+        text: "Continue the safe API wiring.",
+        model: "gpt-5.5",
+        mode: "auto",
+        attachmentArtifactIds: ["art_2m6Bc4De9Ff"]
+      }
+    }]);
+    assert.equal(body.accepted, true);
+    assert.equal(body.sessionId, "ses_8h4Lm2Np6Bb");
+    assertNoForbiddenConsoleData(body);
+    assertConsoleIds(body);
+  });
+});
+
+test("POST approval answer rejects invalid decision and calls handler when valid", async () => {
+  const submitted: unknown[] = [];
+  await withServer({
+    provider: makeProvider(),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    consoleWriteAdapter: {
+      answerApproval(approvalId, request) {
+        submitted.push({ approvalId, request });
+        return validApprovalAnswer;
+      }
+    },
+    send: {
+      csrfToken: "csrf-safe-token",
+      submitTextMessage: () => ({ status: "accepted" })
+    }
+  }, async (baseUrl) => {
+    const headers = { "X-CSRF-Token": "csrf-safe-token" };
+    const invalid = await jsonPost(baseUrl, "/api/approvals/apr_5n7Yb3Za8Ee/answer", { answer: "allow" }, { headers });
+    assert.equal(invalid.status, 400);
+    assert.deepEqual(submitted, []);
+
+    const valid = await jsonPost(baseUrl, "/api/approvals/apr_5n7Yb3Za8Ee/answer", {
+      answer: "approve",
+      scope: "single",
+      reason: "Run targeted tests."
+    }, { headers });
+    const body = JSON.parse(valid.text) as ConsoleApprovalAnswerResult;
+
+    assert.equal(valid.status, 200);
+    assert.deepEqual(submitted, [{
+      approvalId: "apr_5n7Yb3Za8Ee",
+      request: {
+        answer: "approve",
+        scope: "single",
+        reason: "Run targeted tests."
+      }
+    }]);
+    assert.equal(body.status, "approved");
+    assertNoForbiddenConsoleData(body);
+    assertConsoleIds(body);
+  });
+});
+
+test("raw platform, path, and token markers are rejected from write requests and responses", async () => {
+  const submitted: unknown[] = [];
+  await withServer({
+    provider: makeProvider(),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    consoleWriteAdapter: {
+      sendMessage(sessionId, request) {
+        submitted.push({ sessionId, request });
+        return {
+          accepted: true,
+          sessionId,
+          message: {
+            messageId: "msg_3k9Pq1Rs7Cc",
+            sessionId,
+            role: "user",
+            text: "token=abc telegram callback_data=raw /tmp/secret",
+            format: "plain_text",
+            status: "pending",
+            createdAt: fixedNow
+          }
+        } as never;
+      }
+    },
+    send: {
+      csrfToken: "csrf-safe-token",
+      submitTextMessage: () => ({ status: "accepted" })
+    }
+  }, async (baseUrl) => {
+    const headers = { "X-CSRF-Token": "csrf-safe-token" };
+    const requestRejected = await jsonPost(baseUrl, "/api/sessions/ses_8h4Lm2Np6Bb/messages", {
+      text: "please use token=abc"
+    }, { headers });
+    assert.equal(requestRejected.status, 400);
+    assert.deepEqual(submitted, []);
+
+    const responseRejected = await jsonPost(baseUrl, "/api/sessions/ses_8h4Lm2Np6Bb/messages", {
+      text: "Please continue safely."
+    }, { headers });
+    const body = JSON.parse(responseRejected.text);
+
+    assert.equal(responseRejected.status, 500);
+    assert.deepEqual(body, {
+      code: "internal_error",
+      message: "Console API response is temporarily unavailable.",
+      retryable: true
+    });
+    assert.equal(submitted.length, 1);
+    for (const forbidden of ["/tmp/", "telegram", "callback_data", "token=", "secret"]) {
+      assert.equal(responseRejected.text.includes(forbidden), false, `leaked ${forbidden}: ${responseRejected.text}`);
+    }
   });
 });
 

--- a/src/web/console-api-http.test.ts
+++ b/src/web/console-api-http.test.ts
@@ -548,6 +548,51 @@ test("unauthenticated POST API is denied and does not call write handlers", asyn
   });
 });
 
+test("bootstrap write capabilities are enabled only with real handler and csrf", async () => {
+  async function bootstrap(writeAdapter: ConsoleApiWriteAdapter, includeCsrf: boolean) {
+    return await withServer({
+      provider: makeProvider(),
+      access: createReadonlyAccessGate({ enabled: true, token }),
+      consoleWriteAdapter: writeAdapter,
+      ...(includeCsrf ? {
+        send: {
+          csrfToken: "csrf-safe-token",
+          submitTextMessage: () => ({ status: "accepted" as const })
+        }
+      } : {})
+    }, async (baseUrl) => {
+      const result = await request(`${baseUrl}/api/console/bootstrap`, { bearer: token });
+      assert.equal(result.status, 200);
+      return JSON.parse(result.text);
+    });
+  }
+
+  const advertisedOnly = await bootstrap({
+    capabilities: { sendMessage: { state: "enabled" } }
+  }, true);
+  assert.equal(advertisedOnly.capabilities.sendMessage.state, "disabled");
+
+  const noCsrf = await bootstrap({
+    sendMessage: () => validSendResult
+  }, false);
+  assert.equal(noCsrf.capabilities.sendMessage.state, "disabled");
+
+  const live = await bootstrap({
+    sendMessage: () => validSendResult
+  }, true);
+  assert.equal(live.capabilities.sendMessage.state, "enabled");
+  assert.equal(live.capabilities.archiveProject.state, "disabled");
+  assert.equal(live.capabilities.createSession.state, "disabled");
+  assert.equal(live.capabilities.answerApproval.state, "disabled");
+  assertNoForbiddenConsoleData(live);
+
+  const explicitlyDisabled = await bootstrap({
+    capabilities: { sendMessage: { state: "disabled", reason: "Existing seam unavailable." } },
+    sendMessage: () => validSendResult
+  }, true);
+  assert.equal(explicitlyDisabled.capabilities.sendMessage.state, "disabled");
+});
+
 test("POST archive and create session are capability-disabled without handlers", async () => {
   await withServer({
     provider: makeProvider(),

--- a/src/web/console-api-http.test.ts
+++ b/src/web/console-api-http.test.ts
@@ -1,0 +1,588 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { AddressInfo } from "node:net";
+
+import { createReadonlyAccessGate } from "./readonly-access.js";
+import { createReadonlyHttpServer } from "./readonly-http-server.js";
+import { createConsoleBridgeReadAdapter, type ConsoleBridgeReadAdapter } from "./console-bridge-read-adapter.js";
+import { isConsoleOpaqueId, type ConsoleApiError, type ConsoleOpaqueIdKind } from "./console-api-contract.js";
+import type {
+  WebReadonlyConversationResultViewModel,
+  WebReadonlyViewModelProvider
+} from "../service/web-readonly-view-model.js";
+
+const token = "local-test-token";
+const fixedNow = "2026-05-01T00:00:00.000Z";
+
+function makeProvider(calls: string[] = []): WebReadonlyViewModelProvider {
+  return {
+    getHomeViewModel() {
+      calls.push("home");
+      throw new Error("home should not be used by API tests");
+    },
+    listWorkspaceViewModels() {
+      calls.push("workspaces");
+      return {
+        generatedAt: fixedNow,
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_workspaces",
+        state: "available",
+        workspaces: [
+          {
+            workspaceId: "wk_aaaabbbbccccdddd",
+            label: "Console Core",
+            availability: "available",
+            conversationCount: 1,
+            pinned: true,
+            lastActivityAt: "2026-04-30T12:00:00.000Z",
+            lastSuccessAt: null,
+            source: "sessions"
+          }
+        ],
+        warnings: []
+      };
+    },
+    listWorkspaceConversationViewModels(workspaceId: string) {
+      calls.push(`workspace:${workspaceId}`);
+      return {
+        generatedAt: fixedNow,
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_workspace_conversations",
+        state: "available",
+        workspaceId,
+        conversations: [
+          {
+            conversationId: "cv_1111222233334444",
+            conversationHandle: "cv_1111222233334444",
+            workspaceId,
+            title: "Implement API wiring",
+            status: "running",
+            failureReason: null,
+            archived: false,
+            createdAt: "2026-04-30T11:00:00.000Z",
+            lastActivityAt: "2026-04-30T12:01:00.000Z",
+            lastTurnStatus: "running",
+            finalAnswerAvailable: true
+          }
+        ],
+        emptyState: null,
+        warnings: []
+      };
+    },
+    getConversationResultViewModel(conversationHandle: string) {
+      calls.push(`conversation:${conversationHandle}`);
+      return conversationDetail(conversationHandle);
+    },
+    getConversationArtifactCatalogViewModel(sessionId: string) {
+      calls.push(`artifacts:${sessionId}`);
+      return {
+        generatedAt: fixedNow,
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_conversation_artifacts",
+        state: "available",
+        conversationId: sessionId,
+        artifacts: [
+          {
+            artifactId: "art_descriptor_1",
+            label: "Run summary",
+            kind: "document",
+            type: "text/markdown",
+            mediaType: "text/markdown",
+            sizeBytes: 512,
+            createdAt: "2026-04-30T12:03:00.000Z",
+            updatedAt: null,
+            availability: "available",
+            previewEligible: false,
+            previewLabel: "Preview unavailable",
+            downloadEligible: false,
+            downloadLabel: "Download unavailable",
+            warnings: []
+          }
+        ],
+        selectedArtifact: null,
+        emptyState: null,
+        warnings: []
+      };
+    },
+    getRuntimeContextViewModel() {
+      calls.push("runtime");
+      return {
+        generatedAt: fixedNow,
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_runtime_context",
+        state: "available",
+        activeTurns: [
+          {
+            sessionId: "cv_1111222233334444",
+            status: "running",
+            summary: "Mapping read-only HTTP endpoints.",
+            blockedReason: null
+          }
+        ],
+        warnings: []
+      };
+    },
+    getPendingInteractionsViewModel() {
+      calls.push("interactions");
+      return {
+        generatedAt: fixedNow,
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_pending_interactions",
+        state: "available",
+        pendingInteractions: [
+          {
+            interactionId: "pi_safe_1",
+            conversationId: "cv_1111222233334444",
+            sessionId: null,
+            status: "pending_approval",
+            kind: "command",
+            createdAt: "2026-04-30T12:02:00.000Z",
+            updatedAt: null,
+            blockingReason: "Codex wants permission to run tests.",
+            summary: { state: "available", text: "Run targeted web tests." },
+            availability: "available",
+            warnings: []
+          }
+        ],
+        warnings: []
+      };
+    },
+    getReadinessGuardrailViewModel() {
+      calls.push("readiness");
+      return {
+        generatedAt: fixedNow,
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_readiness_guardrails",
+        state: "ready",
+        checkedAt: fixedNow,
+        activePack: null,
+        capabilities: [],
+        missingGates: [],
+        warnings: []
+      };
+    }
+  };
+}
+
+function conversationDetail(conversationHandle: string): WebReadonlyConversationResultViewModel {
+  return {
+    generatedAt: fixedNow,
+    prototypeOnly: true,
+    readonly: true,
+    pageId: "web_conversation_result",
+    state: "available",
+    conversation: {
+      conversationId: conversationHandle,
+      conversationHandle,
+      workspaceId: "wk_aaaabbbbccccdddd",
+      title: "Implement API wiring",
+      workspaceLabel: "Console Core",
+      status: "running",
+      failureReason: null,
+      archived: false,
+      createdAt: "2026-04-30T11:00:00.000Z",
+      lastActivityAt: "2026-04-30T12:01:00.000Z"
+    },
+    answers: [
+      {
+        answerId: "answer-safe-1",
+        kind: "final_answer",
+        deliveryState: "delivered",
+        createdAt: "2026-04-30T12:03:00.000Z",
+        body: { state: "available", text: "Read-only API wiring is available." },
+        summary: "Final answer body was provided by an injected Web-safe sanitizer."
+      }
+    ],
+    runtime: {
+      state: "available",
+      activeTurns: [
+        {
+          sessionId: conversationHandle,
+          status: "running",
+          summary: "Mapping read-only HTTP endpoints.",
+          blockedReason: null
+        }
+      ]
+    },
+    pendingInteractions: {
+      state: "available",
+      pendingInteractions: [
+        {
+          interactionId: "pi_safe_1",
+          conversationId: conversationHandle,
+          sessionId: null,
+          status: "pending_approval",
+          kind: "command",
+          createdAt: "2026-04-30T12:02:00.000Z",
+          updatedAt: null,
+          blockingReason: "Codex wants permission to run tests.",
+          summary: { state: "available", text: "Run targeted web tests." },
+          availability: "available",
+          warnings: []
+        }
+      ]
+    },
+    readiness: { state: "ready", missingGates: [] },
+    composer: {
+      state: "disabled",
+      label: "Message Codex",
+      placeholder: "Type a message to Codex",
+      disabledReason: "Sending from Web is landing next.",
+      capability: "web_send_landing_next"
+    },
+    warnings: []
+  };
+}
+
+async function withServer<T>(
+  options: Parameters<typeof createReadonlyHttpServer>[0],
+  run: (baseUrl: string) => Promise<T>
+): Promise<T> {
+  const server = createReadonlyHttpServer(options);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address() as AddressInfo;
+    return await run(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+}
+
+async function request(
+  url: string,
+  options: { bearer?: string; method?: string } = {}
+): Promise<{ status: number; text: string; headers: Headers }> {
+  const init: RequestInit = {
+    method: options.method ?? "GET",
+    redirect: "manual"
+  };
+  if (options.bearer) {
+    init.headers = { Authorization: `Bearer ${options.bearer}` };
+  }
+  const response = await fetch(url, {
+    ...init
+  });
+  return { status: response.status, text: await response.text(), headers: response.headers };
+}
+
+test("unauthenticated API request returns generic JSON denial and does not invoke provider or adapter", async () => {
+  const providerCalls: string[] = [];
+  const adapterCalls: string[] = [];
+  const adapter: ConsoleBridgeReadAdapter = {
+    getBootstrap() {
+      adapterCalls.push("bootstrap");
+      throw new Error("should not be invoked");
+    },
+    listProjects() {
+      adapterCalls.push("projects");
+      return [];
+    },
+    listProjectSessions() {
+      adapterCalls.push("sessions");
+      return [];
+    },
+    getSessionDetail() {
+      adapterCalls.push("detail");
+      return { code: "not_found", message: "Not found.", retryable: false };
+    }
+  };
+
+  await withServer({
+    provider: makeProvider(providerCalls),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    consoleReadAdapter: adapter
+  }, async (baseUrl) => {
+    const result = await request(`${baseUrl}/api/console/bootstrap`);
+
+    assert.equal(result.status, 404);
+    assert.match(result.headers.get("content-type") ?? "", /^application\/json; charset=utf-8/);
+    assert.equal(result.headers.get("cache-control"), "no-store");
+    assert.deepEqual(JSON.parse(result.text), { code: "not_found", message: "Not found.", retryable: false });
+    assert.deepEqual(providerCalls, []);
+    assert.deepEqual(adapterCalls, []);
+  });
+});
+
+test("authenticated bootstrap JSON returns safe contract data and JSON no-store headers", async () => {
+  const providerCalls: string[] = [];
+  await withServer({
+    provider: makeProvider(providerCalls),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    consoleReadAdapter: createConsoleBridgeReadAdapter({ provider: makeProvider(providerCalls), now: () => fixedNow, idSalt: "api-test" })
+  }, async (baseUrl) => {
+    const result = await request(`${baseUrl}/api/console/bootstrap`, { bearer: token });
+    const body = JSON.parse(result.text);
+
+    assert.equal(result.status, 200);
+    assert.match(result.headers.get("content-type") ?? "", /^application\/json; charset=utf-8/);
+    assert.equal(result.headers.get("cache-control"), "no-store");
+    assert.equal(result.headers.get("x-content-type-options"), "nosniff");
+    assert.equal(body.apiVersion, "2026-05-01.phase3");
+    assert.equal(body.viewer.role, "owner");
+    assert.equal(body.capabilities.sendMessage.state, "disabled");
+    assert.equal(isConsoleOpaqueId("project", body.activeProjectId), true);
+    assert.equal(isConsoleOpaqueId("session", body.activeSessionId), true);
+    assertNoForbiddenConsoleData(body);
+    assertConsoleIds(body);
+  });
+});
+
+test("authenticated projects JSON returns opaque project IDs", async () => {
+  await withServer({
+    provider: makeProvider(),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await request(`${baseUrl}/api/projects`, { bearer: token });
+    const projects = JSON.parse(result.text);
+
+    assert.equal(result.status, 200);
+    assert.equal(projects.length, 1);
+    assert.equal(isConsoleOpaqueId("project", projects[0].projectId), true);
+    assert.equal(isConsoleOpaqueId("session", projects[0].activeSessionId), true);
+    assert.notEqual(projects[0].projectId, "wk_aaaabbbbccccdddd");
+    assertNoForbiddenConsoleData(projects);
+    assertConsoleIds(projects);
+  });
+});
+
+test("authenticated project sessions JSON rejects invalid/raw IDs and returns sessions for a valid ID", async () => {
+  await withServer({
+    provider: makeProvider(),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    for (const rawId of ["wk_aaaabbbbccccdddd", "project-1", "%2Ftmp%2Fsecret", "prj_callback_data_123"]) {
+      const result = await request(`${baseUrl}/api/projects/${rawId}/sessions`, { bearer: token });
+      assert.equal(result.status, 400, rawId);
+      assert.equal(result.text.includes(rawId), false);
+      assertNoForbiddenConsoleData(JSON.parse(result.text));
+    }
+
+    const projects = JSON.parse((await request(`${baseUrl}/api/projects`, { bearer: token })).text);
+    const validProjectId = projects[0].projectId;
+    const sessionsResult = await request(`${baseUrl}/api/projects/${validProjectId}/sessions`, { bearer: token });
+    const sessions = JSON.parse(sessionsResult.text);
+
+    assert.equal(sessionsResult.status, 200);
+    assert.equal(sessions.length, 1);
+    assert.equal(sessions[0].projectId, validProjectId);
+    assert.equal(isConsoleOpaqueId("session", sessions[0].sessionId), true);
+    assertNoForbiddenConsoleData(sessions);
+    assertConsoleIds(sessions);
+  });
+});
+
+test("authenticated session detail JSON returns safe data or safe ConsoleApiError", async () => {
+  await withServer({
+    provider: makeProvider(),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const projects = JSON.parse((await request(`${baseUrl}/api/projects`, { bearer: token })).text);
+    const sessions = JSON.parse((await request(`${baseUrl}/api/projects/${projects[0].projectId}/sessions`, { bearer: token })).text);
+    const validSessionId = sessions[0].sessionId;
+
+    const detailResult = await request(`${baseUrl}/api/sessions/${validSessionId}`, { bearer: token });
+    const detail = JSON.parse(detailResult.text);
+    assert.equal(detailResult.status, 200);
+    assert.equal(detail.sessionId, validSessionId);
+    assert.ok(detail.messages.some((message: { role: string }) => message.role === "assistant"));
+    assert.equal(detail.eventsUrl, `/api/sessions/${validSessionId}/events`);
+    assertNoForbiddenConsoleData(detail);
+    assertConsoleIds(detail);
+
+    const invalid = await request(`${baseUrl}/api/sessions/cv_1111222233334444`, { bearer: token });
+    const error = JSON.parse(invalid.text) as ConsoleApiError;
+    assert.equal(invalid.status, 400);
+    assert.equal(error.code, "bad_request");
+    assertNoForbiddenConsoleData(error);
+  });
+});
+
+test("optional session events endpoint is a safe JSON placeholder", async () => {
+  await withServer({
+    provider: makeProvider(),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const projects = JSON.parse((await request(`${baseUrl}/api/projects`, { bearer: token })).text);
+    const sessions = JSON.parse((await request(`${baseUrl}/api/projects/${projects[0].projectId}/sessions`, { bearer: token })).text);
+
+    const result = await request(`${baseUrl}/api/sessions/${sessions[0].sessionId}/events`, { bearer: token });
+    const body = JSON.parse(result.text) as ConsoleApiError;
+
+    assert.equal(result.status, 409);
+    assert.equal(body.code, "capability_disabled");
+    assert.equal(body.capability, "streamEvents");
+    assertNoForbiddenConsoleData(body);
+  });
+});
+
+test("unsupported POST API routes remain denied/not found and do not invoke read source", async () => {
+  const calls: string[] = [];
+  await withServer({
+    provider: makeProvider(calls),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await request(`${baseUrl}/api/projects`, { bearer: token, method: "POST" });
+
+    assert.equal(result.status, 404);
+    assert.deepEqual(JSON.parse(result.text), { code: "not_found", message: "Not found.", retryable: false });
+    assert.deepEqual(calls, []);
+  });
+});
+
+test("no raw platform, path, token, or bridge identifiers leak from an injected dirty adapter", async () => {
+  const dirtyAdapter: ConsoleBridgeReadAdapter = {
+    getBootstrap() {
+      return {
+        apiVersion: "2026-05-01.phase3",
+        generatedAt: fixedNow,
+        viewer: { role: "owner", displayName: "Telegram /home/ubuntu/secret token=abc callback_data=raw" },
+        capabilities: {
+          archiveProject: { state: "disabled", reason: "token=abc" },
+          createSession: { state: "disabled" },
+          sendMessage: { state: "disabled" },
+          answerApproval: { state: "disabled" },
+          uploadFiles: { state: "disabled" },
+          streamEvents: { state: "enabled" },
+          fetchArtifacts: { state: "enabled" }
+        },
+        projects: [
+          {
+            projectId: "wk_aaaabbbbccccdddd",
+            title: "/tmp/raw token=abc telegramChatId=123",
+            archived: false,
+            sessionCount: 1,
+            activeSessionId: "cv_1111222233334444"
+          }
+        ],
+        commands: [],
+        models: [],
+        modes: [],
+        degradedStates: []
+      } as never;
+    },
+    listProjects() {
+      return [
+        {
+          projectId: "wk_aaaabbbbccccdddd",
+          title: "feishu open_id=ou_secret /tmp/project token=abc",
+          archived: false,
+          sessionCount: 1
+        }
+      ] as never;
+    },
+    listProjectSessions() {
+      return [];
+    },
+    getSessionDetail() {
+      return { code: "not_found", message: "Not found.", retryable: false };
+    }
+  };
+
+  await withServer({
+    provider: makeProvider(),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    consoleReadAdapter: dirtyAdapter
+  }, async (baseUrl) => {
+    for (const path of ["/api/console/bootstrap", "/api/projects"]) {
+      const result = await request(`${baseUrl}${path}`, { bearer: token });
+      const body = JSON.parse(result.text);
+
+      assert.equal(result.status, 500, `${path}: ${result.text}`);
+      assert.deepEqual(body, {
+        code: "internal_error",
+        message: "Console API response is temporarily unavailable.",
+        retryable: true
+      });
+      for (const forbidden of ["/home/ubuntu", "/tmp/", "telegram", "Telegram", "feishu", "open_id", "callback_data", "token=", "telegramChatId", "cv_1111222233334444", "wk_aaaabbbbccccdddd"]) {
+        assert.equal(result.text.includes(forbidden), false, `${path} leaked ${forbidden}: ${result.text}`);
+      }
+    }
+  });
+});
+
+const idFieldKinds = {
+  projectId: "project",
+  activeProjectId: "project",
+  sessionId: "session",
+  activeSessionId: "session",
+  messageId: "message",
+  runId: "run",
+  activeRunId: "run",
+  approvalId: "approval",
+  artifactId: "artifact"
+} as const satisfies Record<string, ConsoleOpaqueIdKind>;
+
+const listIdFieldKinds = {
+  approvalIds: "approval",
+  artifactIds: "artifact"
+} as const satisfies Record<string, ConsoleOpaqueIdKind>;
+
+function assertConsoleIds(value: unknown): void {
+  visitShape(value, (node, key) => {
+    if (!key) {
+      return;
+    }
+    const kind = idFieldKinds[key as keyof typeof idFieldKinds];
+    if (kind) {
+      assert.equal(isConsoleOpaqueId(kind, node), true, `${key} must be opaque`);
+    }
+    const listKind = listIdFieldKinds[key as keyof typeof listIdFieldKinds];
+    if (listKind) {
+      assert.ok(Array.isArray(node), `${key} must be an array`);
+      for (const item of node) {
+        assert.equal(isConsoleOpaqueId(listKind, item), true, `${key} item must be opaque`);
+      }
+    }
+  });
+}
+
+function assertNoForbiddenConsoleData(value: unknown): void {
+  const text = JSON.stringify(value);
+  for (const forbidden of [
+    "/home/ubuntu",
+    "/tmp/",
+    "telegram",
+    "Telegram",
+    "feishu",
+    "open_id",
+    "union_id",
+    "chatId",
+    "telegramChatId",
+    "callback_data",
+    "token=",
+    "pid=",
+    "processId",
+    "rawTerminal",
+    "stdout",
+    "stderr",
+    "cv_1111222233334444",
+    "wk_aaaabbbbccccdddd",
+    "answer-safe-1",
+    "pi_safe_1"
+  ]) {
+    assert.equal(text.includes(forbidden), false, `leaked forbidden marker ${forbidden}: ${text}`);
+  }
+}
+
+function visitShape(value: unknown, visitor: (node: unknown, key?: string) => void, key?: string): void {
+  visitor(value, key);
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitShape(item, visitor);
+    }
+    return;
+  }
+  for (const [childKey, childValue] of Object.entries(value)) {
+    visitShape(childValue, visitor, childKey);
+  }
+}

--- a/src/web/console-api-http.ts
+++ b/src/web/console-api-http.ts
@@ -59,6 +59,7 @@ type ApprovalAnswerBody =
   | { ok: false; result: JsonRouteResult };
 
 type ConsoleWriteCapability = keyof NonNullable<ConsoleApiWriteAdapter["capabilities"]>;
+type ConsoleWriteCapabilityValue = ConsoleCapabilities["sendMessage"];
 
 const JSON_SECURITY_HEADERS = {
   "Cache-Control": "no-store",
@@ -144,7 +145,7 @@ export function handleConsoleApiHttpRequest(
 function resolveConsoleApiRoute(pathname: string, options: ConsoleApiHttpOptions): JsonRouteResult {
   try {
     if (pathname === "/api/console/bootstrap") {
-      return adapterPayload(() => adapterFor(options).getBootstrap());
+      return adapterPayload(() => bootstrapFor(options));
     }
 
     if (pathname === "/api/projects") {
@@ -290,6 +291,43 @@ async function resolveConsoleApiPostRoute(
   } catch {
     return safeError(500, internalError());
   }
+}
+
+function bootstrapFor(options: ConsoleApiHttpOptions): unknown {
+  const bootstrap = adapterFor(options).getBootstrap();
+  return {
+    ...bootstrap,
+    capabilities: mergeWriteCapabilities(bootstrap.capabilities, options)
+  };
+}
+
+function mergeWriteCapabilities(capabilities: ConsoleCapabilities, options: ConsoleApiHttpOptions): ConsoleCapabilities {
+  return {
+    ...capabilities,
+    archiveProject: writeCapabilityFor(capabilities.archiveProject, options, "archiveProject", options.writeAdapter?.archiveProject),
+    createSession: writeCapabilityFor(capabilities.createSession, options, "createSession", options.writeAdapter?.createSession),
+    sendMessage: writeCapabilityFor(capabilities.sendMessage, options, "sendMessage", options.writeAdapter?.sendMessage),
+    answerApproval: writeCapabilityFor(capabilities.answerApproval, options, "answerApproval", options.writeAdapter?.answerApproval)
+  };
+}
+
+function writeCapabilityFor(
+  fallback: ConsoleWriteCapabilityValue,
+  options: ConsoleApiHttpOptions,
+  capability: ConsoleWriteCapability,
+  handler: unknown
+): ConsoleWriteCapabilityValue {
+  const advertised = options.writeAdapter?.capabilities?.[capability];
+  if (!handler) {
+    return fallback;
+  }
+  if (advertised?.state === "disabled") {
+    return advertised;
+  }
+  if (!currentCsrfToken(options)) {
+    return { state: "disabled", reason: "Console write capability requires CSRF protection." };
+  }
+  return advertised ?? { state: "enabled" };
 }
 
 function adapterFor(options: ConsoleApiHttpOptions): ConsoleBridgeReadAdapter {

--- a/src/web/console-api-http.ts
+++ b/src/web/console-api-http.ts
@@ -10,21 +10,68 @@ import {
   assertConsoleSafeString,
   isConsoleOpaqueId,
   type ConsoleApiError,
-  type ConsoleOpaqueIdKind
+  type ConsoleApprovalAnswerRequest,
+  type ConsoleApprovalAnswerResult,
+  type ConsoleApprovalId,
+  type ConsoleArchiveProjectRequest,
+  type ConsoleCapabilities,
+  type ConsoleCreateSessionRequest,
+  type ConsoleOpaqueIdKind,
+  type ConsoleProject,
+  type ConsoleProjectId,
+  type ConsoleSendMessageRequest,
+  type ConsoleSendMessageResult,
+  type ConsoleSessionDetail,
+  type ConsoleSessionId
 } from "./console-api-contract.js";
 
 export interface ConsoleApiHttpOptions {
   provider: WebReadonlyViewModelProvider;
   adapter?: ConsoleBridgeReadAdapter;
+  writeAdapter?: ConsoleApiWriteAdapter;
+  csrfToken?: string | (() => string | null | undefined);
+}
+
+export interface ConsoleApiWriteAdapter {
+  capabilities?: Partial<Pick<ConsoleCapabilities, "archiveProject" | "createSession" | "sendMessage" | "answerApproval">>;
+  archiveProject?: (request: ConsoleArchiveProjectRequest) => Promise<ConsoleProject | ConsoleApiError> | ConsoleProject | ConsoleApiError;
+  createSession?: (request: ConsoleCreateSessionRequest) => Promise<ConsoleSessionDetail | ConsoleApiError> | ConsoleSessionDetail | ConsoleApiError;
+  sendMessage?: (sessionId: ConsoleSessionId, request: ConsoleSendMessageRequest) => Promise<ConsoleSendMessageResult | ConsoleApiError> | ConsoleSendMessageResult | ConsoleApiError;
+  answerApproval?: (approvalId: ConsoleApprovalId, request: ConsoleApprovalAnswerRequest) => Promise<ConsoleApprovalAnswerResult | ConsoleApiError> | ConsoleApprovalAnswerResult | ConsoleApiError;
 }
 
 type JsonRouteResult = { status: number; body: unknown };
+
+type ParsedJsonBody =
+  | { ok: true; value: unknown }
+  | { ok: false; result: JsonRouteResult };
+
+type SendMessageBody =
+  | { ok: true; value: ConsoleSendMessageRequest }
+  | { ok: false; result: JsonRouteResult };
+
+type CreateSessionBody =
+  | { ok: true; value: Omit<ConsoleCreateSessionRequest, "projectId"> }
+  | { ok: false; result: JsonRouteResult };
+
+type ApprovalAnswerBody =
+  | { ok: true; value: ConsoleApprovalAnswerRequest }
+  | { ok: false; result: JsonRouteResult };
+
+type ConsoleWriteCapability = keyof NonNullable<ConsoleApiWriteAdapter["capabilities"]>;
 
 const JSON_SECURITY_HEADERS = {
   "Cache-Control": "no-store",
   "Content-Type": "application/json; charset=utf-8",
   "X-Content-Type-Options": "nosniff"
 } as const;
+
+const MAX_JSON_BODY_BYTES = 32 * 1024;
+const MAX_MESSAGE_CHARS = 8_000;
+const MAX_OPTION_CHARS = 128;
+const MAX_REASON_CHARS = 1_000;
+const MAX_TITLE_CHARS = 200;
+const MAX_ATTACHMENT_IDS = 10;
 
 const idFieldKinds = {
   projectId: "project",
@@ -80,12 +127,17 @@ export function handleConsoleApiHttpRequest(
 
   const method = request.method ?? "GET";
   const headOnly = method === "HEAD";
-  if (method !== "GET" && method !== "HEAD") {
-    sendJson(response, 404, notFoundError(), false);
+  if (method === "GET" || method === "HEAD") {
+    sendRouteResult(response, resolveConsoleApiRoute(pathname, options), headOnly);
     return true;
   }
 
-  sendRouteResult(response, resolveConsoleApiRoute(pathname, options), headOnly);
+  if (method === "POST") {
+    void handleConsoleApiPostRoute(pathname, options, request, response);
+    return true;
+  }
+
+  sendJson(response, 404, notFoundError(), false);
   return true;
 }
 
@@ -137,6 +189,109 @@ function resolveConsoleApiRoute(pathname: string, options: ConsoleApiHttpOptions
   }
 }
 
+async function handleConsoleApiPostRoute(
+  pathname: string,
+  options: ConsoleApiHttpOptions,
+  request: IncomingMessage,
+  response: ServerResponse
+): Promise<void> {
+  let result: JsonRouteResult;
+  try {
+    result = await resolveConsoleApiPostRoute(pathname, options, request);
+  } catch {
+    result = safeError(500, internalError());
+  }
+  sendRouteResult(response, result, false);
+}
+
+async function resolveConsoleApiPostRoute(
+  pathname: string,
+  options: ConsoleApiHttpOptions,
+  request: IncomingMessage
+): Promise<JsonRouteResult> {
+  try {
+    const archiveMatch = /^\/api\/projects\/([^/]+)\/archive$/.exec(pathname);
+    if (archiveMatch?.[1]) {
+      const projectId = archiveMatch[1];
+      if (!isSafeRouteOpaqueId("project", projectId)) {
+        drain(request);
+        return safeError(400, badRequestError("Project id must be an opaque Console project id."));
+      }
+      return await withWriteGuards(request, options, "archiveProject", options.writeAdapter?.archiveProject, async () => {
+        const parsed = await readJsonBody(request, { allowEmpty: true });
+        if (!parsed.ok) {
+          return parsed.result;
+        }
+        const object = asPlainObject(parsed.value);
+        if (!object || hasUnknownKeys(object, [])) {
+          return safeError(400, badRequestError("Archive project request body must be an empty JSON object."));
+        }
+        const safeProjectId = projectId as ConsoleProjectId;
+        return writePayload(() => options.writeAdapter!.archiveProject!({ projectId: safeProjectId }), 200);
+      });
+    }
+
+    const createSessionMatch = /^\/api\/projects\/([^/]+)\/sessions$/.exec(pathname);
+    if (createSessionMatch?.[1]) {
+      const projectId = createSessionMatch[1];
+      if (!isSafeRouteOpaqueId("project", projectId)) {
+        drain(request);
+        return safeError(400, badRequestError("Project id must be an opaque Console project id."));
+      }
+      return await withWriteGuards(request, options, "createSession", options.writeAdapter?.createSession, async () => {
+        const parsed = parseCreateSessionBody(await readJsonBody(request, { allowEmpty: true }));
+        if (!parsed.ok) {
+          return parsed.result;
+        }
+        const safeProjectId = projectId as ConsoleProjectId;
+        return writePayload(
+          () => options.writeAdapter!.createSession!({ projectId: safeProjectId, ...parsed.value }),
+          201
+        );
+      });
+    }
+
+    const sendMessageMatch = /^\/api\/sessions\/([^/]+)\/messages$/.exec(pathname);
+    if (sendMessageMatch?.[1]) {
+      const sessionId = sendMessageMatch[1];
+      if (!isSafeRouteOpaqueId("session", sessionId)) {
+        drain(request);
+        return safeError(400, badRequestError("Session id must be an opaque Console session id."));
+      }
+      return await withWriteGuards(request, options, "sendMessage", options.writeAdapter?.sendMessage, async () => {
+        const parsed = parseSendMessageBody(await readJsonBody(request, { allowEmpty: false }));
+        if (!parsed.ok) {
+          return parsed.result;
+        }
+        const safeSessionId = sessionId as ConsoleSessionId;
+        return writePayload(() => options.writeAdapter!.sendMessage!(safeSessionId, parsed.value), 202);
+      });
+    }
+
+    const approvalMatch = /^\/api\/approvals\/([^/]+)\/answer$/.exec(pathname);
+    if (approvalMatch?.[1]) {
+      const approvalId = approvalMatch[1];
+      if (!isSafeRouteOpaqueId("approval", approvalId)) {
+        drain(request);
+        return safeError(400, badRequestError("Approval id must be an opaque Console approval id."));
+      }
+      return await withWriteGuards(request, options, "answerApproval", options.writeAdapter?.answerApproval, async () => {
+        const parsed = parseApprovalAnswerBody(await readJsonBody(request, { allowEmpty: false }));
+        if (!parsed.ok) {
+          return parsed.result;
+        }
+        const safeApprovalId = approvalId as ConsoleApprovalId;
+        return writePayload(() => options.writeAdapter!.answerApproval!(safeApprovalId, parsed.value), 200);
+      });
+    }
+
+    drain(request);
+    return safeError(404, notFoundError());
+  } catch {
+    return safeError(500, internalError());
+  }
+}
+
 function adapterFor(options: ConsoleApiHttpOptions): ConsoleBridgeReadAdapter {
   return options.adapter ?? createConsoleBridgeReadAdapter({ provider: options.provider });
 }
@@ -153,6 +308,38 @@ function adapterPayload(read: () => unknown): JsonRouteResult {
     return safeError(statusForConsoleApiError(payload), payload);
   }
   return safeBody(200, payload);
+}
+
+async function withWriteGuards(
+  request: IncomingMessage,
+  options: ConsoleApiHttpOptions,
+  capability: ConsoleWriteCapability,
+  handler: unknown,
+  run: () => Promise<JsonRouteResult>
+): Promise<JsonRouteResult> {
+  if (!handler || options.writeAdapter?.capabilities?.[capability]?.state === "disabled") {
+    drain(request);
+    return capabilityDisabled(capability);
+  }
+  if (!sameOriginAllowed(request) || !csrfAllowed(request, options)) {
+    drain(request);
+    return safeError(403, { code: "forbidden", message: "Write request was denied.", retryable: false });
+  }
+  return run();
+}
+
+async function writePayload(write: () => unknown | Promise<unknown>, successStatus: number): Promise<JsonRouteResult> {
+  let payload: unknown;
+  try {
+    payload = await write();
+  } catch {
+    return safeError(500, internalError());
+  }
+
+  if (isConsoleApiError(payload)) {
+    return safeError(statusForConsoleApiError(payload), payload);
+  }
+  return safeBody(successStatus, payload);
 }
 
 function sendRouteResult(response: ServerResponse, result: JsonRouteResult, headOnly: boolean): void {
@@ -184,6 +371,15 @@ function safeError(status: number, error: ConsoleApiError): JsonRouteResult {
 
 function badRequestError(message: string): ConsoleApiError {
   return { code: "bad_request", message, retryable: false };
+}
+
+function capabilityDisabled(capability: NonNullable<ConsoleApiError["capability"]>): JsonRouteResult {
+  return safeError(409, {
+    code: "capability_disabled",
+    message: "Console write capability is disabled.",
+    retryable: false,
+    capability
+  });
 }
 
 function notFoundError(): ConsoleApiError {
@@ -228,6 +424,237 @@ function isSafeRouteOpaqueId(kind: ConsoleOpaqueIdKind, value: string): boolean 
   } catch {
     return false;
   }
+}
+
+async function readJsonBody(
+  request: IncomingMessage,
+  options: { allowEmpty: boolean }
+): Promise<ParsedJsonBody> {
+  const contentType = firstHeader(request.headers["content-type"])?.toLowerCase() ?? "";
+  if (contentType && !contentType.includes("application/json")) {
+    drain(request);
+    return { ok: false, result: safeError(400, badRequestError("Request body must be JSON.")) };
+  }
+
+  const raw = await readBody(request);
+  if (!raw) {
+    return { ok: false, result: safeError(400, badRequestError("Request body is too large.")) };
+  }
+  if (raw.length === 0) {
+    return options.allowEmpty
+      ? { ok: true, value: {} }
+      : { ok: false, result: safeError(400, badRequestError("Request body must be a JSON object.")) };
+  }
+
+  try {
+    const value = JSON.parse(raw.toString("utf-8")) as unknown;
+    assertConsoleApiPayloadSafe(value);
+    return { ok: true, value };
+  } catch {
+    return { ok: false, result: safeError(400, badRequestError("Request body must be safe, well-formed JSON.")) };
+  }
+}
+
+async function readBody(request: IncomingMessage): Promise<Buffer | null> {
+  const declaredLength = Number.parseInt(firstHeader(request.headers["content-length"]) ?? "0", 10);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    drain(request);
+    return null;
+  }
+
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.length;
+    if (total > MAX_JSON_BODY_BYTES) {
+      drain(request);
+      return null;
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks);
+}
+
+function parseSendMessageBody(parsed: ParsedJsonBody): SendMessageBody {
+  if (!parsed.ok) {
+    return parsed;
+  }
+  const object = asPlainObject(parsed.value);
+  if (!object || hasUnknownKeys(object, ["text", "model", "mode", "attachmentArtifactIds"])) {
+    return { ok: false, result: safeError(400, badRequestError("Message request body has invalid fields.")) };
+  }
+
+  const text = safeTrimmedBodyString(object.text, "Message text", MAX_MESSAGE_CHARS);
+  if (!text.ok) {
+    return text;
+  }
+
+  const request: ConsoleSendMessageRequest = { text: text.value };
+  if (object.model !== undefined) {
+    const model = safeTrimmedBodyString(object.model, "Model", MAX_OPTION_CHARS);
+    if (!model.ok) {
+      return model;
+    }
+    request.model = model.value;
+  }
+  if (object.mode !== undefined) {
+    const mode = safeTrimmedBodyString(object.mode, "Mode", MAX_OPTION_CHARS);
+    if (!mode.ok) {
+      return mode;
+    }
+    request.mode = mode.value;
+  }
+  if (object.attachmentArtifactIds !== undefined) {
+    if (!Array.isArray(object.attachmentArtifactIds) || object.attachmentArtifactIds.length > MAX_ATTACHMENT_IDS) {
+      return { ok: false, result: safeError(400, badRequestError("Attachment artifact ids must be a small list of opaque Console artifact ids.")) };
+    }
+    const attachmentArtifactIds: NonNullable<ConsoleSendMessageRequest["attachmentArtifactIds"]> = [];
+    for (const id of object.attachmentArtifactIds) {
+      if (!isConsoleOpaqueId("artifact", id)) {
+        return { ok: false, result: safeError(400, badRequestError("Attachment artifact ids must be opaque Console artifact ids.")) };
+      }
+      attachmentArtifactIds.push(id);
+    }
+    request.attachmentArtifactIds = attachmentArtifactIds;
+  }
+
+  return { ok: true, value: request };
+}
+
+function parseCreateSessionBody(parsed: ParsedJsonBody): CreateSessionBody {
+  if (!parsed.ok) {
+    return parsed;
+  }
+  const object = asPlainObject(parsed.value);
+  if (!object || hasUnknownKeys(object, ["title"])) {
+    return { ok: false, result: safeError(400, badRequestError("Create session request body has invalid fields.")) };
+  }
+
+  if (object.title === undefined) {
+    return { ok: true, value: {} };
+  }
+
+  const title = safeTrimmedBodyString(object.title, "Session title", MAX_TITLE_CHARS);
+  if (!title.ok) {
+    return title;
+  }
+  return { ok: true, value: { title: title.value } };
+}
+
+function parseApprovalAnswerBody(parsed: ParsedJsonBody): ApprovalAnswerBody {
+  if (!parsed.ok) {
+    return parsed;
+  }
+  const object = asPlainObject(parsed.value);
+  if (!object || hasUnknownKeys(object, ["answer", "scope", "reason"])) {
+    return { ok: false, result: safeError(400, badRequestError("Approval answer request body has invalid fields.")) };
+  }
+
+  if (object.answer !== "approve" && object.answer !== "deny") {
+    return { ok: false, result: safeError(400, badRequestError("Approval answer must be approve or deny.")) };
+  }
+
+  const request: ConsoleApprovalAnswerRequest = { answer: object.answer };
+  if (object.scope !== undefined) {
+    if (object.scope !== "single" && object.scope !== "all_pending_in_session") {
+      return { ok: false, result: safeError(400, badRequestError("Approval answer scope is invalid.")) };
+    }
+    request.scope = object.scope;
+  }
+  if (object.reason !== undefined) {
+    const reason = safeTrimmedBodyString(object.reason, "Approval answer reason", MAX_REASON_CHARS);
+    if (!reason.ok) {
+      return reason;
+    }
+    request.reason = reason.value;
+  }
+
+  return { ok: true, value: request };
+}
+
+function asPlainObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function hasUnknownKeys(object: Record<string, unknown>, allowed: string[]): boolean {
+  const allowedSet = new Set(allowed);
+  return Object.keys(object).some((key) => !allowedSet.has(key));
+}
+
+function safeTrimmedBodyString(
+  value: unknown,
+  label: string,
+  maxLength: number
+): { ok: true; value: string } | { ok: false; result: JsonRouteResult } {
+  if (typeof value !== "string") {
+    return { ok: false, result: safeError(400, badRequestError(`${label} must be a string.`)) };
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { ok: false, result: safeError(400, badRequestError(`${label} must not be blank.`)) };
+  }
+  if (trimmed.length > maxLength) {
+    return { ok: false, result: safeError(400, badRequestError(`${label} is too long.`)) };
+  }
+  try {
+    assertConsoleSafeString(trimmed, label);
+    assertNoRawBridgeMarkers(trimmed, label);
+  } catch {
+    return { ok: false, result: safeError(400, badRequestError(`${label} contains unsupported data.`)) };
+  }
+  return { ok: true, value: trimmed };
+}
+
+function csrfAllowed(request: IncomingMessage, options: ConsoleApiHttpOptions): boolean {
+  const csrfToken = currentCsrfToken(options);
+  if (!csrfToken) {
+    return false;
+  }
+  const headerToken = firstHeader(request.headers["x-csrf-token"]);
+  return headerToken !== null && timingSafeEqualString(headerToken, csrfToken);
+}
+
+function currentCsrfToken(options: ConsoleApiHttpOptions): string | null {
+  const value = typeof options.csrfToken === "function" ? options.csrfToken() : options.csrfToken;
+  const trimmed = String(value ?? "").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function sameOriginAllowed(request: IncomingMessage): boolean {
+  const source = firstHeader(request.headers.origin) || firstHeader(request.headers.referer);
+  if (!source) {
+    return true;
+  }
+  try {
+    const sourceUrl = new URL(source);
+    const host = firstHeader(request.headers["x-forwarded-host"]) || firstHeader(request.headers.host);
+    if (!host) {
+      return false;
+    }
+    const proto = firstHeader(request.headers["x-forwarded-proto"]) || "http";
+    const expected = new URL(`${proto}://${host}`);
+    return sourceUrl.protocol === expected.protocol && sourceUrl.host === expected.host;
+  } catch {
+    return false;
+  }
+}
+
+function firstHeader(value: string | string[] | undefined): string | null {
+  const text = Array.isArray(value) ? value[0] : value;
+  const trimmed = String(text ?? "").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function timingSafeEqualString(a: string, b: string): boolean {
+  return a.length === b.length && a === b;
+}
+
+function drain(request: IncomingMessage): void {
+  request.resume();
 }
 
 function assertConsoleApiPayloadSafe(value: unknown): void {

--- a/src/web/console-api-http.ts
+++ b/src/web/console-api-http.ts
@@ -1,0 +1,319 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import type { WebReadonlyViewModelProvider } from "../service/web-readonly-view-model.js";
+import {
+  createConsoleBridgeReadAdapter,
+  type ConsoleBridgeReadAdapter,
+  type ConsoleSessionSummaryResult
+} from "./console-bridge-read-adapter.js";
+import {
+  assertConsoleSafeString,
+  isConsoleOpaqueId,
+  type ConsoleApiError,
+  type ConsoleOpaqueIdKind
+} from "./console-api-contract.js";
+
+export interface ConsoleApiHttpOptions {
+  provider: WebReadonlyViewModelProvider;
+  adapter?: ConsoleBridgeReadAdapter;
+}
+
+type JsonRouteResult = { status: number; body: unknown };
+
+const JSON_SECURITY_HEADERS = {
+  "Cache-Control": "no-store",
+  "Content-Type": "application/json; charset=utf-8",
+  "X-Content-Type-Options": "nosniff"
+} as const;
+
+const idFieldKinds = {
+  projectId: "project",
+  activeProjectId: "project",
+  sessionId: "session",
+  activeSessionId: "session",
+  messageId: "message",
+  runId: "run",
+  activeRunId: "run",
+  approvalId: "approval",
+  artifactId: "artifact"
+} as const satisfies Record<string, ConsoleOpaqueIdKind>;
+
+const listIdFieldKinds = {
+  approvalIds: "approval",
+  artifactIds: "artifact",
+  attachmentArtifactIds: "artifact"
+} as const satisfies Record<string, ConsoleOpaqueIdKind>;
+
+const rawBridgeStringPatterns: Array<{ label: string; pattern: RegExp }> = [
+  { label: "raw conversation identifier", pattern: /\bcv_[a-f0-9]{16}\b/i },
+  { label: "raw workspace identifier", pattern: /\bwk_[A-Za-z0-9_-]{2,}\b/ },
+  { label: "raw interaction identifier", pattern: /\bpi_[A-Za-z0-9_-]{2,}\b/i },
+  { label: "raw answer identifier", pattern: /\banswer[-_][A-Za-z0-9_-]{2,}\b/i },
+  { label: "platform marker", pattern: /(?:telegram|feishu|open_id|union_id|tenant|callback_data)/i },
+  { label: "chat identifier", pattern: /\b(?:chatId|telegramChatId|feishuChatId|platformMessageId|messageId|threadId)\b/ },
+  { label: "secret marker", pattern: /\b(?:token|authorization|bearer|api[_-]?key|secret|password)\s*[:=]/i },
+  { label: "process marker", pattern: /\b(?:pid|processId|process[_-]?id)\s*[:=]?\s*\d{2,}\b/i },
+  { label: "raw terminal marker", pattern: /\b(?:rawTerminal|stdout|stderr)\b/i }
+];
+
+const rawBridgeKeyPattern =
+  /(?:telegram|feishu|open[_-]?id|union[_-]?id|tenant[_-]?key|callback[_-]?data|rawTerminal|stdout|stderr|token|secret|authorization|bearer|api[_-]?key|password|chatId|threadId|platformMessageId|conversationHandle|conversationId|workspaceId|answerId|interactionId|processId|pid)/;
+
+export function isConsoleApiPath(urlValue: string): boolean {
+  const pathname = safePathname(urlValue);
+  return Boolean(pathname && isApiPathname(pathname));
+}
+
+export function sendConsoleApiDenied(response: ServerResponse, headOnly = false): void {
+  sendJson(response, 404, notFoundError(), headOnly);
+}
+
+export function handleConsoleApiHttpRequest(
+  options: ConsoleApiHttpOptions,
+  request: IncomingMessage,
+  response: ServerResponse
+): boolean {
+  const pathname = safePathname(request.url ?? "/");
+  if (!pathname || !isApiPathname(pathname)) {
+    return false;
+  }
+
+  const method = request.method ?? "GET";
+  const headOnly = method === "HEAD";
+  if (method !== "GET" && method !== "HEAD") {
+    sendJson(response, 404, notFoundError(), false);
+    return true;
+  }
+
+  sendRouteResult(response, resolveConsoleApiRoute(pathname, options), headOnly);
+  return true;
+}
+
+function resolveConsoleApiRoute(pathname: string, options: ConsoleApiHttpOptions): JsonRouteResult {
+  try {
+    if (pathname === "/api/console/bootstrap") {
+      return adapterPayload(() => adapterFor(options).getBootstrap());
+    }
+
+    if (pathname === "/api/projects") {
+      return adapterPayload(() => adapterFor(options).listProjects());
+    }
+
+    const projectSessionsMatch = /^\/api\/projects\/([^/]+)\/sessions$/.exec(pathname);
+    if (projectSessionsMatch?.[1]) {
+      const projectId = projectSessionsMatch[1];
+      if (!isSafeRouteOpaqueId("project", projectId)) {
+        return safeError(400, badRequestError("Project id must be an opaque Console project id."));
+      }
+      return adapterPayload((): ConsoleSessionSummaryResult => adapterFor(options).listProjectSessions(projectId));
+    }
+
+    const sessionEventsMatch = /^\/api\/sessions\/([^/]+)\/events$/.exec(pathname);
+    if (sessionEventsMatch?.[1]) {
+      const sessionId = sessionEventsMatch[1];
+      if (!isSafeRouteOpaqueId("session", sessionId)) {
+        return safeError(400, badRequestError("Session id must be an opaque Console session id."));
+      }
+      return safeError(409, {
+        code: "capability_disabled",
+        message: "Session event streams are unavailable in this read-only HTTP harness.",
+        retryable: false,
+        capability: "streamEvents"
+      });
+    }
+
+    const sessionDetailMatch = /^\/api\/sessions\/([^/]+)$/.exec(pathname);
+    if (sessionDetailMatch?.[1]) {
+      const sessionId = sessionDetailMatch[1];
+      if (!isSafeRouteOpaqueId("session", sessionId)) {
+        return safeError(400, badRequestError("Session id must be an opaque Console session id."));
+      }
+      return adapterPayload(() => adapterFor(options).getSessionDetail(sessionId));
+    }
+
+    return safeError(404, notFoundError());
+  } catch {
+    return safeError(500, internalError());
+  }
+}
+
+function adapterFor(options: ConsoleApiHttpOptions): ConsoleBridgeReadAdapter {
+  return options.adapter ?? createConsoleBridgeReadAdapter({ provider: options.provider });
+}
+
+function adapterPayload(read: () => unknown): JsonRouteResult {
+  let payload: unknown;
+  try {
+    payload = read();
+  } catch {
+    return safeError(500, internalError());
+  }
+
+  if (isConsoleApiError(payload)) {
+    return safeError(statusForConsoleApiError(payload), payload);
+  }
+  return safeBody(200, payload);
+}
+
+function sendRouteResult(response: ServerResponse, result: JsonRouteResult, headOnly: boolean): void {
+  sendJson(response, result.status, result.body, headOnly);
+}
+
+function sendJson(response: ServerResponse, status: number, body: unknown, headOnly: boolean): void {
+  const text = `${JSON.stringify(body)}\n`;
+  response.writeHead(status, {
+    ...JSON_SECURITY_HEADERS,
+    "Content-Length": Buffer.byteLength(headOnly ? "" : text)
+  });
+  response.end(headOnly ? undefined : text);
+}
+
+function safeBody(status: number, body: unknown): JsonRouteResult {
+  try {
+    assertConsoleApiPayloadSafe(body);
+    JSON.stringify(body);
+    return { status, body };
+  } catch {
+    return { status: 500, body: internalError() };
+  }
+}
+
+function safeError(status: number, error: ConsoleApiError): JsonRouteResult {
+  return safeBody(status, error);
+}
+
+function badRequestError(message: string): ConsoleApiError {
+  return { code: "bad_request", message, retryable: false };
+}
+
+function notFoundError(): ConsoleApiError {
+  return { code: "not_found", message: "Not found.", retryable: false };
+}
+
+function internalError(): ConsoleApiError {
+  return {
+    code: "internal_error",
+    message: "Console API response is temporarily unavailable.",
+    retryable: true
+  };
+}
+
+function statusForConsoleApiError(error: ConsoleApiError): number {
+  switch (error.code) {
+    case "bad_request":
+      return 400;
+    case "unauthorized":
+    case "forbidden":
+    case "not_found":
+      return 404;
+    case "capability_disabled":
+    case "conflict":
+      return 409;
+    case "rate_limited":
+      return 429;
+    case "bridge_unavailable":
+      return 503;
+    case "internal_error":
+      return 500;
+  }
+}
+
+function isSafeRouteOpaqueId(kind: ConsoleOpaqueIdKind, value: string): boolean {
+  if (!isConsoleOpaqueId(kind, value)) {
+    return false;
+  }
+  try {
+    assertNoRawBridgeMarkers(value, `${kind}Id`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertConsoleApiPayloadSafe(value: unknown): void {
+  visitShape(value, (node, key) => {
+    if (key && rawBridgeKeyPattern.test(key)) {
+      throw new TypeError(`field name contains raw Bridge marker`);
+    }
+
+    if (typeof node === "string") {
+      assertConsoleSafeString(node, key ?? "value");
+      assertNoRawBridgeMarkers(node, key ?? "value");
+    }
+
+    if (!key) {
+      return;
+    }
+
+    const kind = idFieldKinds[key as keyof typeof idFieldKinds];
+    if (kind && !isConsoleOpaqueId(kind, node)) {
+      throw new TypeError(`${key} must be an opaque Console ${kind} id`);
+    }
+
+    const listKind = listIdFieldKinds[key as keyof typeof listIdFieldKinds];
+    if (listKind) {
+      if (!Array.isArray(node)) {
+        throw new TypeError(`${key} must be a list of opaque Console ${listKind} ids`);
+      }
+      for (const item of node) {
+        if (!isConsoleOpaqueId(listKind, item)) {
+          throw new TypeError(`${key} must contain only opaque Console ${listKind} ids`);
+        }
+      }
+    }
+
+    if (key === "eventsUrl" && typeof node === "string" && !/^\/api\/sessions\/ses_[A-Za-z0-9_-]{6,128}\/events$/.test(node)) {
+      throw new TypeError("eventsUrl must use an opaque Console session id");
+    }
+
+    if (key === "url" && typeof node === "string" && node.startsWith("/api/artifacts/") && !/^\/api\/artifacts\/art_[A-Za-z0-9_-]{6,128}$/.test(node)) {
+      throw new TypeError("artifact url must use an opaque Console artifact id");
+    }
+  });
+}
+
+function assertNoRawBridgeMarkers(value: string, fieldName: string): void {
+  for (const { label, pattern } of rawBridgeStringPatterns) {
+    if (pattern.test(value)) {
+      throw new TypeError(`${fieldName} contains ${label}`);
+    }
+  }
+}
+
+function visitShape(value: unknown, visitor: (node: unknown, key?: string) => void, key?: string): void {
+  visitor(value, key);
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitShape(item, visitor);
+    }
+    return;
+  }
+  for (const [childKey, childValue] of Object.entries(value)) {
+    visitShape(childValue, visitor, childKey);
+  }
+}
+
+function isConsoleApiError(value: unknown): value is ConsoleApiError {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    typeof (value as ConsoleApiError).code === "string" &&
+    typeof (value as ConsoleApiError).message === "string" &&
+    typeof (value as ConsoleApiError).retryable === "boolean"
+  );
+}
+
+function safePathname(urlValue: string): string | null {
+  try {
+    return new URL(urlValue, "http://127.0.0.1").pathname;
+  } catch {
+    return null;
+  }
+}
+
+function isApiPathname(pathname: string): boolean {
+  return pathname === "/api" || pathname.startsWith("/api/");
+}

--- a/src/web/console-bridge-read-adapter.test.ts
+++ b/src/web/console-bridge-read-adapter.test.ts
@@ -32,12 +32,14 @@ function makeProvider(options: {
   throwWorkspaces?: boolean;
   workspaceLabel?: string;
   conversationTitle?: string;
+  conversationHandle?: string;
   answerText?: string;
   includePending?: boolean;
   readiness?: Partial<WebReadonlyReadinessGuardrailViewModel>;
   runtime?: Partial<WebReadonlyRuntimeContextViewModel>;
   detailState?: WebReadonlyConversationResultViewModel["state"];
 } = {}): WebReadonlyViewModelProvider {
+  const conversationHandle = options.conversationHandle ?? "cv_1111222233334444";
   const runtime: WebReadonlyRuntimeContextViewModel = {
     generatedAt: fixedNow,
     prototypeOnly: true,
@@ -46,7 +48,7 @@ function makeProvider(options: {
     state: options.runtime?.state ?? "available",
     activeTurns: options.runtime?.activeTurns ?? [
       {
-        sessionId: "cv_1111222233334444",
+        sessionId: conversationHandle,
         status: "running",
         summary: "Running tests without terminal logs.",
         blockedReason: null
@@ -106,8 +108,8 @@ function makeProvider(options: {
         workspaceId,
         conversations: [
           {
-            conversationId: "cv_1111222233334444",
-            conversationHandle: "cv_1111222233334444",
+            conversationId: conversationHandle,
+            conversationHandle,
             workspaceId,
             title: options.conversationTitle ?? "Implement Bridge adapter",
             status: "running",
@@ -334,15 +336,36 @@ test("raw IDs, paths, and platform markers from source are redacted or rejected"
   assert.ok(detail.messages.every((message) => !message.text.includes("secret")));
 });
 
-test("adapter exposes no write methods", () => {
+test("session resolver returns current opaque handle only without leaking it in Console payloads", () => {
+  const adapter = createConsoleBridgeReadAdapter({
+    provider: makeProvider({ conversationHandle: "cv_aaaaaaaaaaaaaaaa" }),
+    now: () => fixedNow,
+    idSalt: "resolver"
+  });
+  const project = adapter.listProjects()[0];
+  assert.ok(project?.activeSessionId);
+
+  assert.equal(adapter.resolveConversationHandleForSession?.(project.activeSessionId), "cv_aaaaaaaaaaaaaaaa");
+  assert.equal(adapter.resolveConversationHandleForSession?.("ses_missing1"), null);
+  assert.equal(JSON.stringify(project).includes("cv_aaaaaaaaaaaaaaaa"), false);
+});
+
+test("adapter exposes no write methods and only a narrow internal session resolver", () => {
   const adapter = createConsoleBridgeReadAdapter({ provider: makeProvider(), now: () => fixedNow });
+  const bootstrap = adapter.getBootstrap();
+  const sessionId = bootstrap.activeSessionId;
+  assert.ok(sessionId);
 
   assert.deepEqual(Object.keys(adapter).sort(), [
     "getBootstrap",
     "getSessionDetail",
     "listProjectSessions",
-    "listProjects"
+    "listProjects",
+    "resolveConversationHandleForSession"
   ]);
+  assert.equal(adapter.resolveConversationHandleForSession?.(sessionId), "cv_1111222233334444");
+  assert.equal(adapter.resolveConversationHandleForSession?.("session-1"), null);
+  assert.equal(JSON.stringify(bootstrap).includes("cv_1111222233334444"), false);
   for (const key of Object.keys(adapter)) {
     assert.doesNotMatch(key, /send|create|archive|answer|upload|post|write/i);
   }

--- a/src/web/console-bridge-read-adapter.test.ts
+++ b/src/web/console-bridge-read-adapter.test.ts
@@ -1,0 +1,436 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createConsoleBridgeReadAdapter } from "./console-bridge-read-adapter.js";
+import { assertConsoleSafeString, isConsoleOpaqueId } from "./console-api-contract.js";
+import type { ConsoleApiError, ConsoleOpaqueIdKind } from "./console-api-contract.js";
+import type {
+  WebReadonlyConversationResultViewModel,
+  WebReadonlyPendingInteractionViewRow,
+  WebReadonlyReadinessGuardrailViewModel,
+  WebReadonlyRuntimeContextViewModel,
+  WebReadonlyViewModelProvider
+} from "../service/web-readonly-view-model.js";
+
+const fixedNow = "2026-05-01T00:00:00.000Z";
+
+const pendingInteraction: WebReadonlyPendingInteractionViewRow = {
+  interactionId: "pi_safe_1",
+  conversationId: "cv_1111222233334444",
+  sessionId: null,
+  status: "awaiting_user_input",
+  kind: "command",
+  createdAt: "2026-04-30T12:02:00.000Z",
+  updatedAt: null,
+  blockingReason: "Codex wants permission to run tests.",
+  summary: { state: "available", text: "Run the targeted web tests." },
+  availability: "available",
+  warnings: []
+};
+
+function makeProvider(options: {
+  throwWorkspaces?: boolean;
+  workspaceLabel?: string;
+  conversationTitle?: string;
+  answerText?: string;
+  includePending?: boolean;
+  readiness?: Partial<WebReadonlyReadinessGuardrailViewModel>;
+  runtime?: Partial<WebReadonlyRuntimeContextViewModel>;
+  detailState?: WebReadonlyConversationResultViewModel["state"];
+} = {}): WebReadonlyViewModelProvider {
+  const runtime: WebReadonlyRuntimeContextViewModel = {
+    generatedAt: fixedNow,
+    prototypeOnly: true,
+    readonly: true,
+    pageId: "web_runtime_context",
+    state: options.runtime?.state ?? "available",
+    activeTurns: options.runtime?.activeTurns ?? [
+      {
+        sessionId: "cv_1111222233334444",
+        status: "running",
+        summary: "Running tests without terminal logs.",
+        blockedReason: null
+      }
+    ],
+    warnings: options.runtime?.warnings ?? []
+  };
+  const readiness: WebReadonlyReadinessGuardrailViewModel = {
+    generatedAt: fixedNow,
+    prototypeOnly: true,
+    readonly: true,
+    pageId: "web_readiness_guardrails",
+    state: options.readiness?.state ?? "ready",
+    checkedAt: fixedNow,
+    activePack: null,
+    capabilities: [],
+    missingGates: options.readiness?.missingGates ?? [],
+    warnings: options.readiness?.warnings ?? []
+  };
+
+  return {
+    getHomeViewModel() {
+      throw new Error("not used by adapter");
+    },
+    listWorkspaceViewModels() {
+      if (options.throwWorkspaces) {
+        throw new Error("store exploded /tmp/raw token=abc telegramChatId=123");
+      }
+      return {
+        generatedAt: fixedNow,
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_workspaces",
+        state: "available",
+        workspaces: [
+          {
+            workspaceId: "wk_aaaabbbbccccdddd",
+            label: options.workspaceLabel ?? "Console Core",
+            availability: "available",
+            conversationCount: 1,
+            pinned: true,
+            lastActivityAt: "2026-04-30T12:00:00.000Z",
+            lastSuccessAt: null,
+            source: "sessions"
+          }
+        ],
+        warnings: []
+      };
+    },
+    listWorkspaceConversationViewModels(workspaceId: string) {
+      return {
+        generatedAt: fixedNow,
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_workspace_conversations",
+        state: "available",
+        workspaceId,
+        conversations: [
+          {
+            conversationId: "cv_1111222233334444",
+            conversationHandle: "cv_1111222233334444",
+            workspaceId,
+            title: options.conversationTitle ?? "Implement Bridge adapter",
+            status: "running",
+            failureReason: null,
+            archived: false,
+            createdAt: "2026-04-30T11:00:00.000Z",
+            lastActivityAt: "2026-04-30T12:01:00.000Z",
+            lastTurnStatus: "running",
+            finalAnswerAvailable: true
+          }
+        ],
+        emptyState: null,
+        warnings: []
+      };
+    },
+    getConversationResultViewModel(conversationHandle: string) {
+      return {
+        generatedAt: fixedNow,
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_conversation_result",
+        state: options.detailState ?? "available",
+        conversation: {
+          conversationId: conversationHandle,
+          conversationHandle,
+          workspaceId: "wk_aaaabbbbccccdddd",
+          title: options.conversationTitle ?? "Implement Bridge adapter",
+          workspaceLabel: options.workspaceLabel ?? "Console Core",
+          status: "running",
+          failureReason: null,
+          archived: false,
+          createdAt: "2026-04-30T11:00:00.000Z",
+          lastActivityAt: "2026-04-30T12:01:00.000Z"
+        },
+        answers: [
+          {
+            answerId: "answer-safe-1",
+            kind: "final_answer",
+            deliveryState: "delivered",
+            createdAt: "2026-04-30T12:03:00.000Z",
+            body: { state: "available", text: options.answerText ?? "Mapped a read-only adapter over the safe Web view models." },
+            summary: "Final answer body was provided by an injected Web-safe sanitizer."
+          }
+        ],
+        runtime: { state: runtime.state, activeTurns: runtime.activeTurns },
+        pendingInteractions: {
+          state: options.includePending === false ? "unavailable" : "available",
+          pendingInteractions: options.includePending === false ? [] : [pendingInteraction]
+        },
+        readiness: { state: readiness.state, missingGates: readiness.missingGates },
+        composer: {
+          state: "disabled",
+          label: "Message Codex",
+          placeholder: "Type a message to Codex",
+          disabledReason: "Sending from Web is landing next.",
+          capability: "web_send_landing_next"
+        },
+        warnings: []
+      };
+    },
+    getConversationArtifactCatalogViewModel(sessionId: string) {
+      assert.match(sessionId, /^cv_[a-f0-9]{16}$/);
+      return {
+        generatedAt: fixedNow,
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_conversation_artifacts",
+        state: "available",
+        conversationId: sessionId,
+        artifacts: [
+          {
+            artifactId: "art_safe_descriptor_1",
+            label: "Run summary",
+            kind: "document",
+            type: "text/markdown",
+            mediaType: "text/markdown",
+            sizeBytes: 512,
+            createdAt: "2026-04-30T12:03:00.000Z",
+            updatedAt: null,
+            availability: "available",
+            previewEligible: false,
+            previewLabel: "Preview unavailable",
+            downloadEligible: false,
+            downloadLabel: "Download unavailable",
+            warnings: []
+          }
+        ],
+        selectedArtifact: null,
+        emptyState: null,
+        warnings: []
+      };
+    },
+    getRuntimeContextViewModel() {
+      return runtime;
+    },
+    getPendingInteractionsViewModel() {
+      return {
+        generatedAt: fixedNow,
+        prototypeOnly: true,
+        readonly: true,
+        pageId: "web_pending_interactions",
+        state: options.includePending === false ? "unavailable" : "available",
+        pendingInteractions: options.includePending === false ? [] : [pendingInteraction],
+        warnings: []
+      };
+    },
+    getReadinessGuardrailViewModel() {
+      return readiness;
+    }
+  };
+}
+
+test("bootstrap has safe defaults, read-only capabilities, models, and commands", () => {
+  const adapter = createConsoleBridgeReadAdapter({ provider: makeProvider(), now: () => fixedNow, idSalt: "test-salt" });
+
+  const bootstrap = adapter.getBootstrap();
+
+  assert.equal(bootstrap.apiVersion, "2026-05-01.phase3");
+  assert.equal(bootstrap.generatedAt, fixedNow);
+  assert.equal(bootstrap.viewer.role, "owner");
+  assert.equal(bootstrap.capabilities.sendMessage.state, "disabled");
+  assert.equal(bootstrap.capabilities.createSession.state, "disabled");
+  assert.equal(bootstrap.capabilities.archiveProject.state, "disabled");
+  assert.equal(bootstrap.capabilities.answerApproval.state, "disabled");
+  assert.equal(bootstrap.capabilities.streamEvents.state, "enabled");
+  assert.equal(bootstrap.capabilities.fetchArtifacts.state, "enabled");
+  assert.ok(bootstrap.commands.some((command) => command.name === "/status" && command.enabled));
+  assert.ok(bootstrap.models.some((model) => model.value === "gpt-5.5"));
+  assert.ok(bootstrap.modes.some((mode) => mode.value === "auto"));
+  assert.equal(bootstrap.projects.length, 1);
+  assertNoForbiddenConsoleData(bootstrap);
+  assertConsoleShape(bootstrap);
+});
+
+test("projects and sessions use deterministic opaque Console IDs", () => {
+  const first = createConsoleBridgeReadAdapter({ provider: makeProvider(), now: () => fixedNow, idSalt: "stable" });
+  const second = createConsoleBridgeReadAdapter({ provider: makeProvider(), now: () => fixedNow, idSalt: "stable" });
+
+  const project = first.listProjects()[0];
+  const projectAgain = second.listProjects()[0];
+  assert.ok(project);
+  assert.ok(projectAgain);
+  assert.equal(project.projectId, projectAgain.projectId);
+  assert.equal(isConsoleOpaqueId("project", project.projectId), true);
+  assert.equal(isConsoleOpaqueId("session", project.activeSessionId), true);
+
+  const sessions = first.listProjectSessions(project.projectId);
+  assert.ok(Array.isArray(sessions));
+  assert.equal(sessions.length, 1);
+  assert.equal(isConsoleOpaqueId("session", sessions[0]?.sessionId), true);
+  assert.equal(sessions[0]?.projectId, project.projectId);
+  assert.equal(sessions[0]?.status, "waiting_for_approval");
+  assertNoForbiddenConsoleData({ project, sessions });
+  assertConsoleShape({ project, sessions });
+});
+
+test("session detail maps messages, run, diff, approvals, and artifacts", () => {
+  const adapter = createConsoleBridgeReadAdapter({ provider: makeProvider(), now: () => fixedNow, idSalt: "detail" });
+  const project = adapter.listProjects()[0];
+  assert.ok(project?.activeSessionId);
+
+  const detail = adapter.getSessionDetail(project.activeSessionId);
+
+  assert.ok(!isConsoleApiError(detail));
+  assert.equal(detail.status, "waiting_for_approval");
+  assert.ok(detail.messages.some((message) => message.role === "assistant" && message.format === "markdown"));
+  assert.equal(detail.activeRun?.status, "waiting_for_approval");
+  assert.equal(detail.activeRunId, detail.activeRun?.runId);
+  assert.equal(detail.approvals.length, 1);
+  assert.equal(detail.approvals[0]?.kind, "command");
+  assert.equal(detail.artifacts.length, 1);
+  assert.equal(detail.artifacts[0]?.kind, "run_summary");
+  assert.equal(detail.diffs.length, 1);
+  assert.equal(detail.eventsUrl, `/api/sessions/${detail.sessionId}/events`);
+  assertNoForbiddenConsoleData(detail);
+  assertConsoleShape(detail);
+});
+
+test("unavailable and degraded read sources return safe API errors or degraded capability states", () => {
+  const unavailable = createConsoleBridgeReadAdapter({ provider: makeProvider({ throwWorkspaces: true }), now: () => fixedNow });
+  const bootstrap = unavailable.getBootstrap();
+
+  assert.equal(bootstrap.projects.length, 0);
+  assert.equal(bootstrap.capabilities.streamEvents.state, "degraded");
+  assert.ok(bootstrap.degradedStates.some((state) => state.code === "read_source_unavailable"));
+  assertNoForbiddenConsoleData(bootstrap);
+
+  const missing = unavailable.getSessionDetail("ses_missing123A");
+  assert.ok(isConsoleApiError(missing));
+  assert.equal(missing.code, "bridge_unavailable");
+  assertNoForbiddenConsoleData(missing);
+
+  const degraded = createConsoleBridgeReadAdapter({
+    provider: makeProvider({ readiness: { state: "app_server_unavailable", missingGates: ["App server unavailable"] } }),
+    now: () => fixedNow
+  }).getBootstrap();
+  assert.equal(degraded.capabilities.streamEvents.state, "degraded");
+  assert.ok(degraded.degradedStates.some((state) => state.code === "readiness_degraded"));
+  assertNoForbiddenConsoleData(degraded);
+});
+
+test("raw IDs, paths, and platform markers from source are redacted or rejected", () => {
+  const adapter = createConsoleBridgeReadAdapter({
+    provider: makeProvider({
+      workspaceLabel: "Telegram /home/ubuntu/secret token=abc callback_data=approve",
+      conversationTitle: "feishu open_id=ou_secret /tmp/session pid=4242",
+      answerText: "Done in /home/ubuntu/secret with telegramChatId=123 token=abc"
+    }),
+    now: () => fixedNow,
+    idSalt: "unsafe"
+  });
+
+  const bootstrap = adapter.getBootstrap();
+  assertNoForbiddenConsoleData(bootstrap);
+  assertConsoleShape(bootstrap);
+  assert.equal(bootstrap.projects[0]?.title, "Workspace");
+
+  const sessionId = bootstrap.activeSessionId;
+  assert.ok(sessionId);
+  const detail = adapter.getSessionDetail(sessionId);
+  assert.ok(!isConsoleApiError(detail));
+  assertNoForbiddenConsoleData(detail);
+  assertConsoleShape(detail);
+  assert.ok(detail.messages.every((message) => !message.text.includes("secret")));
+});
+
+test("adapter exposes no write methods", () => {
+  const adapter = createConsoleBridgeReadAdapter({ provider: makeProvider(), now: () => fixedNow });
+
+  assert.deepEqual(Object.keys(adapter).sort(), [
+    "getBootstrap",
+    "getSessionDetail",
+    "listProjectSessions",
+    "listProjects"
+  ]);
+  for (const key of Object.keys(adapter)) {
+    assert.doesNotMatch(key, /send|create|archive|answer|upload|post|write/i);
+  }
+});
+
+const idFieldKinds = {
+  projectId: "project",
+  activeProjectId: "project",
+  sessionId: "session",
+  activeSessionId: "session",
+  messageId: "message",
+  runId: "run",
+  activeRunId: "run",
+  approvalId: "approval",
+  artifactId: "artifact"
+} as const satisfies Record<string, ConsoleOpaqueIdKind>;
+
+const listIdFieldKinds = {
+  approvalIds: "approval",
+  artifactIds: "artifact"
+} as const satisfies Record<string, ConsoleOpaqueIdKind>;
+
+function assertConsoleShape(value: unknown): void {
+  visitShape(value, (node, key) => {
+    if (typeof node === "string") {
+      assertConsoleSafeString(node, key ?? "value");
+    }
+    if (!key) {
+      return;
+    }
+    const kind = idFieldKinds[key as keyof typeof idFieldKinds];
+    if (kind) {
+      assert.equal(isConsoleOpaqueId(kind, node), true, `${key} must be opaque`);
+    }
+    const listKind = listIdFieldKinds[key as keyof typeof listIdFieldKinds];
+    if (listKind) {
+      assert.ok(Array.isArray(node), `${key} must be an array`);
+      for (const item of node) {
+        assert.equal(isConsoleOpaqueId(listKind, item), true, `${key} item must be opaque`);
+      }
+    }
+  });
+}
+
+function assertNoForbiddenConsoleData(value: unknown): void {
+  const text = JSON.stringify(value);
+  for (const forbidden of [
+    "/home/ubuntu",
+    "/tmp/",
+    "telegram",
+    "Telegram",
+    "feishu",
+    "open_id",
+    "union_id",
+    "chatId",
+    "telegramChatId",
+    "callback_data",
+    "token=",
+    "pid=",
+    "processId",
+    "rawTerminal",
+    "stdout",
+    "stderr",
+    "cv_1111222233334444",
+    "wk_aaaabbbbccccdddd",
+    "answer-safe-1",
+    "pi_safe_1"
+  ]) {
+    assert.equal(text.includes(forbidden), false, `leaked forbidden marker ${forbidden}: ${text}`);
+  }
+}
+
+function visitShape(value: unknown, visitor: (node: unknown, key?: string) => void, key?: string): void {
+  visitor(value, key);
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitShape(item, visitor);
+    }
+    return;
+  }
+  for (const [childKey, childValue] of Object.entries(value)) {
+    visitShape(childValue, visitor, childKey);
+  }
+}
+
+function isConsoleApiError(value: unknown): value is ConsoleApiError {
+  return Boolean(value && typeof value === "object" && "code" in value && "message" in value && "retryable" in value);
+}

--- a/src/web/console-bridge-read-adapter.ts
+++ b/src/web/console-bridge-read-adapter.ts
@@ -1,0 +1,960 @@
+import { createHash } from "node:crypto";
+
+import type {
+  WebReadonlyAnswerRow,
+  WebReadonlyArtifactDescriptorRow,
+  WebReadonlyAvailability,
+  WebReadonlyConversationResultViewModel,
+  WebReadonlyConversationRow,
+  WebReadonlyPendingInteractionViewRow,
+  WebReadonlyReadinessGuardrailViewModel,
+  WebReadonlyRuntimeTurnRow,
+  WebReadonlyViewModelProvider,
+  WebReadonlyWorkspaceRow
+} from "../service/web-readonly-view-model.js";
+import {
+  CONSOLE_API_VERSION,
+  assertConsoleOpaqueId,
+  assertConsoleSafeString,
+  type ConsoleApiError,
+  type ConsoleApprovalKind,
+  type ConsoleApprovalRequest,
+  type ConsoleArtifactKind,
+  type ConsoleArtifactStatus,
+  type ConsoleArtifactSummary,
+  type ConsoleBootstrap,
+  type ConsoleCapabilities,
+  type ConsoleCapability,
+  type ConsoleDegradedState,
+  type ConsoleDiffFileSummary,
+  type ConsoleDiffSummary,
+  type ConsoleMessage,
+  type ConsoleMessageStatus,
+  type ConsoleProject,
+  type ConsoleProjectId,
+  type ConsoleRunState,
+  type ConsoleRunStatus,
+  type ConsoleRunStep,
+  type ConsoleSessionDetail,
+  type ConsoleSessionSummary,
+  type ConsoleSessionId,
+  type ConsoleSessionStatus
+} from "./console-api-contract.js";
+
+export interface ConsoleBridgeReadAdapter {
+  getBootstrap(): ConsoleBootstrap;
+  listProjects(): ConsoleProject[];
+  listProjectSessions(projectId: ConsoleProjectId | string): ConsoleSessionSummaryResult;
+  getSessionDetail(sessionId: ConsoleSessionId | string): ConsoleSessionDetail | ConsoleApiError;
+}
+
+export type ConsoleSessionSummaryResult = ConsoleSessionSummary[] | ConsoleApiError;
+
+export interface ConsoleBridgeReadAdapterOptions {
+  provider: WebReadonlyViewModelProvider;
+  now?: () => string;
+  idSalt?: string;
+}
+
+interface AdapterIndexes {
+  generatedAt: string;
+  projects: ConsoleProject[];
+  projectById: Map<ConsoleProjectId, ProjectIndexEntry>;
+  sessionById: Map<ConsoleSessionId, SessionIndexEntry>;
+  degradedStates: ConsoleDegradedState[];
+  sourceUnavailable: boolean;
+}
+
+interface ProjectIndexEntry {
+  project: ConsoleProject;
+  conversations: WebReadonlyConversationRow[];
+  state: WebReadonlyAvailability;
+}
+
+interface SessionIndexEntry {
+  conversation: WebReadonlyConversationRow;
+  summary: ConsoleSessionSummary;
+}
+
+interface DetailParts {
+  messages: ConsoleMessage[];
+  activeRun?: ConsoleRunState;
+  diffs: ConsoleDiffSummary[];
+  approvals: ConsoleApprovalRequest[];
+  artifacts: ConsoleArtifactSummary[];
+}
+
+const DEFAULT_ADAPTER_ID_SALT = "console-bridge-read-adapter:v1";
+
+const READ_ONLY_REASON = "Console Bridge read adapter is read-only in this phase.";
+
+export function createConsoleBridgeReadAdapter(options: ConsoleBridgeReadAdapterOptions): ConsoleBridgeReadAdapter {
+  const now = () => safeIso(options.now?.() ?? new Date().toISOString());
+  const idSalt = options.idSalt ?? DEFAULT_ADAPTER_ID_SALT;
+
+  const projectIdForWorkspace = (workspaceId: string): ConsoleProjectId => opaqueId("project", idSalt, workspaceId);
+  const sessionIdForConversation = (conversationHandle: string): ConsoleSessionId => opaqueId("session", idSalt, conversationHandle);
+
+  const buildIndexes = (): AdapterIndexes => {
+    const generatedAt = now();
+    const degradedStates: ConsoleDegradedState[] = [];
+    const projectById = new Map<ConsoleProjectId, ProjectIndexEntry>();
+    const sessionById = new Map<ConsoleSessionId, SessionIndexEntry>();
+
+    const workspaceVm = callProvider(
+      () => options.provider.listWorkspaceViewModels(),
+      "bridge_unavailable",
+      "Project list is temporarily unavailable."
+    );
+    if (!workspaceVm.ok) {
+      degradedStates.push(readSourceUnavailableState("Project list is temporarily unavailable."));
+      return { generatedAt, projects: [], projectById, sessionById, degradedStates, sourceUnavailable: true };
+    }
+
+    if (workspaceVm.value.state !== "available") {
+      degradedStates.push(degradedStateFromAvailability("projects", workspaceVm.value.state, workspaceVm.value.warnings));
+    }
+
+    const runtimeVm = callProvider(
+      () => options.provider.getRuntimeContextViewModel(),
+      "bridge_unavailable",
+      "Runtime state is temporarily unavailable."
+    );
+    if (runtimeVm.ok) {
+      if (runtimeVm.value.state !== "available") {
+        degradedStates.push(degradedStateFromAvailability("runtime", runtimeVm.value.state, runtimeVm.value.warnings));
+      }
+    } else {
+      degradedStates.push(readSourceUnavailableState("Runtime state is temporarily unavailable."));
+    }
+
+    const pendingVm = callProvider(
+      () => options.provider.getPendingInteractionsViewModel(),
+      "bridge_unavailable",
+      "Approval state is temporarily unavailable."
+    );
+    if (pendingVm.ok) {
+      if (pendingVm.value.state !== "available") {
+        degradedStates.push(degradedStateFromAvailability("approvals", pendingVm.value.state, pendingVm.value.warnings));
+      }
+    } else {
+      degradedStates.push(readSourceUnavailableState("Approval state is temporarily unavailable."));
+    }
+
+    const projects: ConsoleProject[] = [];
+    for (const workspace of workspaceVm.value.workspaces) {
+      const projectId = projectIdForWorkspace(workspace.workspaceId);
+      const conversationVm = callProvider(
+        () => options.provider.listWorkspaceConversationViewModels(workspace.workspaceId),
+        "bridge_unavailable",
+        "Session list is temporarily unavailable."
+      );
+      const conversations = conversationVm.ok ? conversationVm.value.conversations : [];
+      const conversationWarnings = conversationVm.ok ? safeWarningCodes(conversationVm.value.warnings) : [conversationVm.error.message];
+      const state = conversationVm.ok ? conversationVm.value.state : "unavailable";
+      if (state !== "available") {
+        degradedStates.push(degradedStateFromAvailability("sessions", state, conversationWarnings));
+      }
+
+      const activeConversation = conversations[0] ?? null;
+      const activeSessionId = activeConversation ? sessionIdForConversation(activeConversation.conversationHandle) : undefined;
+      const project: ConsoleProject = scrubShape({
+        projectId,
+        title: safeDisplayString(workspace.label, "Workspace", "project.title"),
+        ...(workspace.pinned ? { hint: "Pinned" } : {}),
+        archived: false,
+        sessionCount: Math.max(0, workspace.conversationCount || conversations.length),
+        ...(activeSessionId ? { activeSessionId } : {}),
+        ...(workspace.lastActivityAt ? { lastActivityAt: safeIso(workspace.lastActivityAt) } : {})
+      });
+
+      const entry: ProjectIndexEntry = {
+        project,
+        conversations,
+        state
+      };
+      projects.push(project);
+      projectById.set(projectId, entry);
+
+      for (const conversation of conversations) {
+        const sessionId = sessionIdForConversation(conversation.conversationHandle);
+        const summary = toSessionSummary(conversation, projectId, sessionId, pendingVm.ok ? pendingVm.value.pendingInteractions : [], idSalt);
+        sessionById.set(sessionId, {
+          conversation,
+          summary
+        });
+      }
+    }
+
+    return {
+      generatedAt,
+      projects,
+      projectById,
+      sessionById,
+      degradedStates: uniqueDegradedStates(degradedStates),
+      sourceUnavailable: false
+    };
+  };
+
+  const adapter: ConsoleBridgeReadAdapter = {
+    getBootstrap() {
+      const indexes = buildIndexes();
+      const readiness = callProvider(
+        () => options.provider.getReadinessGuardrailViewModel(),
+        "bridge_unavailable",
+        "Readiness state is temporarily unavailable."
+      );
+      const degradedStates = [...indexes.degradedStates];
+      if (readiness.ok) {
+        const readinessValue = readiness.value;
+        const readinessDegraded = readinessValue.state !== "ready" && readinessValue.state !== "available";
+        if (readinessDegraded || readinessValue.warnings.length > 0 || readinessValue.missingGates.length > 0) {
+          degradedStates.push(readinessDegradedState(readinessValue));
+        }
+      } else {
+        degradedStates.push(readSourceUnavailableState(readiness.error.message));
+      }
+
+      const activeProject = indexes.projects[0];
+      const activeSessionId = activeProject?.activeSessionId;
+      return scrubShape({
+        apiVersion: CONSOLE_API_VERSION,
+        generatedAt: indexes.generatedAt,
+        viewer: { role: "owner", displayName: "Workspace owner" },
+        capabilities: capabilitiesFor(readiness.ok ? readiness.value : null, indexes.degradedStates.length > 0 || !readiness.ok),
+        projects: indexes.projects,
+        ...(activeProject ? { activeProjectId: activeProject.projectId } : {}),
+        ...(activeSessionId ? { activeSessionId } : {}),
+        commands: defaultCommands(),
+        models: defaultModels(),
+        modes: defaultModes(),
+        degradedStates: uniqueDegradedStates(degradedStates)
+      });
+    },
+
+    listProjects() {
+      return buildIndexes().projects;
+    },
+
+    listProjectSessions(projectId) {
+      const indexes = buildIndexes();
+      const safeProjectId = parseConsoleId("project", projectId);
+      if (!safeProjectId) {
+        return apiError("bad_request", "Project id must be an opaque Console project id.", false);
+      }
+      if (indexes.sourceUnavailable) {
+        return apiError("bridge_unavailable", "Session list is temporarily unavailable.", true);
+      }
+      const project = indexes.projectById.get(safeProjectId);
+      if (!project) {
+        return apiError("not_found", "Project was not found in the read-only Console view.", false);
+      }
+      if (project.state === "unavailable") {
+        return apiError("bridge_unavailable", "Session list is temporarily unavailable for this project.", true);
+      }
+      return project.conversations.map((conversation) => {
+        const sessionId = sessionIdForConversation(conversation.conversationHandle);
+        return indexes.sessionById.get(sessionId)?.summary
+          ?? toSessionSummary(conversation, safeProjectId, sessionId, [], idSalt);
+      });
+    },
+
+    getSessionDetail(sessionId) {
+      const indexes = buildIndexes();
+      const safeSessionId = parseConsoleId("session", sessionId);
+      if (!safeSessionId) {
+        return apiError("bad_request", "Session id must be an opaque Console session id.", false);
+      }
+      if (indexes.sourceUnavailable) {
+        return apiError("bridge_unavailable", "Session detail is temporarily unavailable.", true);
+      }
+
+      const session = indexes.sessionById.get(safeSessionId);
+      if (!session) {
+        return apiError("not_found", "Session was not found in the read-only Console view.", false);
+      }
+
+      const detailVm = callProvider(
+        () => options.provider.getConversationResultViewModel(session.conversation.conversationHandle),
+        "bridge_unavailable",
+        "Session detail is temporarily unavailable."
+      );
+      if (!detailVm.ok) {
+        return detailVm.error;
+      }
+      if (!detailVm.value.conversation || detailVm.value.state === "unavailable") {
+        return apiError("bridge_unavailable", "Session detail is temporarily unavailable.", true);
+      }
+
+      const artifactsVm = callProvider(
+        () => options.provider.getConversationArtifactCatalogViewModel(session.conversation.conversationHandle),
+        "bridge_unavailable",
+        "Artifact list is temporarily unavailable."
+      );
+      const artifacts = artifactsVm.ok
+        ? artifactsVm.value.artifacts.map((artifact, index) => toArtifact(artifact, safeSessionId, idSalt, index))
+        : [];
+      const parts = detailParts(detailVm.value, safeSessionId, artifacts, idSalt);
+      const status = parts.activeRun?.status === "waiting_for_approval"
+        ? "waiting_for_approval"
+        : parts.activeRun?.status === "running"
+          ? "running"
+          : session.summary.status;
+
+      return scrubShape({
+        ...session.summary,
+        status,
+        ...((parts.activeRun?.runId ?? session.summary.activeRunId)
+          ? { activeRunId: parts.activeRun?.runId ?? session.summary.activeRunId }
+          : {}),
+        pendingApprovalCount: parts.approvals.filter((approval) => approval.status === "pending").length,
+        artifactCount: parts.artifacts.length,
+        messages: parts.messages,
+        ...(parts.activeRun ? { activeRun: parts.activeRun } : {}),
+        diffs: parts.diffs,
+        approvals: parts.approvals,
+        artifacts: parts.artifacts,
+        eventsUrl: `/api/sessions/${safeSessionId}/events`
+      });
+    }
+  };
+
+  return adapter;
+}
+
+function toSessionSummary(
+  conversation: WebReadonlyConversationRow,
+  projectId: ConsoleProjectId,
+  sessionId: ConsoleSessionId,
+  pendingInteractions: WebReadonlyPendingInteractionViewRow[],
+  idSalt: string
+): ConsoleSessionSummary {
+  const pendingCount = pendingInteractions.filter((row) => row.conversationId === conversation.conversationHandle).length;
+  const status = toSessionStatus(conversation.status, conversation.archived, pendingCount);
+  const activeRunId = status === "running" || status === "waiting_for_approval"
+    ? opaqueId("run", idSalt, `${sessionId}:active`)
+    : undefined;
+  return scrubShape({
+    sessionId,
+    projectId,
+    title: safeDisplayString(conversation.title, "Untitled session", "session.title"),
+    status,
+    archived: Boolean(conversation.archived),
+    createdAt: safeIso(conversation.createdAt),
+    ...(conversation.lastActivityAt ? { lastActivityAt: safeIso(conversation.lastActivityAt) } : {}),
+    ...(conversation.finalAnswerAvailable ? { lastMessagePreview: "Final answer available." } : {}),
+    ...(activeRunId ? { activeRunId } : {}),
+    pendingApprovalCount: pendingCount,
+    artifactCount: conversation.finalAnswerAvailable ? 1 : 0
+  });
+}
+
+function detailParts(
+  vm: WebReadonlyConversationResultViewModel,
+  sessionId: ConsoleSessionId,
+  artifacts: ConsoleArtifactSummary[],
+  idSalt: string
+): DetailParts {
+  const messages: ConsoleMessage[] = [];
+  const approvals = vm.pendingInteractions.pendingInteractions.map((interaction, index) =>
+    toApproval(interaction, sessionId, idSalt, index)
+  );
+  const run = toRun(vm, sessionId, idSalt, approvals.length);
+
+  if (vm.conversation) {
+    messages.push(scrubShape({
+      messageId: opaqueId("message", idSalt, `${sessionId}:system:summary`),
+      sessionId,
+      role: "system",
+      text: safeDisplayString(
+        sessionSystemText(vm.conversation.status, vm.readiness.missingGates),
+        "Session is visible in read-only mode.",
+        "message.text"
+      ),
+      format: "plain_text",
+      status: "complete",
+      createdAt: safeIso(vm.conversation.createdAt),
+      ...(run ? { runId: run.runId } : {})
+    }));
+  }
+
+  for (const [index, answer] of vm.answers.entries()) {
+    const message = answerToMessage(answer, sessionId, idSalt, index, run?.runId, artifacts.map((artifact) => artifact.artifactId));
+    if (!message) {
+      continue;
+    }
+    messages.push(message);
+  }
+
+  if (messages.length === 0 && vm.conversation) {
+    messages.push(scrubShape({
+      messageId: opaqueId("message", idSalt, `${sessionId}:empty`),
+      sessionId,
+      role: "system",
+      text: "No Web-safe messages are available for this session yet.",
+      format: "plain_text",
+      status: "complete",
+      createdAt: safeIso(vm.conversation.createdAt)
+    }));
+  }
+
+  const diffs = artifacts.length > 0 ? [toDiff(sessionId, run?.runId, artifacts)] : [];
+  return {
+    messages,
+    ...(run ? { activeRun: run } : {}),
+    diffs,
+    approvals,
+    artifacts
+  };
+}
+
+function answerToMessage(
+  answer: WebReadonlyAnswerRow,
+  sessionId: ConsoleSessionId,
+  idSalt: string,
+  index: number,
+  runId: ConsoleRunState["runId"] | undefined,
+  artifactIds: ConsoleArtifactSummary["artifactId"][]
+): ConsoleMessage | null {
+  const body = answer.body.state === "available" ? answer.body.text : answer.summary;
+  const text = safeOptionalText(body, `message.${index}.text`);
+  if (!text) {
+    return null;
+  }
+
+  const status = answer.deliveryState === "failed" ? "failed" : "complete" satisfies ConsoleMessageStatus;
+  return scrubShape({
+    messageId: opaqueId("message", idSalt, `${sessionId}:answer:${answer.answerId}:${index}`),
+    sessionId,
+    role: "assistant",
+    text,
+    format: answer.body.state === "available" ? "markdown" : "plain_text",
+    status,
+    createdAt: safeIso(answer.createdAt),
+    ...(runId ? { runId } : {}),
+    ...(artifactIds.length > 0 ? { artifactIds } : {})
+  });
+}
+
+function toRun(
+  vm: WebReadonlyConversationResultViewModel,
+  sessionId: ConsoleSessionId,
+  idSalt: string,
+  pendingApprovalCount: number
+): ConsoleRunState | undefined {
+  const activeTurn = vm.runtime.activeTurns[0];
+  const conversation = vm.conversation;
+  if (!activeTurn && !conversation) {
+    return undefined;
+  }
+
+  const status = runStatus(activeTurn, conversation?.status, pendingApprovalCount);
+  const updatedAt = safeIso(conversation?.lastActivityAt ?? new Date(0).toISOString());
+  const steps = runSteps(activeTurn, vm.answers.length, pendingApprovalCount);
+  return scrubShape({
+    runId: opaqueId("run", idSalt, `${sessionId}:active`),
+    sessionId,
+    title: safeDisplayString(activeTurn?.summary ?? conversation?.title ?? "Session activity", "Session activity", "run.title"),
+    status,
+    progressLabel: progressLabel(status, steps),
+    progressPercent: progressPercent(status, steps),
+    steps,
+    ...(conversation?.createdAt ? { startedAt: safeIso(conversation.createdAt) } : {}),
+    updatedAt,
+    ...(status === "completed" || status === "failed" || status === "cancelled" ? { completedAt: updatedAt } : {})
+  });
+}
+
+function runSteps(activeTurn: WebReadonlyRuntimeTurnRow | undefined, answerCount: number, pendingApprovalCount: number): ConsoleRunStep[] {
+  const steps: ConsoleRunStep[] = [
+    { order: 1, label: "Session opened", state: "done" }
+  ];
+  if (activeTurn) {
+    steps.push({
+      order: 2,
+      label: safeDisplayString(activeTurn.summary ?? "Codex is working", "Codex is working", "run.step"),
+      state: activeTurn.blockedReason ? "done" : "active",
+      ...(activeTurn.blockedReason ? { summary: safeDisplayString(activeTurn.blockedReason, "Waiting", "run.step.summary") } : {})
+    });
+  }
+  if (pendingApprovalCount > 0) {
+    steps.push({ order: steps.length + 1, label: "Awaiting owner approval", state: "active" });
+  }
+  if (answerCount > 0) {
+    steps.push({ order: steps.length + 1, label: "Final answer available", state: "done" });
+  }
+  return steps.map((step, index) => ({ ...step, order: index + 1 }));
+}
+
+function toApproval(
+  interaction: WebReadonlyPendingInteractionViewRow,
+  sessionId: ConsoleSessionId,
+  idSalt: string,
+  index: number
+): ConsoleApprovalRequest {
+  const summaryText = interaction.summary.state === "available" ? interaction.summary.text : interaction.blockingReason;
+  return scrubShape({
+    approvalId: opaqueId("approval", idSalt, `${sessionId}:approval:${interaction.interactionId}:${index}`),
+    sessionId,
+    title: safeDisplayString(kindTitle(interaction.kind), "Approval required", "approval.title"),
+    body: safeDisplayString(summaryText, "Awaiting owner input; details are hidden for this read-only surface.", "approval.body"),
+    kind: approvalKind(interaction.kind),
+    status: approvalStatus(interaction.status),
+    requestedAt: safeIso(interaction.createdAt ?? new Date(0).toISOString()),
+    options: [
+      { answer: "approve", label: "Approve", style: "primary" },
+      { answer: "deny", label: "Deny", style: "secondary" }
+    ]
+  });
+}
+
+function toArtifact(
+  artifact: WebReadonlyArtifactDescriptorRow,
+  sessionId: ConsoleSessionId,
+  idSalt: string,
+  index: number
+): ConsoleArtifactSummary {
+  const artifactId = opaqueId("artifact", idSalt, `${sessionId}:artifact:${artifact.artifactId}:${index}`);
+  const title = safeDisplayString(artifact.label, "Artifact", "artifact.title");
+  const mediaType = artifact.mediaType ? safeMediaType(artifact.mediaType) : undefined;
+  return scrubShape({
+    artifactId,
+    sessionId,
+    kind: artifactKind(artifact.kind, artifact.type),
+    status: artifactStatus(artifact.availability),
+    title,
+    displayName: title,
+    ...(mediaType ? { mediaType } : {}),
+    ...(typeof artifact.sizeBytes === "number" ? { sizeBytes: artifact.sizeBytes } : {}),
+    url: `/api/artifacts/${artifactId}`,
+    files: [{
+      displayName: title,
+      status: artifactKind(artifact.kind, artifact.type) === "generated_file" ? "generated" : "modified"
+    }]
+  });
+}
+
+function toDiff(
+  sessionId: ConsoleSessionId,
+  runId: ConsoleRunState["runId"] | undefined,
+  artifacts: ConsoleArtifactSummary[]
+): ConsoleDiffSummary {
+  const files: ConsoleDiffFileSummary[] = artifacts.flatMap((artifact) =>
+    (artifact.files ?? []).map((file) => ({
+      displayName: file.displayName,
+      status: file.status === "created" || file.status === "generated" ? "created" : file.status,
+      added: file.added ?? 0,
+      removed: file.removed ?? 0
+    }))
+  );
+  return scrubShape({
+    sessionId,
+    ...(runId ? { runId } : {}),
+    title: "Artifacts available",
+    status: "preview",
+    totals: {
+      changedFiles: files.length,
+      added: files.reduce((sum, file) => sum + file.added, 0),
+      removed: files.reduce((sum, file) => sum + file.removed, 0)
+    },
+    files
+  });
+}
+
+function capabilitiesFor(readiness: WebReadonlyReadinessGuardrailViewModel | null, degraded: boolean): ConsoleCapabilities {
+  const missing = new Set(readiness?.missingGates ?? []);
+  const readState: ConsoleCapability = degraded || !readiness || readiness.state !== "ready"
+    ? { state: "degraded", reason: "Read source is partially available." }
+    : { state: "enabled" };
+  if (missing.size > 0) {
+    readState.reason = "Bridge readiness has missing gates.";
+    readState.ownerAction = "Check the bridge service readiness before relying on live updates.";
+  }
+
+  const disabled = (reason = READ_ONLY_REASON): ConsoleCapability => ({ state: "disabled", reason });
+  return {
+    archiveProject: disabled(),
+    createSession: disabled(),
+    sendMessage: disabled(),
+    answerApproval: disabled("Approval answers are not enabled in the read-only adapter."),
+    uploadFiles: disabled("Uploads are not enabled in the read-only adapter."),
+    streamEvents: readState,
+    fetchArtifacts: readState
+  };
+}
+
+function defaultCommands() {
+  return [
+    { name: "/help", label: "Help", enabled: true },
+    { name: "/status", label: "Status", enabled: true },
+    { name: "/where", label: "Where", enabled: true },
+    { name: "/model", label: "Model", enabled: true },
+    { name: "/review", label: "Review", enabled: false },
+    { name: "/rollback", label: "Rollback", enabled: false }
+  ];
+}
+
+function defaultModels() {
+  return [
+    { value: "gpt-5.5", label: "GPT-5.5", enabled: true },
+    { value: "gpt-5.4", label: "GPT-5.4", enabled: true },
+    { value: "gpt-5", label: "GPT-5", enabled: true }
+  ];
+}
+
+function defaultModes() {
+  return [
+    { value: "auto", label: "Auto", enabled: true },
+    { value: "plan", label: "Plan", enabled: true },
+    { value: "review", label: "Review only", enabled: false }
+  ];
+}
+
+function toSessionStatus(status: string, archived: boolean, pendingApprovalCount: number): ConsoleSessionStatus {
+  if (archived) {
+    return "archived";
+  }
+  if (pendingApprovalCount > 0) {
+    return "waiting_for_approval";
+  }
+  const normalized = status.trim().toLowerCase();
+  if (["running", "active", "streaming"].includes(normalized)) {
+    return "running";
+  }
+  if (["completed", "complete", "succeeded", "success"].includes(normalized)) {
+    return "completed";
+  }
+  if (["failed", "error"].includes(normalized)) {
+    return "failed";
+  }
+  if (["empty", "new"].includes(normalized)) {
+    return "empty";
+  }
+  return "idle";
+}
+
+function runStatus(
+  activeTurn: WebReadonlyRuntimeTurnRow | undefined,
+  conversationStatus: string | undefined,
+  pendingApprovalCount: number
+): ConsoleRunStatus {
+  if (pendingApprovalCount > 0 || activeTurn?.blockedReason) {
+    return "waiting_for_approval";
+  }
+  const status = (activeTurn?.status ?? conversationStatus ?? "idle").trim().toLowerCase();
+  if (["running", "active", "streaming"].includes(status)) {
+    return "running";
+  }
+  if (["failed", "error"].includes(status)) {
+    return "failed";
+  }
+  if (["cancelled", "canceled", "interrupted"].includes(status)) {
+    return "cancelled";
+  }
+  if (["completed", "complete", "succeeded", "success"].includes(status)) {
+    return "completed";
+  }
+  return "queued";
+}
+
+function approvalStatus(status: string): ConsoleApprovalRequest["status"] {
+  const normalized = status.trim().toLowerCase();
+  if (["approved", "accepted", "allowed"].includes(normalized)) {
+    return "approved";
+  }
+  if (["denied", "rejected", "declined"].includes(normalized)) {
+    return "denied";
+  }
+  if (["expired", "timed_out", "timeout"].includes(normalized)) {
+    return "expired";
+  }
+  return "pending";
+}
+
+function approvalKind(kind: string): ConsoleApprovalKind {
+  const normalized = kind.trim().toLowerCase();
+  if (normalized.includes("command") || normalized.includes("exec")) {
+    return "command";
+  }
+  if (normalized.includes("file") || normalized.includes("patch")) {
+    return "file_change";
+  }
+  if (normalized.includes("network") || normalized.includes("web")) {
+    return "network";
+  }
+  if (normalized.includes("external")) {
+    return "external_action";
+  }
+  return "other";
+}
+
+function artifactKind(kind: string, type: string | null): ConsoleArtifactKind {
+  const normalized = `${kind} ${type ?? ""}`.trim().toLowerCase();
+  if (normalized.includes("diff")) {
+    return "diff";
+  }
+  if (normalized.includes("summary") || normalized.includes("markdown")) {
+    return "run_summary";
+  }
+  if (normalized.includes("generated")) {
+    return "generated_file";
+  }
+  if (normalized.includes("file") || normalized.includes("document")) {
+    return "changed_file";
+  }
+  return "attachment";
+}
+
+function artifactStatus(availability: WebReadonlyAvailability): ConsoleArtifactStatus {
+  if (availability === "available") {
+    return "ready";
+  }
+  if (availability === "degraded") {
+    return "pending";
+  }
+  return "failed";
+}
+
+function kindTitle(kind: string): string {
+  const normalized = kind.trim().replace(/[_-]+/g, " ");
+  return normalized ? `Approval required: ${normalized}` : "Approval required";
+}
+
+function sessionSystemText(status: string, missingGates: string[]): string {
+  if (missingGates.length > 0) {
+    return `Session is visible in read-only mode. Missing readiness gates: ${missingGates.slice(0, 3).join(", ")}.`;
+  }
+  return `Session is visible in read-only mode with status ${status || "unknown"}.`;
+}
+
+function progressLabel(status: ConsoleRunStatus, steps: ConsoleRunStep[]): string {
+  if (status === "completed") {
+    return "Completed";
+  }
+  if (status === "waiting_for_approval") {
+    return "Waiting for approval";
+  }
+  const done = steps.filter((step) => step.state === "done").length;
+  return `${done}/${steps.length} steps`;
+}
+
+function progressPercent(status: ConsoleRunStatus, steps: ConsoleRunStep[]): number {
+  if (status === "completed") {
+    return 100;
+  }
+  if (status === "failed" || status === "cancelled") {
+    return 100;
+  }
+  if (steps.length === 0) {
+    return 0;
+  }
+  return Math.max(5, Math.min(95, Math.round((steps.filter((step) => step.state === "done").length / steps.length) * 100)));
+}
+
+function degradedStateFromAvailability(kind: string, state: WebReadonlyAvailability | "empty", warnings: string[]): ConsoleDegradedState {
+  if (state === "unavailable") {
+    return readSourceUnavailableState(`${titleCase(kind)} read source is unavailable.`);
+  }
+  return scrubShape({
+    code: `${kind}_degraded`,
+    title: `${titleCase(kind)} data is degraded`,
+    body: safeDisplayString(warnings[0] ?? `${titleCase(kind)} data is partially available.`, "Read source is degraded.", "degraded.body"),
+    ownerAction: "Refresh later or check bridge readiness."
+  });
+}
+
+function readinessDegradedState(readiness: WebReadonlyReadinessGuardrailViewModel): ConsoleDegradedState {
+  const body = readiness.missingGates[0] ?? readiness.warnings[0] ?? "Bridge readiness is not fully available.";
+  return scrubShape({
+    code: "readiness_degraded",
+    title: "Bridge readiness needs attention",
+    body: safeDisplayString(body, "Bridge readiness is not fully available.", "degraded.body"),
+    ownerAction: "Check the bridge service readiness."
+  });
+}
+
+function readSourceUnavailableState(message: string): ConsoleDegradedState {
+  return scrubShape({
+    code: "read_source_unavailable",
+    title: "Read source unavailable",
+    body: safeDisplayString(message, "Console read source is unavailable.", "degraded.body"),
+    ownerAction: "Check the bridge service and retry."
+  });
+}
+
+function apiError(code: ConsoleApiError["code"], message: string, retryable: boolean): ConsoleApiError {
+  return scrubShape({
+    code,
+    message: safeDisplayString(message, "Console read request failed.", "error.message"),
+    retryable
+  });
+}
+
+function callProvider<T>(fn: () => T, code: ConsoleApiError["code"], message: string): { ok: true; value: T } | { ok: false; error: ConsoleApiError } {
+  try {
+    return { ok: true, value: fn() };
+  } catch {
+    return { ok: false, error: apiError(code, message, true) };
+  }
+}
+
+function opaqueId<K extends Parameters<typeof assertConsoleOpaqueId>[0]>(
+  kind: K,
+  salt: string,
+  value: string
+): ReturnType<typeof assertConsoleOpaqueId<K>> {
+  const digest = createHash("sha256").update(salt).update("\0").update(value).digest("base64url").slice(0, 18);
+  return assertConsoleOpaqueId(kind, `${prefixFor(kind)}_a${digest}0`, `${kind}Id`) as ReturnType<typeof assertConsoleOpaqueId<K>>;
+}
+
+function prefixFor(kind: Parameters<typeof assertConsoleOpaqueId>[0]): string {
+  switch (kind) {
+    case "project": return "prj";
+    case "session": return "ses";
+    case "message": return "msg";
+    case "run": return "run";
+    case "approval": return "apr";
+    case "artifact": return "art";
+  }
+}
+
+function parseConsoleId<K extends Parameters<typeof assertConsoleOpaqueId>[0]>(kind: K, value: unknown): ReturnType<typeof assertConsoleOpaqueId<K>> | null {
+  try {
+    return assertConsoleOpaqueId(kind, value, `${kind}Id`) as ReturnType<typeof assertConsoleOpaqueId<K>>;
+  } catch {
+    return null;
+  }
+}
+
+function scrubShape<T>(value: T): T {
+  visitShape(value, (node, key) => {
+    if (typeof node === "string") {
+      assertConsoleSafeString(node, key ?? "value");
+    }
+  });
+  return value;
+}
+
+function visitShape(value: unknown, visitor: (node: unknown, key?: string) => void, key?: string): void {
+  visitor(value, key);
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitShape(item, visitor);
+    }
+    return;
+  }
+  for (const [childKey, childValue] of Object.entries(value)) {
+    visitShape(childValue, visitor, childKey);
+  }
+}
+
+function safeDisplayString(value: unknown, fallback: string, fieldName: string): string {
+  const normalized = normalizeText(value);
+  const candidates = [normalized, redactUnsafeText(normalized), fallback];
+  for (const candidate of candidates) {
+    const trimmed = candidate.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      return assertConsoleSafeString(trimmed, fieldName);
+    } catch {
+      // Try next candidate.
+    }
+  }
+  return assertConsoleSafeString("Unavailable", fieldName);
+}
+
+function safeOptionalText(value: unknown, fieldName: string): string | null {
+  const text = normalizeText(value);
+  if (!text) {
+    return null;
+  }
+  try {
+    return assertConsoleSafeString(text, fieldName);
+  } catch {
+    const redacted = redactUnsafeText(text);
+    try {
+      return assertConsoleSafeString(redacted, fieldName);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function safeIso(value: string): string {
+  const text = normalizeText(value);
+  try {
+    assertConsoleSafeString(text, "timestamp");
+    return text;
+  } catch {
+    return new Date(0).toISOString();
+  }
+}
+
+function safeWarningCodes(warnings: string[]): string[] {
+  return warnings.map((warning) => safeDisplayString(warning, "read_source_warning", "warning"));
+}
+
+function safeMediaType(value: string): string | undefined {
+  const normalized = value.trim().toLowerCase();
+  if (/^[a-z0-9][a-z0-9.+-]{0,63}\/[a-z0-9][a-z0-9.+-]{0,127}$/.test(normalized)) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeText(value: unknown): string {
+  return String(value ?? "")
+    .replace(/<[^>]*>/g, "")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{4,}/g, "\n\n\n")
+    .trim();
+}
+
+function redactUnsafeText(value: string): string {
+  return value
+    .replace(/\b(?:https?|file):\/\/[^\s"'<>)]*/gi, "[redacted-url]")
+    .replace(/(?:^|[\s"'(])(?:\/(?:home|tmp|var|etc|root|Users|usr)\/[^\s<>"']*|~\/[^\s<>"']*|[A-Za-z]:\\[^\s<>"']*)/g, " [redacted-path]")
+    .replace(/\b(?:telegram|feishu)[_-]?(?:chat|message|user|open|union|tenant)?[_-]?id\b/gi, "platform-id")
+    .replace(/\b(?:telegram|feishu|lark)\b/gi, "platform")
+    .replace(/\b(?:chat|callback|open|union|tenant|message|user|thread)[_-]?id\b/gi, "platform-id")
+    .replace(/\bcallback[_-]?data\b/gi, "callback-data")
+    .replace(/\b(?:token|authorization|bearer|api[_-]?key|secret|password)\s*[:=]\s*\S+/gi, "[redacted-secret]")
+    .replace(/\bsecret\b/gi, "redacted")
+    .replace(/\b(?:sk|xox[baprs])-[A-Za-z0-9_-]{8,}/gi, "[redacted-secret]")
+    .replace(/\b(?:pid|process[_-]?id)\s*[:=]?\s*\d{2,}\b/gi, "process-id")
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "")
+    .trim();
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function uniqueDegradedStates(states: ConsoleDegradedState[]): ConsoleDegradedState[] {
+  const seen = new Set<string>();
+  const result: ConsoleDegradedState[] = [];
+  for (const state of states) {
+    const key = `${state.code}:${state.body}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(state);
+  }
+  return result;
+}
+
+function titleCase(value: string): string {
+  return value ? value[0]?.toUpperCase() + value.slice(1) : "Read source";
+}

--- a/src/web/console-bridge-read-adapter.ts
+++ b/src/web/console-bridge-read-adapter.ts
@@ -46,6 +46,7 @@ export interface ConsoleBridgeReadAdapter {
   listProjects(): ConsoleProject[];
   listProjectSessions(projectId: ConsoleProjectId | string): ConsoleSessionSummaryResult;
   getSessionDetail(sessionId: ConsoleSessionId | string): ConsoleSessionDetail | ConsoleApiError;
+  resolveConversationHandleForSession?(sessionId: ConsoleSessionId | string): string | null;
 }
 
 export type ConsoleSessionSummaryResult = ConsoleSessionSummary[] | ConsoleApiError;
@@ -316,6 +317,16 @@ export function createConsoleBridgeReadAdapter(options: ConsoleBridgeReadAdapter
         artifacts: parts.artifacts,
         eventsUrl: `/api/sessions/${safeSessionId}/events`
       });
+
+    },
+
+    resolveConversationHandleForSession(sessionId) {
+      const indexes = buildIndexes();
+      const safeSessionId = parseConsoleId("session", sessionId);
+      if (!safeSessionId || indexes.sourceUnavailable) {
+        return null;
+      }
+      return indexes.sessionById.get(safeSessionId)?.conversation.conversationHandle ?? null;
     }
   };
 

--- a/src/web/console-live-write-adapter.test.ts
+++ b/src/web/console-live-write-adapter.test.ts
@@ -1,0 +1,190 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { ConsoleBridgeReadAdapter } from "./console-bridge-read-adapter.js";
+import { createConsoleLiveWriteAdapter } from "./console-live-write-adapter.js";
+import type { ConsoleApiError, ConsoleSendMessageResult, ConsoleSessionDetail } from "./console-api-contract.js";
+
+const fixedNow = "2026-05-01T00:00:00.000Z";
+const sessionId = "ses_8h4Lm2Np6Bb";
+const conversationHandle = "cv_1234567890abcdef";
+
+function makeReadAdapter(
+  detail: ConsoleSessionDetail | { code: "not_found"; message: string; retryable: false },
+  handle: string | null = conversationHandle
+): ConsoleBridgeReadAdapter {
+  return {
+    getBootstrap() {
+      throw new Error("not used");
+    },
+    listProjects() {
+      throw new Error("not used");
+    },
+    listProjectSessions() {
+      throw new Error("not used");
+    },
+    getSessionDetail(requestedSessionId) {
+      assert.equal(requestedSessionId, sessionId);
+      return detail;
+    },
+    resolveConversationHandleForSession(requestedSessionId) {
+      assert.equal(requestedSessionId, sessionId);
+      return handle;
+    }
+  };
+}
+
+function sessionDetail(patch: Partial<ConsoleSessionDetail> = {}): ConsoleSessionDetail {
+  return {
+    sessionId,
+    projectId: "prj_7f3Kp9Qm2Aa",
+    title: "Safe live send",
+    status: "idle",
+    archived: false,
+    createdAt: fixedNow,
+    lastActivityAt: fixedNow,
+    pendingApprovalCount: 0,
+    artifactCount: 0,
+    messages: [
+      {
+        messageId: "msg_3k9Pq1Rs7Cc",
+        sessionId,
+        role: "system",
+        text: "Session is visible in read-only mode.",
+        format: "plain_text",
+        status: "complete",
+        createdAt: fixedNow
+      }
+    ],
+    diffs: [],
+    approvals: [],
+    artifacts: [],
+    eventsUrl: `/api/sessions/${sessionId}/events`,
+    ...patch
+  };
+}
+
+function sendMessage(adapter: ReturnType<typeof createConsoleLiveWriteAdapter>) {
+  assert.ok(adapter.sendMessage);
+  return adapter.sendMessage;
+}
+
+function assertSendResult(value: ConsoleSendMessageResult | ConsoleApiError): asserts value is ConsoleSendMessageResult {
+  assert.equal("accepted" in value && value.accepted, true);
+}
+
+test("live write adapter resolves Console session through read adapter and submits text once", async () => {
+  const submitted: unknown[] = [];
+  const adapter = createConsoleLiveWriteAdapter({
+    readAdapter: makeReadAdapter(sessionDetail()),
+    now: () => fixedNow,
+    submitTextMessage(request) {
+      submitted.push(request);
+      return { status: "accepted" };
+    }
+  });
+
+  const result = await sendMessage(adapter)(sessionId, { text: "  Continue safely.  ", model: "gpt-5.5", mode: "auto" });
+  assertSendResult(result);
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.sessionId, sessionId);
+  assert.equal(result.message.sessionId, sessionId);
+  assert.equal(result.message.role, "user");
+  assert.equal(result.message.text, "Continue safely.");
+  assert.equal(result.message.status, "pending");
+  assert.equal(result.message.createdAt, fixedNow);
+  assert.match(result.message.messageId, /^msg_[A-Za-z0-9_-]{6,128}$/);
+  assert.deepEqual(submitted, [{ conversationHandle, text: "Continue safely.", nonce: null }]);
+});
+
+test("live write adapter keeps unsupported actions disabled", () => {
+  const adapter = createConsoleLiveWriteAdapter({
+    readAdapter: makeReadAdapter(sessionDetail()),
+    submitTextMessage: () => ({ status: "accepted" })
+  });
+  const unresolved = createConsoleLiveWriteAdapter({
+    readAdapter: {
+      getBootstrap() { throw new Error("not used"); },
+      listProjects() { return []; },
+      listProjectSessions() { return []; },
+      getSessionDetail() { return sessionDetail(); }
+    },
+    submitTextMessage: () => ({ status: "accepted" })
+  });
+
+  assert.equal(adapter.capabilities?.sendMessage?.state, "enabled");
+  assert.equal(unresolved.capabilities?.sendMessage?.state, "disabled");
+  assert.equal(adapter.capabilities?.archiveProject?.state, "disabled");
+  assert.equal(adapter.capabilities?.createSession?.state, "disabled");
+  assert.equal(adapter.capabilities?.answerApproval?.state, "disabled");
+  assert.equal(adapter.archiveProject, undefined);
+  assert.equal(adapter.createSession, undefined);
+  assert.equal(adapter.answerApproval, undefined);
+});
+
+test("live write adapter maps missing session, unsupported payload, and submit failures safely", async () => {
+  const missing = createConsoleLiveWriteAdapter({
+    readAdapter: makeReadAdapter({ code: "not_found", message: "Session not found.", retryable: false }),
+    submitTextMessage: () => ({ status: "accepted" })
+  });
+  assert.deepEqual(await sendMessage(missing)(sessionId, { text: "hello" }), {
+    code: "not_found",
+    message: "Session is not available for live Web send.",
+    retryable: false
+  });
+
+  const archived = createConsoleLiveWriteAdapter({
+    readAdapter: makeReadAdapter(sessionDetail({ archived: true, status: "archived" })),
+    submitTextMessage: () => ({ status: "accepted" })
+  });
+  assert.deepEqual(await sendMessage(archived)(sessionId, { text: "hello" }), {
+    code: "conflict",
+    message: "Archived sessions cannot receive live Web messages.",
+    retryable: false
+  });
+
+  const withAttachment = createConsoleLiveWriteAdapter({
+    readAdapter: makeReadAdapter(sessionDetail()),
+    submitTextMessage: () => ({ status: "accepted" })
+  });
+  assert.deepEqual(await sendMessage(withAttachment)(sessionId, {
+    text: "hello",
+    attachmentArtifactIds: ["art_2m6Bc4De9Ff"]
+  }), {
+    code: "capability_disabled",
+    message: "Attachments are not enabled for live Web send.",
+    retryable: false,
+    capability: "uploadFiles"
+  });
+
+  const unavailable = createConsoleLiveWriteAdapter({
+    readAdapter: makeReadAdapter(sessionDetail()),
+    submitTextMessage: () => ({ status: "unavailable" })
+  });
+  assert.deepEqual(await sendMessage(unavailable)(sessionId, { text: "hello" }), {
+    code: "bridge_unavailable",
+    message: "Live Web send is temporarily unavailable.",
+    retryable: true
+  });
+
+  const blocked = createConsoleLiveWriteAdapter({
+    readAdapter: makeReadAdapter(sessionDetail()),
+    submitTextMessage: () => ({ status: "blocked" })
+  });
+  assert.deepEqual(await sendMessage(blocked)(sessionId, { text: "hello" }), {
+    code: "conflict",
+    message: "Codex is busy or waiting for owner input in this session.",
+    retryable: false
+  });
+
+  const rejected = createConsoleLiveWriteAdapter({
+    readAdapter: makeReadAdapter(sessionDetail()),
+    submitTextMessage: () => ({ status: "rejected" })
+  });
+  assert.deepEqual(await sendMessage(rejected)(sessionId, { text: "hello" }), {
+    code: "not_found",
+    message: "Session is not available for live Web send.",
+    retryable: false
+  });
+});

--- a/src/web/console-live-write-adapter.ts
+++ b/src/web/console-live-write-adapter.ts
@@ -1,0 +1,144 @@
+import { createHash } from "node:crypto";
+
+import type {
+  ConsoleApiError,
+  ConsoleMessage,
+  ConsoleSendMessageRequest,
+  ConsoleSendMessageResult,
+  ConsoleSessionId
+} from "./console-api-contract.js";
+import type { ConsoleBridgeReadAdapter } from "./console-bridge-read-adapter.js";
+import type { ConsoleApiWriteAdapter } from "./console-api-http.js";
+import type { WebMessageSubmitRequest, WebMessageSubmitResult } from "./readonly-http-server.js";
+
+export interface ConsoleLiveWriteAdapterOptions {
+  readAdapter: ConsoleBridgeReadAdapter;
+  submitTextMessage: (request: WebMessageSubmitRequest) => Promise<WebMessageSubmitResult> | WebMessageSubmitResult;
+  now?: () => string;
+}
+
+interface ConsoleSessionHandleResolver {
+  resolveConversationHandleForSession?(sessionId: ConsoleSessionId | string): string | null;
+}
+
+export function createConsoleLiveWriteAdapter(options: ConsoleLiveWriteAdapterOptions): ConsoleApiWriteAdapter {
+  const now = () => safeIso(options.now?.() ?? new Date().toISOString());
+  const canResolveSession = Boolean((options.readAdapter as ConsoleSessionHandleResolver).resolveConversationHandleForSession);
+  return {
+    capabilities: {
+      archiveProject: { state: "disabled", reason: "Project archive is not wired to a safe live Web submit seam." },
+      createSession: { state: "disabled", reason: "Session creation is not wired to a safe live Web submit seam." },
+      sendMessage: canResolveSession
+        ? { state: "enabled" }
+        : { state: "disabled", reason: "Console sessions cannot be resolved to the live Web submit seam." },
+      answerApproval: { state: "disabled", reason: "Approval answers are not wired to a safe live Web submit seam." }
+    },
+    async sendMessage(sessionId, request) {
+      if (request.attachmentArtifactIds && request.attachmentArtifactIds.length > 0) {
+        return apiError(
+          "capability_disabled",
+          "Attachments are not enabled for live Web send.",
+          false,
+          "uploadFiles"
+        );
+      }
+
+      const conversationHandle = (options.readAdapter as ConsoleSessionHandleResolver)
+        .resolveConversationHandleForSession?.(sessionId) ?? null;
+      if (!conversationHandle) {
+        return apiError("not_found", "Session is not available for live Web send.", false);
+      }
+
+      const detail = options.readAdapter.getSessionDetail(sessionId);
+      if (isConsoleApiError(detail)) {
+        return apiError("not_found", "Session is not available for live Web send.", false);
+      }
+      if (detail.archived || detail.status === "archived") {
+        return apiError("conflict", "Archived sessions cannot receive live Web messages.", false);
+      }
+
+      const text = request.text.trim();
+      const outcome = await submitSafely(options.submitTextMessage, { conversationHandle, text, nonce: null });
+      if (outcome.status === "accepted") {
+        return {
+          accepted: true,
+          sessionId,
+          message: pendingUserMessage(sessionId, text, now())
+        };
+      }
+      if (outcome.status === "blocked") {
+        return apiError("conflict", "Codex is busy or waiting for owner input in this session.", false);
+      }
+      if (outcome.status === "unavailable") {
+        return apiError("bridge_unavailable", "Live Web send is temporarily unavailable.", true);
+      }
+      return apiError("not_found", "Session is not available for live Web send.", false);
+    }
+  };
+}
+
+async function submitSafely(
+  submitTextMessage: ConsoleLiveWriteAdapterOptions["submitTextMessage"],
+  request: WebMessageSubmitRequest
+): Promise<WebMessageSubmitResult> {
+  try {
+    return await submitTextMessage(request);
+  } catch {
+    return { status: "unavailable" };
+  }
+}
+
+function pendingUserMessage(sessionId: ConsoleSessionId, text: string, createdAt: string): ConsoleMessage {
+  return {
+    messageId: opaqueMessageId(sessionId, text, createdAt),
+    sessionId,
+    role: "user",
+    text,
+    format: "plain_text",
+    status: "pending",
+    createdAt
+  };
+}
+
+function opaqueMessageId(sessionId: ConsoleSessionId, text: string, createdAt: string): ConsoleMessage["messageId"] {
+  const digest = createHash("sha256")
+    .update("console-live-write-adapter:v1")
+    .update("\0")
+    .update(sessionId)
+    .update("\0")
+    .update(createdAt)
+    .update("\0")
+    .update(text)
+    .digest("base64url")
+    .slice(0, 22);
+  return `msg_${digest}`;
+}
+
+function apiError(
+  code: ConsoleApiError["code"],
+  message: string,
+  retryable: boolean,
+  capability?: ConsoleApiError["capability"]
+): ConsoleApiError {
+  return {
+    code,
+    message,
+    retryable,
+    ...(capability ? { capability } : {})
+  };
+}
+
+function isConsoleApiError(value: unknown): value is ConsoleApiError {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    typeof (value as ConsoleApiError).code === "string" &&
+    typeof (value as ConsoleApiError).message === "string" &&
+    typeof (value as ConsoleApiError).retryable === "boolean"
+  );
+}
+
+function safeIso(value: string): string {
+  const time = Date.parse(value);
+  return Number.isFinite(time) ? new Date(time).toISOString() : new Date(0).toISOString();
+}

--- a/src/web/console-product-api-model.test.ts
+++ b/src/web/console-product-api-model.test.ts
@@ -1,0 +1,159 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createConsoleProductApiModel } from "./console-product-api-model.js";
+import { renderConsoleProductHomePage } from "./console-product-renderer.js";
+import type { ConsoleBootstrap, ConsoleSessionDetail, ConsoleSessionSummary } from "./console-api-contract.js";
+
+const bootstrap: ConsoleBootstrap = {
+  apiVersion: "2026-05-01.phase3",
+  generatedAt: "2026-05-01T00:00:00.000Z",
+  viewer: { role: "owner", displayName: "Workspace owner" },
+  capabilities: {
+    archiveProject: { state: "disabled", reason: "Archive is not wired." },
+    createSession: { state: "disabled", reason: "New sessions are not wired." },
+    sendMessage: { state: "disabled", reason: "Text send is disabled." },
+    answerApproval: { state: "disabled", reason: "Approvals are not wired." },
+    uploadFiles: { state: "disabled", reason: "Uploads are disabled." },
+    streamEvents: { state: "enabled" },
+    fetchArtifacts: { state: "enabled" }
+  },
+  projects: [
+    {
+      projectId: "prj_aLiveProject1230",
+      title: "Console Core",
+      branch: "main",
+      hint: "Pinned",
+      archived: false,
+      sessionCount: 1,
+      activeSessionId: "ses_aLiveSession1230",
+      lastActivityAt: "2026-04-30T12:00:00.000Z"
+    }
+  ],
+  activeProjectId: "prj_aLiveProject1230",
+  activeSessionId: "ses_aLiveSession1230",
+  commands: [{ name: "/status", label: "Status", enabled: true }],
+  models: [{ value: "gpt-5.5", label: "GPT-5.5", enabled: true }],
+  modes: [{ value: "auto", label: "Auto", enabled: true }],
+  degradedStates: []
+};
+
+const sessionSummary: ConsoleSessionSummary = {
+  sessionId: "ses_aLiveSession1230",
+  projectId: "prj_aLiveProject1230",
+  title: "Implement live UI",
+  status: "completed",
+  archived: false,
+  createdAt: "2026-04-30T11:00:00.000Z",
+  lastActivityAt: "2026-04-30T12:00:00.000Z",
+  lastMessagePreview: "Final answer available.",
+  pendingApprovalCount: 0,
+  artifactCount: 1
+};
+
+const detail: ConsoleSessionDetail = {
+  ...sessionSummary,
+  messages: [
+    {
+      messageId: "msg_aUserMessage1230",
+      sessionId: "ses_aLiveSession1230",
+      role: "user",
+      text: "Please wire the product UI to live data.",
+      format: "plain_text",
+      status: "complete",
+      createdAt: "2026-04-30T11:10:00.000Z"
+    },
+    {
+      messageId: "msg_aAssistant1230",
+      sessionId: "ses_aLiveSession1230",
+      role: "assistant",
+      text: "Live Console data is now visible.",
+      format: "plain_text",
+      status: "complete",
+      createdAt: "2026-04-30T11:11:00.000Z"
+    }
+  ],
+  diffs: [
+    {
+      sessionId: "ses_aLiveSession1230",
+      title: "UI changes",
+      status: "preview",
+      totals: { changedFiles: 1, added: 2, removed: 1 },
+      files: [{ displayName: "Console UI", status: "modified", added: 2, removed: 1 }]
+    }
+  ],
+  approvals: [],
+  artifacts: [
+    {
+      artifactId: "art_aSummary1230",
+      sessionId: "ses_aLiveSession1230",
+      kind: "run_summary",
+      status: "ready",
+      title: "Run summary",
+      displayName: "Run summary",
+      url: "/api/artifacts/art_aSummary1230",
+      files: [{ displayName: "Run summary", status: "generated" }]
+    }
+  ],
+  eventsUrl: "/api/sessions/ses_aLiveSession1230/events"
+};
+
+test("API product model renders live projects, sessions, disabled controls, and no raw Bridge ids", () => {
+  const model = createConsoleProductApiModel({
+    bootstrap,
+    projectSessions: new Map([["prj_aLiveProject1230", [sessionSummary]]]),
+    activeSessionDetail: detail
+  });
+  const html = renderConsoleProductHomePage(model);
+
+  for (const copy of [
+    "Console Core",
+    "Implement live UI",
+    "Please wire the product UI to live data.",
+    "Live Console data is now visible.",
+    "Archive",
+    "+ New",
+    "Review unavailable",
+    "Message unavailable from Web"
+  ]) {
+    assert.match(html, new RegExp(escapeRegExp(copy)), `missing ${copy}: ${html}`);
+  }
+  for (const marker of [
+    'data-console-api-root="/api"',
+    'data-console-session-id="ses_aLiveSession1230"',
+    'data-capability-send-message="disabled"',
+    'data-capability-state="disabled"'
+  ]) {
+    assert.match(html, new RegExp(escapeRegExp(marker)), `missing marker ${marker}: ${html}`);
+  }
+  for (const forbidden of ["cv_1234567890abcdef", "wk_safe_1", "telegram", "callback_data", "token="]) {
+    assert.equal(html.includes(forbidden), false, `leaked forbidden ${forbidden}: ${html}`);
+  }
+});
+
+test("API product model enables text send form only when sendMessage and CSRF are available", () => {
+  const enabledBootstrap: ConsoleBootstrap = {
+    ...bootstrap,
+    capabilities: {
+      ...bootstrap.capabilities,
+      sendMessage: { state: "enabled" }
+    }
+  };
+  const model = createConsoleProductApiModel({
+    bootstrap: enabledBootstrap,
+    projectSessions: new Map([["prj_aLiveProject1230", [sessionSummary]]]),
+    activeSessionDetail: detail,
+    csrfToken: "csrf-safe-token"
+  });
+  const html = renderConsoleProductHomePage(model);
+
+  assert.match(html, /<form class="console-composer"[^>]*data-console-send-form/);
+  assert.match(html, /action="\/api\/sessions\/ses_aLiveSession1230\/messages"/);
+  assert.match(html, /name="_csrf" value="csrf-safe-token"/);
+  assert.match(html, /<textarea[^>]*name="text"[^>]*maxlength="8000"[^>]*required/);
+  assert.match(html, /data-capability-send-message="enabled"/);
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/web/console-product-api-model.test.ts
+++ b/src/web/console-product-api-model.test.ts
@@ -154,6 +154,57 @@ test("API product model enables text send form only when sendMessage and CSRF ar
   assert.match(html, /data-capability-send-message="enabled"/);
 });
 
+test("API product model keeps send disabled unless capability and CSRF are supplied", () => {
+  const enabledBootstrap: ConsoleBootstrap = {
+    ...bootstrap,
+    capabilities: {
+      ...bootstrap.capabilities,
+      sendMessage: { state: "enabled" }
+    }
+  };
+
+  const missingCsrfModel = createConsoleProductApiModel({
+    bootstrap: enabledBootstrap,
+    projectSessions: new Map([["prj_aLiveProject1230", [sessionSummary]]]),
+    activeSessionDetail: detail
+  });
+  const missingCsrfHtml = renderConsoleProductHomePage(missingCsrfModel);
+  assert.match(missingCsrfHtml, /data-capability-send-message="disabled"/);
+  assert.match(missingCsrfHtml, /Console write capability requires CSRF protection\./);
+  assert.doesNotMatch(missingCsrfHtml, /data-console-send-form/);
+  assert.doesNotMatch(missingCsrfHtml, /action="\/api\/sessions\/ses_aLiveSession1230\/messages"/);
+
+  const disabledModel = createConsoleProductApiModel({
+    bootstrap,
+    projectSessions: new Map([["prj_aLiveProject1230", [sessionSummary]]]),
+    activeSessionDetail: detail,
+    csrfToken: "csrf-safe-token"
+  });
+  const disabledHtml = renderConsoleProductHomePage(disabledModel);
+  assert.match(disabledHtml, /data-capability-send-message="disabled"/);
+  assert.match(disabledHtml, /Text send is disabled\./);
+  assert.doesNotMatch(disabledHtml, /data-console-send-form/);
+});
+
+test("API product model accepts a narrow safe send capability override from server options", () => {
+  const model = createConsoleProductApiModel({
+    bootstrap,
+    projectSessions: new Map([["prj_aLiveProject1230", [sessionSummary]]]),
+    activeSessionDetail: detail,
+    csrfToken: "csrf-safe-token",
+    capabilityOverrides: {
+      sendMessage: { state: "enabled" }
+    }
+  });
+  const html = renderConsoleProductHomePage(model);
+
+  assert.match(html, /data-capability-send-message="enabled"/);
+  assert.match(html, /data-console-send-form/);
+  assert.match(html, /action="\/api\/sessions\/ses_aLiveSession1230\/messages"/);
+  assert.equal(html.includes("cv_1234567890abcdef"), false);
+  assert.equal(html.includes("token="), false);
+});
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/web/console-product-api-model.ts
+++ b/src/web/console-product-api-model.ts
@@ -30,6 +30,7 @@ export interface ConsoleProductApiModelInput {
   projectSessions: Map<ConsoleProjectId, ConsoleSessionSummary[]>;
   activeSessionDetail?: ConsoleSessionDetail | null;
   csrfToken?: string | null;
+  capabilityOverrides?: Partial<Pick<ConsoleCapabilities, "sendMessage">>;
 }
 
 const disabledCapability: ConsoleCapability = { state: "disabled", reason: "This action is not available from Web yet." };
@@ -39,12 +40,17 @@ export function createConsoleProductApiModel(input: ConsoleProductApiModelInput)
   const activeProject = findActiveProject(bootstrap.projects, bootstrap.activeProjectId);
   const activeSession = input.activeSessionDetail ?? findActiveSession(input.projectSessions, bootstrap.activeSessionId);
   const activeSessionId = activeSession?.sessionId ?? bootstrap.activeSessionId;
-  const sendCapability = bootstrap.capabilities.sendMessage;
+  const bootstrapCapabilities: ConsoleCapabilities = {
+    ...bootstrap.capabilities,
+    ...(input.capabilityOverrides?.sendMessage ? { sendMessage: input.capabilityOverrides.sendMessage } : {})
+  };
+  const sendCapability = effectiveComposerSendCapability(bootstrapCapabilities.sendMessage, activeSessionId, input.csrfToken);
+  const capabilities: ConsoleCapabilities = { ...bootstrapCapabilities, sendMessage: sendCapability };
   const canSend = sendCapability.state === "enabled" && Boolean(activeSessionId && input.csrfToken);
   const fallback = createConsoleProductMock();
   const degradedState = bootstrap.degradedStates[0];
   const projects = bootstrap.projects.length > 0
-    ? bootstrap.projects.map((project) => toProductProject(project, input.projectSessions.get(project.projectId) ?? [], activeSessionId, bootstrap.capabilities))
+    ? bootstrap.projects.map((project) => toProductProject(project, input.projectSessions.get(project.projectId) ?? [], activeSessionId, capabilities))
     : [emptyProject()];
   const title = "Codex Console";
   const projectName = activeProject?.title ?? projects[0]?.name ?? "No project selected";
@@ -69,7 +75,7 @@ export function createConsoleProductApiModel(input: ConsoleProductApiModelInput)
     apiRoot: "/api",
     ...(activeProject ? { activeProjectId: activeProject.projectId } : {}),
     ...(activeSessionId ? { activeSessionId } : {}),
-    capabilities: bootstrap.capabilities,
+    capabilities,
     commands: bootstrap.commands.length > 0 ? bootstrap.commands.map((command) => command.name || command.label).slice(0, 8) : fallback.commands,
     modelOptions: optionLabels(bootstrap.models, fallback.modelOptions),
     modeOptions: optionLabels(bootstrap.modes, fallback.modeOptions),
@@ -77,11 +83,11 @@ export function createConsoleProductApiModel(input: ConsoleProductApiModelInput)
     timeline: toTimeline(messages, activeSession?.createdAt),
     runCard: activeRun ? toRunCard(activeRun) : idleRunCard(activeSession?.status),
     diffCard: toDiffCard(diffs[0], artifacts),
-    approvalCard: toApprovalCard(approvals, bootstrap.capabilities.answerApproval),
+    approvalCard: toApprovalCard(approvals, capabilities.answerApproval),
     contextCard: {
       title: "Project context",
       summary: contextSummary(projectName, sessionTitle, bootstrap.degradedStates.length),
-      chips: contextChips(activeProject, activeSession, bootstrap.capabilities),
+      chips: contextChips(activeProject, activeSession, capabilities),
       actionLabel: "Change context unavailable"
     },
     artifactCard: toArtifactCard(artifacts),
@@ -89,8 +95,8 @@ export function createConsoleProductApiModel(input: ConsoleProductApiModelInput)
       title: activeSession ? "Session ready" : "Start a new session",
       body: activeSession
         ? "This chat is loaded from the Console API. Use the composer when live text send is enabled."
-        : `New sessions stay unavailable until the API reports ${capabilityAvailableCopy(bootstrap.capabilities.createSession)}.`,
-      ctaLabel: bootstrap.capabilities.createSession.state === "enabled" ? "+ New session" : "+ New unavailable"
+        : `New sessions stay unavailable until the API reports ${capabilityAvailableCopy(capabilities.createSession)}.`,
+      ctaLabel: capabilities.createSession.state === "enabled" ? "+ New session" : "+ New unavailable"
     },
     degradedState: {
       title: degradedState?.title ?? "Live Console data loaded",
@@ -384,6 +390,23 @@ function contextChips(project: ConsoleProject | null, session: ConsoleSessionSum
 
 function disabledComposerPlaceholder(capability: ConsoleCapability): string {
   return capability.state === "degraded" ? "Message unavailable while Console send is degraded" : "Message unavailable from Web";
+}
+
+function effectiveComposerSendCapability(
+  capability: ConsoleCapability,
+  activeSessionId: ConsoleSessionId | undefined,
+  csrfToken: string | null | undefined
+): ConsoleCapability {
+  if (capability.state !== "enabled") {
+    return capability;
+  }
+  if (!activeSessionId) {
+    return { state: "disabled", reason: "Choose an available session before sending from Web." };
+  }
+  if (!csrfToken) {
+    return { state: "disabled", reason: "Console write capability requires CSRF protection." };
+  }
+  return capability;
 }
 
 function capabilityAvailableCopy(capability: ConsoleCapability): string {

--- a/src/web/console-product-api-model.ts
+++ b/src/web/console-product-api-model.ts
@@ -1,0 +1,398 @@
+import type {
+  ConsoleArtifactSummary,
+  ConsoleBootstrap,
+  ConsoleCapabilities,
+  ConsoleCapability,
+  ConsoleDiffSummary,
+  ConsoleMessage,
+  ConsoleProject,
+  ConsoleProjectId,
+  ConsoleRunState,
+  ConsoleRunStepState,
+  ConsoleSessionDetail,
+  ConsoleSessionId,
+  ConsoleSessionStatus,
+  ConsoleSessionSummary
+} from "./console-api-contract.js";
+import type {
+  ConsoleProductAppModel,
+  ConsoleProductArtifactFile,
+  ConsoleProductDiffLine,
+  ConsoleProductProject,
+  ConsoleProductRunStep,
+  ConsoleProductSession,
+  ConsoleProductTimelineItem
+} from "./console-product-model.js";
+import { createConsoleProductMock } from "./console-product-mock.js";
+
+export interface ConsoleProductApiModelInput {
+  bootstrap: ConsoleBootstrap;
+  projectSessions: Map<ConsoleProjectId, ConsoleSessionSummary[]>;
+  activeSessionDetail?: ConsoleSessionDetail | null;
+  csrfToken?: string | null;
+}
+
+const disabledCapability: ConsoleCapability = { state: "disabled", reason: "This action is not available from Web yet." };
+
+export function createConsoleProductApiModel(input: ConsoleProductApiModelInput): ConsoleProductAppModel {
+  const bootstrap = input.bootstrap;
+  const activeProject = findActiveProject(bootstrap.projects, bootstrap.activeProjectId);
+  const activeSession = input.activeSessionDetail ?? findActiveSession(input.projectSessions, bootstrap.activeSessionId);
+  const activeSessionId = activeSession?.sessionId ?? bootstrap.activeSessionId;
+  const sendCapability = bootstrap.capabilities.sendMessage;
+  const canSend = sendCapability.state === "enabled" && Boolean(activeSessionId && input.csrfToken);
+  const fallback = createConsoleProductMock();
+  const degradedState = bootstrap.degradedStates[0];
+  const projects = bootstrap.projects.length > 0
+    ? bootstrap.projects.map((project) => toProductProject(project, input.projectSessions.get(project.projectId) ?? [], activeSessionId, bootstrap.capabilities))
+    : [emptyProject()];
+  const title = "Codex Console";
+  const projectName = activeProject?.title ?? projects[0]?.name ?? "No project selected";
+  const sessionTitle = activeSession?.title ?? "No session selected";
+  const activeRun = input.activeSessionDetail?.activeRun;
+  const diffs = input.activeSessionDetail?.diffs ?? [];
+  const artifacts = input.activeSessionDetail?.artifacts ?? [];
+  const approvals = input.activeSessionDetail?.approvals ?? [];
+  const messages = input.activeSessionDetail?.messages ?? [];
+  const status = activeRun?.status === "running" || activeRun?.status === "queued" || activeSession?.status === "running"
+    ? "running"
+    : "online";
+
+  return {
+    title,
+    currentProject: projectName,
+    currentSession: sessionTitle,
+    currentModel: selectedOption(bootstrap.models, fallback.currentModel),
+    currentMode: selectedOption(bootstrap.modes, fallback.currentMode),
+    status,
+    source: "api",
+    apiRoot: "/api",
+    ...(activeProject ? { activeProjectId: activeProject.projectId } : {}),
+    ...(activeSessionId ? { activeSessionId } : {}),
+    capabilities: bootstrap.capabilities,
+    commands: bootstrap.commands.length > 0 ? bootstrap.commands.map((command) => command.name || command.label).slice(0, 8) : fallback.commands,
+    modelOptions: optionLabels(bootstrap.models, fallback.modelOptions),
+    modeOptions: optionLabels(bootstrap.modes, fallback.modeOptions),
+    projects,
+    timeline: toTimeline(messages, activeSession?.createdAt),
+    runCard: activeRun ? toRunCard(activeRun) : idleRunCard(activeSession?.status),
+    diffCard: toDiffCard(diffs[0], artifacts),
+    approvalCard: toApprovalCard(approvals, bootstrap.capabilities.answerApproval),
+    contextCard: {
+      title: "Project context",
+      summary: contextSummary(projectName, sessionTitle, bootstrap.degradedStates.length),
+      chips: contextChips(activeProject, activeSession, bootstrap.capabilities),
+      actionLabel: "Change context unavailable"
+    },
+    artifactCard: toArtifactCard(artifacts),
+    emptyState: {
+      title: activeSession ? "Session ready" : "Start a new session",
+      body: activeSession
+        ? "This chat is loaded from the Console API. Use the composer when live text send is enabled."
+        : `New sessions stay unavailable until the API reports ${capabilityAvailableCopy(bootstrap.capabilities.createSession)}.`,
+      ctaLabel: bootstrap.capabilities.createSession.state === "enabled" ? "+ New session" : "+ New unavailable"
+    },
+    degradedState: {
+      title: degradedState?.title ?? "Live Console data loaded",
+      body: degradedState?.body ?? "Home is using the Console API read model for projects, sessions, and the selected chat.",
+      ownerAction: degradedState?.ownerAction ?? "Archive, new session, approvals, uploads, and streams stay gated by reported capabilities."
+    },
+    composer: {
+      placeholder: canSend ? "Message Codex or type /" : disabledComposerPlaceholder(sendCapability),
+      label: "Message Codex",
+      controls: ["Attach", "Command", "Mic", ...(canSend ? ["Send"] : [])],
+      ...(activeSessionId ? { sessionId: activeSessionId, sendEndpoint: `/api/sessions/${activeSessionId}/messages` } : {}),
+      ...(input.csrfToken ? { csrfToken: input.csrfToken } : {}),
+      sendCapability,
+      ...(!canSend ? { unavailableCopy: capabilityDisabledCopy(sendCapability, "Text send is unavailable from Web right now.") } : {})
+    }
+  };
+}
+
+function findActiveProject(projects: ConsoleProject[], activeProjectId: ConsoleProjectId | undefined): ConsoleProject | null {
+  return projects.find((project) => project.projectId === activeProjectId) ?? projects[0] ?? null;
+}
+
+function findActiveSession(
+  sessionsByProject: Map<ConsoleProjectId, ConsoleSessionSummary[]>,
+  activeSessionId: ConsoleSessionId | undefined
+): ConsoleSessionSummary | null {
+  for (const sessions of sessionsByProject.values()) {
+    const selected = activeSessionId ? sessions.find((session) => session.sessionId === activeSessionId) : sessions[0];
+    if (selected) {
+      return selected;
+    }
+  }
+  return null;
+}
+
+function toProductProject(
+  project: ConsoleProject,
+  sessions: ConsoleSessionSummary[],
+  activeSessionId: ConsoleSessionId | undefined,
+  capabilities: ConsoleCapabilities
+): ConsoleProductProject {
+  const expanded = sessions.some((session) => session.sessionId === activeSessionId) || project.projectId === sessions[0]?.projectId;
+  return {
+    projectId: project.projectId,
+    name: project.title,
+    branch: project.branch ?? (project.archived ? "archived" : "active"),
+    hint: project.hint ?? `${project.sessionCount} session${project.sessionCount === 1 ? "" : "s"}`,
+    expanded,
+    archiveCapability: capabilities.archiveProject,
+    createSessionCapability: capabilities.createSession,
+    sessions: sessions.length > 0 ? sessions.map((session) => toProductSession(session, activeSessionId)) : [emptySession(project.projectId)]
+  };
+}
+
+function toProductSession(session: ConsoleSessionSummary, activeSessionId: ConsoleSessionId | undefined): ConsoleProductSession {
+  return {
+    sessionId: session.sessionId,
+    title: session.title,
+    age: sessionAge(session),
+    status: sessionStatusLabel(session.status),
+    active: session.sessionId === activeSessionId
+  };
+}
+
+function emptyProject(): ConsoleProductProject {
+  return {
+    name: "No live projects yet",
+    branch: "empty",
+    hint: "API connected",
+    expanded: true,
+    archiveCapability: disabledCapability,
+    createSessionCapability: disabledCapability,
+    sessions: [{ title: "No sessions available", age: "Waiting for Console data", status: "Empty", active: true }]
+  };
+}
+
+function emptySession(_projectId: ConsoleProjectId): ConsoleProductSession {
+  return {
+    title: "No sessions available",
+    age: "No recent work",
+    status: "Empty",
+    active: false
+  } satisfies ConsoleProductSession;
+}
+
+function sessionAge(session: ConsoleSessionSummary): string {
+  return relativeTime(session.lastActivityAt ?? session.createdAt) ?? sessionStatusLabel(session.status);
+}
+
+function relativeTime(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) {
+    return null;
+  }
+  const now = Date.now();
+  const diff = Math.max(0, now - time);
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diff < minute) return "Just now";
+  if (diff < hour) return `${Math.max(1, Math.round(diff / minute))}m ago`;
+  if (diff < day) return `${Math.max(1, Math.round(diff / hour))}h ago`;
+  if (diff < 7 * day) return `${Math.max(1, Math.round(diff / day))}d ago`;
+  return new Date(time).toLocaleDateString("en", { month: "short", day: "numeric" });
+}
+
+function sessionStatusLabel(status: ConsoleSessionStatus | string | undefined): string {
+  switch (status) {
+    case "running": return "Running";
+    case "waiting_for_approval": return "Approval needed";
+    case "completed": return "Done";
+    case "failed": return "Failed";
+    case "archived": return "Archived";
+    case "empty": return "Empty";
+    case "idle": return "Idle";
+    default: return "Available";
+  }
+}
+
+function selectedOption(options: Array<{ label: string; enabled: boolean }>, fallback: string): string {
+  return options.find((option) => option.enabled)?.label ?? options[0]?.label ?? fallback;
+}
+
+function optionLabels(options: Array<{ label: string }>, fallback: string[]): string[] {
+  return options.length > 0 ? options.map((option) => option.label) : fallback;
+}
+
+function toTimeline(messages: ConsoleMessage[], createdAt: string | undefined): ConsoleProductTimelineItem[] {
+  const visibleMessages = messages.filter((message) => message.role === "user" || message.role === "assistant").slice(-12);
+  if (visibleMessages.length === 0) {
+    return [{
+      role: "assistant",
+      body: "This session is loaded from the Console API. No Web-safe chat messages are available yet.",
+      time: timeLabel(createdAt)
+    }];
+  }
+  return visibleMessages.map((message) => ({
+    role: message.role,
+    body: message.text,
+    time: timeLabel(message.createdAt)
+  }));
+}
+
+function timeLabel(value: string | undefined): string {
+  if (!value) {
+    return "Now";
+  }
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) {
+    return "Now";
+  }
+  return new Date(time).toLocaleTimeString("en", { hour: "numeric", minute: "2-digit" });
+}
+
+function toRunCard(run: ConsoleRunState) {
+  return {
+    title: run.title,
+    status: runStatusLabel(run.status),
+    progressLabel: run.progressLabel ?? runStatusLabel(run.status),
+    progressPercent: run.progressPercent ?? 0,
+    steps: run.steps.length > 0 ? run.steps.map(toRunStep) : [{ label: runStatusLabel(run.status), state: "active" as const }],
+    cancelLabel: "Interrupt unavailable"
+  };
+}
+
+function idleRunCard(status: ConsoleSessionStatus | undefined) {
+  return {
+    title: status === "empty" || !status ? "No active run" : "Session activity",
+    status: sessionStatusLabel(status),
+    progressLabel: status === "completed" ? "Completed" : "Idle",
+    progressPercent: status === "completed" ? 100 : 0,
+    steps: [
+      { label: "Console API loaded", state: "done" as const },
+      { label: "Waiting for next message", state: status === "running" ? "active" as const : "pending" as const }
+    ],
+    cancelLabel: "Interrupt unavailable"
+  };
+}
+
+function toRunStep(step: { label: string; state: ConsoleRunStepState }): ConsoleProductRunStep {
+  return {
+    label: step.label,
+    state: step.state === "done"
+      ? "done"
+      : step.state === "active"
+        ? "active"
+        : step.state === "failed"
+          ? "failed"
+          : step.state === "skipped"
+            ? "skipped"
+            : "pending"
+  };
+}
+
+function runStatusLabel(status: ConsoleRunState["status"]): string {
+  switch (status) {
+    case "queued": return "Queued";
+    case "running": return "Running";
+    case "waiting_for_approval": return "Approval needed";
+    case "completed": return "Completed";
+    case "failed": return "Failed";
+    case "cancelled": return "Cancelled";
+  }
+}
+
+function toDiffCard(diff: ConsoleDiffSummary | undefined, artifacts: ConsoleArtifactSummary[]) {
+  if (diff) {
+    const files = diff.files.slice(0, 4);
+    const lines: ConsoleProductDiffLine[] = files.length > 0
+      ? files.map((file, index) => ({
+        number: String(index + 1),
+        kind: file.status === "deleted" ? "remove" : file.status === "created" ? "add" : "context",
+        text: `${diffLinePrefix(file.status)} ${file.displayName} (+${file.added} −${file.removed})`
+      }))
+      : [{ number: "1", kind: "context", text: diff.title }];
+    return {
+      filename: diff.title,
+      added: diff.totals.added,
+      removed: diff.totals.removed,
+      lines,
+      actions: ["Review diff unavailable", "Open files unavailable"]
+    };
+  }
+  const firstArtifact = artifacts[0];
+  return {
+    filename: firstArtifact?.displayName ?? "No diff preview",
+    added: 0,
+    removed: 0,
+    lines: [{ number: "—", kind: "context" as const, text: firstArtifact ? "Artifact metadata is available." : "No file changes are visible from the Console API yet." }],
+    actions: ["Review diff unavailable", "Open files unavailable"]
+  };
+}
+
+function diffLinePrefix(status: string): string {
+  switch (status) {
+    case "created": return "+";
+    case "deleted": return "−";
+    case "renamed": return "↔";
+    default: return "•";
+  }
+}
+
+function toApprovalCard(approvals: ConsoleSessionDetail["approvals"], capability: ConsoleCapability) {
+  const pending = approvals.filter((approval) => approval.status === "pending");
+  return {
+    title: pending.length > 0 ? "Approval required" : "Approvals unavailable",
+    pendingCount: pending.length,
+    items: pending.length > 0
+      ? pending.slice(0, 3).map((approval) => ({ title: approval.title, detail: approval.body }))
+      : [{
+        title: "No pending approvals",
+        detail: capabilityDisabledCopy(capability, "Approval answers are unavailable from Web right now.")
+      }],
+    actions: capability.state === "enabled" ? ["Review"] : ["Review unavailable", "Approve unavailable"]
+  };
+}
+
+function toArtifactCard(artifacts: ConsoleArtifactSummary[]) {
+  const files: ConsoleProductArtifactFile[] = artifacts.flatMap((artifact): ConsoleProductArtifactFile[] => {
+    const artifactFiles: ConsoleProductArtifactFile[] = artifact.files?.map((file) => ({ name: file.displayName, status: file.status })) ?? [];
+    return artifactFiles.length > 0 ? artifactFiles : [{ name: artifact.displayName, status: artifact.status }];
+  });
+  return {
+    title: "Files & artifacts",
+    summary: artifacts.length > 0
+      ? `${artifacts.length} artifact${artifacts.length === 1 ? "" : "s"} available as safe metadata.`
+      : "No artifacts are visible from the Console API yet.",
+    files: files.slice(0, 4),
+    actionLabel: "Open files unavailable"
+  };
+}
+
+function contextSummary(projectName: string, sessionTitle: string, degradedCount: number): string {
+  if (degradedCount > 0) {
+    return `${projectName} / ${sessionTitle} loaded with ${degradedCount} degraded Console API state${degradedCount === 1 ? "" : "s"}.`;
+  }
+  return `${projectName} / ${sessionTitle} loaded from the Console API.`;
+}
+
+function contextChips(project: ConsoleProject | null, session: ConsoleSessionSummary | null, capabilities: ConsoleCapabilities): string[] {
+  return [
+    project?.archived ? "Archived project" : "Active project",
+    session ? sessionStatusLabel(session.status) : "No session",
+    capabilities.sendMessage.state === "enabled" ? "Text send enabled" : "Text send disabled",
+    capabilities.createSession.state === "enabled" ? "New session enabled" : "New session disabled"
+  ];
+}
+
+function disabledComposerPlaceholder(capability: ConsoleCapability): string {
+  return capability.state === "degraded" ? "Message unavailable while Console send is degraded" : "Message unavailable from Web";
+}
+
+function capabilityAvailableCopy(capability: ConsoleCapability): string {
+  return capability.state === "enabled" ? "the action is enabled" : "the capability is enabled";
+}
+
+function capabilityDisabledCopy(capability: ConsoleCapability, fallback: string): string {
+  if (capability.state === "enabled") {
+    return "Available.";
+  }
+  return capability.reason || capability.ownerAction || fallback;
+}

--- a/src/web/console-product-mock.ts
+++ b/src/web/console-product-mock.ts
@@ -79,11 +79,38 @@ export function createConsoleProductMock(): ConsoleProductAppModel {
     },
     approvalCard: {
       title: "Approval required",
+      pendingCount: 2,
       items: [
         { title: "Run tests", detail: "Will run 128 tests" },
         { title: "Modify config", detail: "Update .env.example" }
       ],
       actions: ["Review", "Approve", "Approve all"]
+    },
+    contextCard: {
+      title: "Project context",
+      summary: "Using selected files and the current project summary before editing.",
+      chips: ["src/web/App.tsx", "src/web/auth.ts", "README.md", "Project notes"],
+      actionLabel: "Change context"
+    },
+    artifactCard: {
+      title: "Files & artifacts",
+      summary: "3 changed files and 1 generated summary are ready for review.",
+      files: [
+        { name: "src/web/App.tsx", status: "modified" },
+        { name: "src/web/auth.ts", status: "modified" },
+        { name: "run-summary.md", status: "generated" }
+      ],
+      actionLabel: "Open files"
+    },
+    emptyState: {
+      title: "Start a new session",
+      body: "New session will be created under acme/web with the same project context. Ask Codex what to change first.",
+      ctaLabel: "+ New session"
+    },
+    degradedState: {
+      title: "Connection needs attention",
+      body: "Codex can keep showing this workspace, but live updates may be delayed.",
+      ownerAction: "Workspace owner: check the bridge service before starting a long run."
     },
     composer: {
       placeholder: "Message Codex or type /",

--- a/src/web/console-product-mock.ts
+++ b/src/web/console-product-mock.ts
@@ -1,0 +1,93 @@
+import type { ConsoleProductAppModel } from "./console-product-model.js";
+
+export function createConsoleProductMock(): ConsoleProductAppModel {
+  return {
+    title: "Codex Console",
+    currentProject: "acme/web",
+    currentSession: "Refactor auth middleware",
+    currentModel: "GPT-5.5 xhigh",
+    currentMode: "Auto",
+    status: "online",
+    commands: ["/code", "/review", "/test", "/deploy", "/explain"],
+    modelOptions: ["GPT-5.5 xhigh", "GPT-5.5 high", "GPT-5.4"],
+    modeOptions: ["Auto", "Ask", "Review only"],
+    projects: [
+      {
+        name: "acme/web",
+        branch: "main",
+        hint: "apps:web",
+        expanded: true,
+        sessions: [
+          { title: "Refactor auth middleware", age: "2h ago", active: true },
+          { title: "Fix CI flaky test", age: "Yesterday" },
+          { title: "Add UI prototype", age: "May 21" }
+        ]
+      },
+      {
+        name: "acme/api",
+        branch: "main",
+        hint: "services:api",
+        expanded: false,
+        sessions: [{ title: "Optimize rate limiter", age: "May 20" }]
+      },
+      {
+        name: "acme/infra",
+        branch: "main",
+        hint: "infra",
+        expanded: false,
+        sessions: [{ title: "Bump Docker images", age: "May 18" }]
+      }
+    ],
+    timeline: [
+      {
+        role: "user",
+        body: "Refactor the auth middleware to use async/await and improve error handling.",
+        time: "10:32 AM"
+      },
+      {
+        role: "assistant",
+        body: "I’ll refactor the auth middleware to use async/await, add better error handling, and keep behavior identical.",
+        time: "10:32 AM"
+      }
+    ],
+    runCard: {
+      title: "Refactoring auth middleware",
+      status: "Running",
+      progressLabel: "2/5 steps",
+      progressPercent: 42,
+      cancelLabel: "Cancel",
+      steps: [
+        { label: "Analyze current middleware", state: "done" },
+        { label: "Refactor to async/await", state: "active" },
+        { label: "Improve error handling", state: "pending" },
+        { label: "Run type check", state: "pending" },
+        { label: "Run tests", state: "pending" }
+      ]
+    },
+    diffCard: {
+      filename: "src/web/App.tsx",
+      added: 23,
+      removed: 17,
+      lines: [
+        { number: "78", kind: "remove", text: "- const user = getUser(req);" },
+        { number: "79", kind: "remove", text: "- if (!user) {" },
+        { number: "79", kind: "add", text: "+ const user = await getUser(req);" },
+        { number: "80", kind: "add", text: "+ if (!user) {" },
+        { number: "…", kind: "context", text: "…" }
+      ],
+      actions: ["Review diff", "Open files"]
+    },
+    approvalCard: {
+      title: "Approval required",
+      items: [
+        { title: "Run tests", detail: "Will run 128 tests" },
+        { title: "Modify config", detail: "Update .env.example" }
+      ],
+      actions: ["Review", "Approve", "Approve all"]
+    },
+    composer: {
+      placeholder: "Message Codex or type /",
+      controls: ["Attach", "Command", "Mic", "Send"]
+    }
+  };
+}

--- a/src/web/console-product-model.ts
+++ b/src/web/console-product-model.ts
@@ -5,6 +5,11 @@ export interface ConsoleProductAppModel {
   currentModel: string;
   currentMode: string;
   status: "online" | "running";
+  source?: "demo" | "api";
+  apiRoot?: string;
+  activeProjectId?: string;
+  activeSessionId?: string;
+  capabilities?: ConsoleProductCapabilities;
   projects: ConsoleProductProject[];
   commands: string[];
   modelOptions: string[];
@@ -20,22 +25,43 @@ export interface ConsoleProductAppModel {
   composer: ConsoleProductComposer;
 }
 
+export interface ConsoleProductCapabilities {
+  archiveProject: ConsoleProductCapability;
+  createSession: ConsoleProductCapability;
+  sendMessage: ConsoleProductCapability;
+  answerApproval: ConsoleProductCapability;
+  uploadFiles?: ConsoleProductCapability;
+  streamEvents?: ConsoleProductCapability;
+  fetchArtifacts?: ConsoleProductCapability;
+}
+
+export interface ConsoleProductCapability {
+  state: "enabled" | "disabled" | "degraded";
+  reason?: string;
+  ownerAction?: string;
+}
+
 export interface ConsoleProductProject {
+  projectId?: string;
   name: string;
   branch: string;
   hint: string;
   expanded: boolean;
   sessions: ConsoleProductSession[];
+  archiveCapability?: ConsoleProductCapability;
+  createSessionCapability?: ConsoleProductCapability;
 }
 
 export interface ConsoleProductSession {
+  sessionId?: string;
   title: string;
   age: string;
+  status?: string;
   active?: boolean;
 }
 
 export interface ConsoleProductTimelineItem {
-  role: "user" | "assistant";
+  role: "user" | "assistant" | "system";
   body: string;
   time: string;
 }
@@ -51,7 +77,7 @@ export interface ConsoleProductRunCard {
 
 export interface ConsoleProductRunStep {
   label: string;
-  state: "done" | "active" | "pending";
+  state: "done" | "active" | "pending" | "failed" | "skipped";
 }
 
 export interface ConsoleProductDiffCard {
@@ -114,4 +140,10 @@ export interface ConsoleProductDegradedStateCard {
 export interface ConsoleProductComposer {
   placeholder: string;
   controls: string[];
+  label?: string;
+  sessionId?: string;
+  sendEndpoint?: string;
+  csrfToken?: string;
+  sendCapability?: ConsoleProductCapability;
+  unavailableCopy?: string;
 }

--- a/src/web/console-product-model.ts
+++ b/src/web/console-product-model.ts
@@ -13,6 +13,10 @@ export interface ConsoleProductAppModel {
   runCard: ConsoleProductRunCard;
   diffCard: ConsoleProductDiffCard;
   approvalCard: ConsoleProductApprovalCard;
+  contextCard: ConsoleProductContextCard;
+  artifactCard: ConsoleProductArtifactCard;
+  emptyState: ConsoleProductEmptyStateCard;
+  degradedState: ConsoleProductDegradedStateCard;
   composer: ConsoleProductComposer;
 }
 
@@ -66,6 +70,7 @@ export interface ConsoleProductDiffLine {
 
 export interface ConsoleProductApprovalCard {
   title: string;
+  pendingCount: number;
   items: ConsoleProductApprovalItem[];
   actions: string[];
 }
@@ -73,6 +78,37 @@ export interface ConsoleProductApprovalCard {
 export interface ConsoleProductApprovalItem {
   title: string;
   detail: string;
+}
+
+export interface ConsoleProductContextCard {
+  title: string;
+  summary: string;
+  chips: string[];
+  actionLabel: string;
+}
+
+export interface ConsoleProductArtifactCard {
+  title: string;
+  summary: string;
+  files: ConsoleProductArtifactFile[];
+  actionLabel: string;
+}
+
+export interface ConsoleProductArtifactFile {
+  name: string;
+  status: string;
+}
+
+export interface ConsoleProductEmptyStateCard {
+  title: string;
+  body: string;
+  ctaLabel: string;
+}
+
+export interface ConsoleProductDegradedStateCard {
+  title: string;
+  body: string;
+  ownerAction: string;
 }
 
 export interface ConsoleProductComposer {

--- a/src/web/console-product-model.ts
+++ b/src/web/console-product-model.ts
@@ -1,0 +1,81 @@
+export interface ConsoleProductAppModel {
+  title: string;
+  currentProject: string;
+  currentSession: string;
+  currentModel: string;
+  currentMode: string;
+  status: "online" | "running";
+  projects: ConsoleProductProject[];
+  commands: string[];
+  modelOptions: string[];
+  modeOptions: string[];
+  timeline: ConsoleProductTimelineItem[];
+  runCard: ConsoleProductRunCard;
+  diffCard: ConsoleProductDiffCard;
+  approvalCard: ConsoleProductApprovalCard;
+  composer: ConsoleProductComposer;
+}
+
+export interface ConsoleProductProject {
+  name: string;
+  branch: string;
+  hint: string;
+  expanded: boolean;
+  sessions: ConsoleProductSession[];
+}
+
+export interface ConsoleProductSession {
+  title: string;
+  age: string;
+  active?: boolean;
+}
+
+export interface ConsoleProductTimelineItem {
+  role: "user" | "assistant";
+  body: string;
+  time: string;
+}
+
+export interface ConsoleProductRunCard {
+  title: string;
+  status: string;
+  progressLabel: string;
+  progressPercent: number;
+  steps: ConsoleProductRunStep[];
+  cancelLabel: string;
+}
+
+export interface ConsoleProductRunStep {
+  label: string;
+  state: "done" | "active" | "pending";
+}
+
+export interface ConsoleProductDiffCard {
+  filename: string;
+  added: number;
+  removed: number;
+  lines: ConsoleProductDiffLine[];
+  actions: string[];
+}
+
+export interface ConsoleProductDiffLine {
+  number: string;
+  kind: "add" | "remove" | "context";
+  text: string;
+}
+
+export interface ConsoleProductApprovalCard {
+  title: string;
+  items: ConsoleProductApprovalItem[];
+  actions: string[];
+}
+
+export interface ConsoleProductApprovalItem {
+  title: string;
+  detail: string;
+}
+
+export interface ConsoleProductComposer {
+  placeholder: string;
+  controls: string[];
+}

--- a/src/web/console-product-renderer.test.ts
+++ b/src/web/console-product-renderer.test.ts
@@ -179,6 +179,57 @@ test("product renderer CSS keeps the mobile composer in flow below scrollable co
   assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-composer \{[\s\S]*?position: static;[\s\S]*?border-radius: 22px;/);
 });
 
+test("product renderer enables send form only with enabled capability, session endpoint, and CSRF", () => {
+  const base = createConsoleProductMock();
+  const enabledHtml = renderConsoleProductHomePage({
+    ...base,
+    source: "api",
+    apiRoot: "/api",
+    activeSessionId: "ses_RenderSend1230",
+    composer: {
+      ...base.composer,
+      sessionId: "ses_RenderSend1230",
+      sendEndpoint: "/api/sessions/ses_RenderSend1230/messages",
+      csrfToken: "csrf-render-token",
+      sendCapability: { state: "enabled" },
+      controls: ["Attach", "Command", "Mic", "Send"]
+    }
+  });
+  assert.match(enabledHtml, /<form class="console-composer"[^>]*data-console-send-form/);
+  assert.match(enabledHtml, /data-capability-send-message="enabled"/);
+  assert.match(enabledHtml, /action="\/api\/sessions\/ses_RenderSend1230\/messages"/);
+  assert.match(enabledHtml, /name="_csrf" value="csrf-render-token"/);
+
+  const missingCsrfHtml = renderConsoleProductHomePage({
+    ...base,
+    composer: {
+      ...base.composer,
+      sessionId: "ses_RenderSend1230",
+      sendEndpoint: "/api/sessions/ses_RenderSend1230/messages",
+      sendCapability: { state: "enabled" },
+      controls: ["Attach", "Command", "Mic", "Send"]
+    }
+  });
+  assert.doesNotMatch(missingCsrfHtml, /data-console-send-form/);
+  assert.match(missingCsrfHtml, /data-capability-send-message="enabled"/);
+  assert.match(missingCsrfHtml, /Send unavailable/);
+
+  const disabledHtml = renderConsoleProductHomePage({
+    ...base,
+    composer: {
+      ...base.composer,
+      sessionId: "ses_RenderSend1230",
+      sendEndpoint: "/api/sessions/ses_RenderSend1230/messages",
+      csrfToken: "csrf-render-token",
+      sendCapability: { state: "disabled", reason: "Server send seam is unavailable." },
+      controls: ["Attach", "Command", "Mic"]
+    }
+  });
+  assert.doesNotMatch(disabledHtml, /data-console-send-form/);
+  assert.match(disabledHtml, /data-capability-send-message="disabled"/);
+  assert.match(disabledHtml, /Server send seam is unavailable\./);
+});
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/web/console-product-renderer.test.ts
+++ b/src/web/console-product-renderer.test.ts
@@ -21,6 +21,10 @@ test("product renderer emits required fake-data mobile console shell", () => {
     "console-run-card",
     "console-diff-card",
     "console-approval-card",
+    "console-context-card",
+    "console-mobile-artifact-card",
+    "console-empty-state-card",
+    "console-service-state-card",
     "console-composer"
   ]) {
     assert.match(html, new RegExp(escapeRegExp(marker)), `missing marker ${marker}: ${html}`);
@@ -40,6 +44,8 @@ test("product renderer shows required projects, sessions, controls, and cards", 
     "GPT-5.5 xhigh",
     "Auto",
     "Ask",
+    "Current model",
+    "Work mode",
     "/code",
     "/review",
     "/test",
@@ -50,6 +56,7 @@ test("product renderer shows required projects, sessions, controls, and cards", 
     "Message Codex or type /",
     "src/web/App.tsx",
     "Approval required",
+    "2 pending",
     "Run tests",
     "Modify config",
     "Review diff",
@@ -69,6 +76,46 @@ test("product renderer shows required projects, sessions, controls, and cards", 
   assert.match(html, /[-+]\s+(const|if)/, `missing diff-like lines: ${html}`);
 });
 
+test("product renderer emits desktop three-pane markers and inspector sections", () => {
+  const html = renderConsoleProductHomePage(createConsoleProductMock());
+
+  for (const marker of [
+    "desktop-console-shell",
+    "desktop-sidebar",
+    "desktop-main",
+    "desktop-inspector",
+    "desktop-task-card",
+    "desktop-diff-panel",
+    "desktop-run-summary"
+  ]) {
+    assert.match(html, new RegExp(escapeRegExp(marker)), `missing desktop marker ${marker}: ${html}`);
+  }
+
+  assert.match(html, /@media \(min-width: 960px\)[\s\S]*?\.desktop-console-shell \.console-app-frame \{[\s\S]*?grid-template-columns: minmax\(260px, 320px\) minmax\(0, 1fr\) minmax\(270px, 340px\);/);
+  for (const copy of ["Task", "Files &amp; artifacts", "Activity", "Approvals", "3 changed files", "run-summary.md"]) {
+    assert.match(html, new RegExp(escapeRegExp(copy)), `missing inspector copy ${copy}: ${html}`);
+  }
+});
+
+test("product renderer includes UX completeness copy for static flows and states", () => {
+  const html = renderConsoleProductHomePage(createConsoleProductMock());
+
+  for (const copy of [
+    "New session under acme/web",
+    "Creates an empty chat in the selected project",
+    "Archive selected project",
+    "Archives the selected project",
+    "Project context",
+    "Change context",
+    "Start a new session",
+    "New session will be created under acme/web",
+    "Connection needs attention",
+    "Workspace owner: check the bridge service"
+  ]) {
+    assert.match(html, new RegExp(escapeRegExp(copy)), `missing UX state copy ${copy}: ${html}`);
+  }
+});
+
 test("product renderer does not render old bottom tab navigation labels", () => {
   const html = renderConsoleProductHomePage(createConsoleProductMock());
 
@@ -84,9 +131,23 @@ test("product renderer CSS makes the project drawer a mobile overlay", () => {
   const html = renderConsoleProductHomePage(createConsoleProductMock());
 
   assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-app-frame \{[\s\S]*?grid-template-columns: 1fr;/);
-  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-project-drawer \{[\s\S]*?position: fixed;[\s\S]*?left: 14px;[\s\S]*?width: min\(340px, calc\(100vw - 28px\)\);[\s\S]*?max-width: calc\(100vw - 28px\);[\s\S]*?transform: translateX\(calc\(-100% - 28px\)\);/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-project-drawer \{[\s\S]*?position: fixed;[\s\S]*?top: calc\(8px \+ env\(safe-area-inset-top\)\);[\s\S]*?right: 8px;[\s\S]*?bottom: calc\(8px \+ env\(safe-area-inset-bottom\)\);[\s\S]*?left: 8px;[\s\S]*?width: auto;[\s\S]*?max-width: none;[\s\S]*?overflow-x: hidden;[\s\S]*?overflow-y: auto;[\s\S]*?transform: translateX\(calc\(-100% - 16px\)\);/);
   assert.match(html, /@media \(max-width: 720px\)[\s\S]*?#console-drawer-toggle:checked ~ \.console-app-frame \.console-project-drawer \{[\s\S]*?transform: translateX\(0\);/);
   assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-drawer-scrim \{[\s\S]*?position: fixed;[\s\S]*?inset: 0;/);
+});
+
+test("product renderer CSS stacks mobile header context and controls without clipping", () => {
+  const html = renderConsoleProductHomePage(createConsoleProductMock());
+
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-topbar \{[\s\S]*?display: grid;[\s\S]*?grid-template-columns: 44px minmax\(0, 1fr\) max-content;[\s\S]*?align-items: start;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-context \{[\s\S]*?grid-column: 2;[\s\S]*?grid-row: 1;[\s\S]*?min-width: 0;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-context h1 \{[\s\S]*?overflow: hidden;[\s\S]*?text-overflow: ellipsis;[\s\S]*?white-space: nowrap;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-status-pill \{[\s\S]*?grid-column: 3;[\s\S]*?grid-row: 1;[\s\S]*?min-height: 36px;[\s\S]*?white-space: nowrap;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-select-pill \{[\s\S]*?width: 100%;[\s\S]*?flex-direction: row;[\s\S]*?justify-content: space-between;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-select-pill span \{[\s\S]*?flex: 0 0 auto;[\s\S]*?white-space: nowrap;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-select-pill select \{[\s\S]*?max-width: 58%;[\s\S]*?text-align: right;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-model-selector \{[\s\S]*?grid-column: 1 \/ -1;[\s\S]*?grid-row: 2;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-mode-selector \{[\s\S]*?grid-column: 1 \/ -1;[\s\S]*?grid-row: 3;/);
 });
 
 test("product renderer CSS keeps mobile drawer project actions readable and tappable", () => {
@@ -95,16 +156,26 @@ test("product renderer CSS keeps mobile drawer project actions readable and tapp
   assert.match(html, /\.console-project-title-block \{[\s\S]*?flex: 1 1 auto;[\s\S]*?min-width: 0;/);
   assert.match(html, /\.console-project-copy \{[\s\S]*?flex: 1 1 auto;[\s\S]*?min-width: 0;/);
   assert.match(html, /\.console-project-actions button \{[\s\S]*?white-space: nowrap;/);
-  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-project-row \{[\s\S]*?display: grid;[\s\S]*?grid-template-columns: minmax\(0, 1fr\) auto;/);
-  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-project-actions \{[\s\S]*?justify-content: flex-end;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-project-row \{[\s\S]*?display: grid;[\s\S]*?grid-template-columns: minmax\(0, 1fr\) max-content;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-project-actions \{[\s\S]*?min-width: max-content;[\s\S]*?flex-wrap: nowrap;[\s\S]*?justify-content: flex-end;/);
+});
+
+test("product renderer CSS lets the mobile command row scroll inside the viewport", () => {
+  const html = renderConsoleProductHomePage(createConsoleProductMock());
+
+  assert.match(html, /\.console-command-bar \{[\s\S]*?display: flex;[\s\S]*?overflow-x: auto;[\s\S]*?scroll-padding-inline: 8px;/);
+  assert.match(html, /\.console-command-bar::after \{[\s\S]*?content: "";[\s\S]*?flex: 0 0 1px;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-command-bar \{[\s\S]*?width: calc\(100% \+ 20px\);[\s\S]*?max-width: 100vw;[\s\S]*?margin: 0 -10px;[\s\S]*?overflow-x: auto;[\s\S]*?overscroll-behavior-inline: contain;[\s\S]*?padding: 0 10px 8px;[\s\S]*?scroll-padding-inline: 10px;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-command-bar::after \{[\s\S]*?flex-basis: 2px;/);
 });
 
 test("product renderer CSS keeps the mobile composer in flow below scrollable content", () => {
   const html = renderConsoleProductHomePage(createConsoleProductMock());
 
-  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-mobile-shell \{[\s\S]*?height: 100dvh;[\s\S]*?grid-template-rows: auto minmax\(0, 1fr\);[\s\S]*?overflow: hidden;/);
-  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-workspace \{[\s\S]*?display: grid;[\s\S]*?grid-template-rows: auto minmax\(0, 1fr\) auto;[\s\S]*?overflow: hidden;/);
-  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-chat-timeline \{[\s\S]*?min-height: 0;[\s\S]*?overflow-y: auto;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-mobile-shell \{[\s\S]*?min-height: 100dvh;[\s\S]*?display: block;[\s\S]*?overflow: visible;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-app-frame \{[\s\S]*?min-height: auto;[\s\S]*?overflow: visible;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-workspace \{[\s\S]*?display: grid;[\s\S]*?grid-template-rows: none;[\s\S]*?overflow: visible;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-chat-timeline \{[\s\S]*?min-height: auto;[\s\S]*?overflow: visible;/);
   assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-composer \{[\s\S]*?position: static;[\s\S]*?border-radius: 22px;/);
 });
 

--- a/src/web/console-product-renderer.test.ts
+++ b/src/web/console-product-renderer.test.ts
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createConsoleProductMock } from "./console-product-mock.js";
+import { renderConsoleProductHomePage } from "./console-product-renderer.js";
+
+test("product renderer emits required fake-data mobile console shell", () => {
+  const html = renderConsoleProductHomePage(createConsoleProductMock());
+
+  for (const marker of [
+    "console-mobile-shell",
+    "console-project-drawer",
+    "console-project-row",
+    "console-project-action-archive",
+    "console-project-action-new-session",
+    "console-session-child",
+    "console-chat-timeline",
+    "console-command-bar",
+    "console-model-selector",
+    "console-mode-selector",
+    "console-run-card",
+    "console-diff-card",
+    "console-approval-card",
+    "console-composer"
+  ]) {
+    assert.match(html, new RegExp(escapeRegExp(marker)), `missing marker ${marker}: ${html}`);
+  }
+});
+
+test("product renderer shows required projects, sessions, controls, and cards", () => {
+  const html = renderConsoleProductHomePage(createConsoleProductMock());
+
+  for (const copy of [
+    "acme/web",
+    "acme/api",
+    "acme/infra",
+    "Refactor auth middleware",
+    "Fix CI flaky test",
+    "Add UI prototype",
+    "GPT-5.5 xhigh",
+    "Auto",
+    "Ask",
+    "/code",
+    "/review",
+    "/test",
+    "/deploy",
+    "/explain",
+    "Online",
+    "Running",
+    "Message Codex or type /",
+    "src/web/App.tsx",
+    "Approval required",
+    "Run tests",
+    "Modify config",
+    "Review diff",
+    "Open files",
+    "Approve",
+    "Approve all",
+    "Cancel"
+  ]) {
+    assert.match(html, new RegExp(escapeRegExp(copy)), `missing required content ${copy}: ${html}`);
+  }
+
+  assert.match(html, /class="console-project-row"[\s\S]*?acme\/web[\s\S]*?class="console-project-action-archive"[\s\S]*?Archive[\s\S]*?class="console-project-action-new-session"[\s\S]*?\+ New/);
+  assert.match(html, /class="console-project-row"[\s\S]*?acme\/api[\s\S]*?class="console-project-action-archive"[\s\S]*?Archive[\s\S]*?class="console-project-action-new-session"[\s\S]*?\+ New/);
+  assert.match(html, /class="console-project-row"[\s\S]*?acme\/infra[\s\S]*?class="console-project-action-archive"[\s\S]*?Archive[\s\S]*?class="console-project-action-new-session"[\s\S]*?\+ New/);
+  assert.match(html, /class="console-project-action-archive"[^>]*aria-label="Archive acme\/web"[^>]*>Archive<\/button>/);
+  assert.match(html, /class="console-project-action-new-session"[^>]*aria-label="Create new session in acme\/web"[^>]*>\+ New<\/button>/);
+  assert.match(html, /[-+]\s+(const|if)/, `missing diff-like lines: ${html}`);
+});
+
+test("product renderer does not render old bottom tab navigation labels", () => {
+  const html = renderConsoleProductHomePage(createConsoleProductMock());
+
+  assert.doesNotMatch(html, /bottom[^<]{0,40}tab/i);
+  for (const label of ["Chat", "Files", "Status"]) {
+    assert.doesNotMatch(html, new RegExp(`>${label}<`), `rendered bottom-tab-like label ${label}: ${html}`);
+  }
+  assert.doesNotMatch(html, /class="[^"]*bottom[^"]*"/i);
+  assert.doesNotMatch(html, /class="[^"]*tab[^"]*"/i);
+});
+
+test("product renderer CSS makes the project drawer a mobile overlay", () => {
+  const html = renderConsoleProductHomePage(createConsoleProductMock());
+
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-app-frame \{[\s\S]*?grid-template-columns: 1fr;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-project-drawer \{[\s\S]*?position: fixed;[\s\S]*?left: 14px;[\s\S]*?width: min\(340px, calc\(100vw - 28px\)\);[\s\S]*?max-width: calc\(100vw - 28px\);[\s\S]*?transform: translateX\(calc\(-100% - 28px\)\);/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?#console-drawer-toggle:checked ~ \.console-app-frame \.console-project-drawer \{[\s\S]*?transform: translateX\(0\);/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-drawer-scrim \{[\s\S]*?position: fixed;[\s\S]*?inset: 0;/);
+});
+
+test("product renderer CSS keeps mobile drawer project actions readable and tappable", () => {
+  const html = renderConsoleProductHomePage(createConsoleProductMock());
+
+  assert.match(html, /\.console-project-title-block \{[\s\S]*?flex: 1 1 auto;[\s\S]*?min-width: 0;/);
+  assert.match(html, /\.console-project-copy \{[\s\S]*?flex: 1 1 auto;[\s\S]*?min-width: 0;/);
+  assert.match(html, /\.console-project-actions button \{[\s\S]*?white-space: nowrap;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-project-row \{[\s\S]*?display: grid;[\s\S]*?grid-template-columns: minmax\(0, 1fr\) auto;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-project-actions \{[\s\S]*?justify-content: flex-end;/);
+});
+
+test("product renderer CSS keeps the mobile composer in flow below scrollable content", () => {
+  const html = renderConsoleProductHomePage(createConsoleProductMock());
+
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-mobile-shell \{[\s\S]*?height: 100dvh;[\s\S]*?grid-template-rows: auto minmax\(0, 1fr\);[\s\S]*?overflow: hidden;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-workspace \{[\s\S]*?display: grid;[\s\S]*?grid-template-rows: auto minmax\(0, 1fr\) auto;[\s\S]*?overflow: hidden;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-chat-timeline \{[\s\S]*?min-height: 0;[\s\S]*?overflow-y: auto;/);
+  assert.match(html, /@media \(max-width: 720px\)[\s\S]*?\.console-composer \{[\s\S]*?position: static;[\s\S]*?border-radius: 22px;/);
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/web/console-product-renderer.ts
+++ b/src/web/console-product-renderer.ts
@@ -1,0 +1,1001 @@
+import type {
+  ConsoleProductAppModel,
+  ConsoleProductApprovalCard,
+  ConsoleProductDiffCard,
+  ConsoleProductProject,
+  ConsoleProductRunCard,
+  ConsoleProductTimelineItem
+} from "./console-product-model.js";
+import { createConsoleProductMock } from "./console-product-mock.js";
+
+export function renderConsoleProductHomePage(
+  model: ConsoleProductAppModel | undefined = createConsoleProductMock(),
+  css = CONSOLE_PRODUCT_CSS
+): string {
+  model ??= createConsoleProductMock();
+  return [
+    "<!doctype html>",
+    "<html lang=\"en\">",
+    "<head>",
+    "<meta charset=\"utf-8\">",
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
+    `<title>${escapeHtml(model.title)} · Product Prototype</title>`,
+    `<style>\n${css}\n</style>`,
+    "</head>",
+    "<body class=\"console-product-body\">",
+    renderShell(model),
+    "</body>",
+    "</html>"
+  ].join("\n");
+}
+
+function renderShell(model: ConsoleProductAppModel): string {
+  return `<main class="console-mobile-shell" aria-label="Codex Console fake-data product prototype">
+  <header class="console-topbar" aria-label="Current console context">
+    <label class="console-icon-button" for="console-drawer-toggle" role="button" aria-label="Open project drawer">☰</label>
+    <section class="console-context">
+      <p class="console-kicker">${escapeHtml(model.currentProject)} · ${escapeHtml(model.currentSession)}</p>
+      <h1>${escapeHtml(model.title)}</h1>
+    </section>
+    <label class="console-select-pill console-model-selector">Model <select aria-label="Model">${renderOptions(model.modelOptions, model.currentModel)}</select></label>
+    <label class="console-select-pill console-mode-selector">Mode <select aria-label="Mode">${renderOptions(model.modeOptions, model.currentMode)}</select></label>
+    <span class="console-status-pill console-status-${escapeHtml(model.status)}"><span class="console-status-dot"></span>${escapeHtml(statusLabel(model.status))}</span>
+  </header>
+  <input class="console-drawer-toggle" id="console-drawer-toggle" type="checkbox" aria-label="Toggle project drawer">
+  <section class="console-app-frame">
+    <label class="console-drawer-scrim" for="console-drawer-toggle" aria-label="Close project drawer"></label>
+    ${renderProjectDrawer(model.projects)}
+    <section class="console-workspace" aria-label="Chat timeline and task cards">
+      ${renderCommandBar(model.commands)}
+      <section class="console-chat-timeline" aria-label="Chat timeline">
+        ${model.timeline.map(renderTimelineItem).join("")}
+        ${renderRunCard(model.runCard)}
+        ${renderDiffCard(model.diffCard)}
+        ${renderApprovalCard(model.approvalCard)}
+      </section>
+      ${renderComposer(model)}
+    </section>
+  </section>
+</main>`;
+}
+
+function renderProjectDrawer(projects: ConsoleProductProject[]): string {
+  return `<aside class="console-project-drawer" aria-label="Projects and sessions">
+    <section class="console-drawer-heading">
+      <h2>Projects</h2>
+      <label class="console-drawer-close" for="console-drawer-toggle" role="button" aria-label="Close project drawer">×</label>
+    </section>
+    <label class="console-search"><span>⌕</span><input aria-label="Search projects or sessions" placeholder="Search projects or sessions"></label>
+    <section class="console-project-list">
+      ${projects.map(renderProject).join("")}
+    </section>
+    <button class="console-archive-link" type="button">View archived projects <span>›</span></button>
+  </aside>`;
+}
+
+function renderProject(project: ConsoleProductProject): string {
+  const expanded = project.expanded ? "true" : "false";
+  return `<article class="console-project-group" data-expanded="${expanded}">
+    <section class="console-project-row">
+      <section class="console-project-title-block">
+        <span class="console-disclosure">${project.expanded ? "⌄" : "›"}</span>
+        <span class="console-folder" aria-hidden="true">▣</span>
+        <span class="console-project-copy"><strong>${escapeHtml(project.name)}</strong><small>⌘ ${escapeHtml(project.branch)} · ${escapeHtml(project.hint)}</small></span>
+      </section>
+      <section class="console-project-actions" aria-label="${escapeHtml(project.name)} actions">
+        <button class="console-project-action-archive" type="button" aria-label="Archive ${escapeHtml(project.name)}">Archive</button>
+        <button class="console-project-action-new-session" type="button" aria-label="Create new session in ${escapeHtml(project.name)}">+ New</button>
+      </section>
+    </section>
+    <section class="console-session-list" aria-label="${escapeHtml(project.name)} sessions">
+      ${project.sessions.map((session) => `<article class="console-session-child${session.active ? " is-active" : ""}"><span class="console-session-icon">☵</span><span><strong>${escapeHtml(session.title)}</strong><small>${escapeHtml(session.age)}</small></span><button type="button" aria-label="Session actions">•••</button></article>`).join("")}
+    </section>
+  </article>`;
+}
+
+function renderCommandBar(commands: string[]): string {
+  return `<nav class="console-command-bar" aria-label="Command selection">
+    ${commands.map((command) => `<button type="button">${escapeHtml(command)}</button>`).join("")}
+    <button type="button" aria-label="Command settings">☷</button>
+  </nav>`;
+}
+
+function renderTimelineItem(item: ConsoleProductTimelineItem): string {
+  return `<article class="console-chat-bubble console-chat-bubble-${escapeHtml(item.role)}">
+    <p>${escapeHtml(item.body)}</p>
+    <time>${escapeHtml(item.time)}</time>
+  </article>`;
+}
+
+function renderRunCard(card: ConsoleProductRunCard): string {
+  const progress = Math.max(0, Math.min(100, card.progressPercent));
+  return `<article class="console-run-card" aria-label="Running task card">
+    <section class="console-card-header">
+      <h2>${escapeHtml(card.title)}</h2>
+      <span>${escapeHtml(card.status)}</span>
+    </section>
+    <section class="console-progress-row" aria-label="${escapeHtml(card.progressLabel)}">
+      <span class="console-progress"><span class="console-progress-fill console-progress-fill-${progressClass(progress)}"></span></span>
+      <strong>${escapeHtml(card.progressLabel)}</strong>
+    </section>
+    <ol class="console-step-list">
+      ${card.steps.map((step) => `<li class="is-${escapeHtml(step.state)}"><span></span>${escapeHtml(step.label)}</li>`).join("")}
+    </ol>
+    <button class="console-card-secondary" type="button">${escapeHtml(card.cancelLabel)}</button>
+  </article>`;
+}
+
+function progressClass(progress: number): string {
+  return String(Math.round(progress / 5) * 5);
+}
+
+function renderDiffCard(card: ConsoleProductDiffCard): string {
+  return `<article class="console-diff-card" aria-label="Diff card">
+    <section class="console-card-header">
+      <h2>${escapeHtml(card.filename)}</h2>
+      <span class="console-diff-stat">+${card.added} −${card.removed}</span>
+    </section>
+    <pre class="console-diff-lines">${card.lines.map((line) => `${escapeHtml(line.number)}  ${escapeHtml(line.text)}`).join("\n")}</pre>
+    <section class="console-card-actions">
+      ${card.actions.map((action) => `<button type="button">${escapeHtml(action)}</button>`).join("")}
+    </section>
+  </article>`;
+}
+
+function renderApprovalCard(card: ConsoleProductApprovalCard): string {
+  return `<article class="console-approval-card" aria-label="Approval card">
+    <section class="console-card-header console-card-header-warning">
+      <h2>⚠ ${escapeHtml(card.title)}</h2>
+    </section>
+    <section class="console-approval-items">
+      ${card.items.map((item) => `<article><span>⚙</span><strong>${escapeHtml(item.title)}</strong><small>${escapeHtml(item.detail)}</small><button type="button">Review</button></article>`).join("")}
+    </section>
+    <section class="console-card-actions">
+      ${card.actions.filter((action) => action !== "Review").map((action) => `<button type="button">${escapeHtml(action)}</button>`).join("")}
+    </section>
+  </article>`;
+}
+
+function renderComposer(model: ConsoleProductAppModel): string {
+  const controls = new Set(model.composer.controls);
+  return `<section class="console-composer" aria-label="Message composer">
+    <section class="console-composer-input" role="textbox" aria-label="${escapeHtml(model.composer.placeholder)}" aria-readonly="true">${escapeHtml(model.composer.placeholder)}</section>
+    <section class="console-composer-tools" aria-label="Composer tools">
+      <button type="button" aria-label="Attach">${controls.has("Attach") ? "⌘" : "+"}</button>
+      <button type="button" aria-label="Command">${controls.has("Command") ? "/" : "⌕"}</button>
+      <button type="button" aria-label="Mic">${controls.has("Mic") ? "🎙" : "Mic"}</button>
+      <button type="button" aria-label="Send">${controls.has("Send") ? "➤" : "Send"}</button>
+    </section>
+  </section>`;
+}
+
+function renderOptions(options: string[], selected: string): string {
+  return options.map((option) => `<option${option === selected ? " selected" : ""}>${escapeHtml(option)}</option>`).join("");
+}
+
+function statusLabel(status: ConsoleProductAppModel["status"]): string {
+  return status === "running" ? "Running" : "Online";
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export const CONSOLE_PRODUCT_CSS = `
+:root {
+  color-scheme: light;
+  --console-product-bg: #f5f7fb;
+  --console-product-panel: rgba(255, 255, 255, 0.92);
+  --console-product-border: #d9e1ef;
+  --console-product-border-strong: #b9cdf5;
+  --console-product-text: #141922;
+  --console-product-muted: #657085;
+  --console-product-blue: #2463eb;
+  --console-product-blue-soft: #eaf3ff;
+  --console-product-warning: #f59e0b;
+  --console-product-success: #24a067;
+  --console-product-shadow: 0 18px 60px rgba(31, 42, 68, 0.14);
+}
+* {
+  box-sizing: border-box;
+}
+html {
+  background: var(--console-product-bg);
+}
+body.console-product-body {
+  margin: 0;
+  color: var(--console-product-text);
+  background:
+    radial-gradient(circle at 0 0, rgba(36, 99, 235, 0.12), transparent 24rem),
+    linear-gradient(180deg, #ffffff 0, var(--console-product-bg) 18rem);
+  font: 16px/1.45 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+button,
+select,
+input {
+  font: inherit;
+}
+button,
+select {
+  min-height: 44px;
+}
+button,
+.console-icon-button {
+  cursor: default;
+}
+.console-mobile-shell {
+  width: min(1180px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 18px 24px 28px;
+}
+.console-drawer-toggle {
+  position: fixed;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+.console-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 6;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  gap: 14px;
+  align-items: center;
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(217, 225, 239, 0.84);
+  background: rgba(248, 250, 253, 0.86);
+  backdrop-filter: blur(16px);
+}
+.console-icon-button,
+.console-drawer-close,
+.console-command-bar button,
+.console-project-actions button,
+.console-session-child button,
+.console-card-actions button,
+.console-card-secondary,
+.console-composer button,
+.console-archive-link,
+.console-approval-items button {
+  border: 1px solid var(--console-product-border);
+  border-radius: 14px;
+  background: #ffffff;
+  color: var(--console-product-text);
+}
+.console-icon-button {
+  display: grid;
+  place-items: center;
+  width: 52px;
+  min-height: 52px;
+  font-size: 1.55rem;
+}
+.console-context {
+  min-width: 0;
+}
+.console-context h1,
+.console-context p,
+.console-drawer-heading h2,
+.console-card-header h2,
+.console-chat-bubble p {
+  margin: 0;
+}
+.console-context h1 {
+  font-size: clamp(1.35rem, 3vw, 2.05rem);
+  letter-spacing: -0.04em;
+}
+.console-kicker {
+  color: var(--console-product-muted);
+  font-size: 0.82rem;
+  font-weight: 760;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.console-select-pill,
+.console-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid var(--console-product-border);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.86);
+  color: var(--console-product-muted);
+  font-weight: 760;
+}
+.console-select-pill select {
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--console-product-text);
+}
+.console-status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--console-product-success);
+}
+.console-app-frame {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(320px, 400px) minmax(0, 1fr);
+  gap: 22px;
+  align-items: start;
+  padding-top: 20px;
+}
+.console-drawer-scrim {
+  display: none;
+}
+.console-project-drawer,
+.console-run-card,
+.console-diff-card,
+.console-approval-card,
+.console-composer,
+.console-chat-bubble {
+  border: 1px solid var(--console-product-border);
+  background: var(--console-product-panel);
+  box-shadow: var(--console-product-shadow);
+}
+.console-project-drawer {
+  position: sticky;
+  top: 86px;
+  display: grid;
+  gap: 12px;
+  max-height: calc(100vh - 112px);
+  min-height: calc(100vh - 112px);
+  overflow: auto;
+  padding: 18px;
+  border-radius: 28px;
+}
+.console-drawer-heading,
+.console-card-header,
+.console-project-row,
+.console-project-title-block,
+.console-project-actions,
+.console-card-actions,
+.console-progress-row,
+.console-approval-items article,
+.console-composer-tools {
+  display: flex;
+  align-items: center;
+}
+.console-drawer-heading,
+.console-card-header,
+.console-project-row {
+  justify-content: space-between;
+  gap: 12px;
+}
+.console-drawer-heading h2 {
+  font-size: 1.32rem;
+}
+.console-drawer-close {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  min-height: 44px;
+  color: var(--console-product-blue);
+  font-size: 1.35rem;
+}
+.console-search {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 48px;
+  padding: 0 12px;
+  border: 1px solid var(--console-product-border);
+  border-radius: 16px;
+  background: #ffffff;
+  color: var(--console-product-muted);
+}
+.console-search input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  color: var(--console-product-text);
+}
+.console-project-list {
+  display: grid;
+  gap: 12px;
+}
+.console-project-group {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid transparent;
+  border-radius: 18px;
+}
+.console-project-group[data-expanded="true"] {
+  border-color: var(--console-product-border-strong);
+  background: rgba(234, 243, 255, 0.62);
+}
+.console-project-row {
+  min-height: 48px;
+}
+.console-project-title-block {
+  flex: 1 1 auto;
+  min-width: 0;
+  gap: 9px;
+}
+.console-project-copy {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.console-project-title-block strong,
+.console-session-child strong {
+  display: block;
+  overflow: hidden;
+  color: #0f172a;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.console-project-title-block small,
+.console-session-child small,
+.console-approval-items small {
+  display: block;
+  color: var(--console-product-muted);
+}
+.console-disclosure {
+  color: var(--console-product-muted);
+  font-weight: 800;
+}
+.console-folder,
+.console-session-icon {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  border: 1px solid var(--console-product-border);
+  border-radius: 10px;
+  background: #f8fbff;
+  color: var(--console-product-blue);
+}
+.console-project-actions {
+  flex: 0 0 auto;
+  gap: 6px;
+}
+.console-project-actions button {
+  min-height: 32px;
+  min-width: 0;
+  padding: 0 9px;
+  border-radius: 999px;
+  border-color: rgba(185, 205, 245, 0.84);
+  background: rgba(255, 255, 255, 0.78);
+  color: #2e3440;
+  font-size: 0.78rem;
+  font-weight: 760;
+  white-space: nowrap;
+}
+.console-project-action-new-session {
+  color: var(--console-product-blue) !important;
+}
+.console-session-list {
+  display: grid;
+  gap: 7px;
+  margin-left: 16px;
+  padding-left: 12px;
+  border-left: 1px solid rgba(185, 205, 245, 0.9);
+}
+.console-session-child {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  min-height: 58px;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: 14px;
+}
+.console-session-child.is-active {
+  border-color: var(--console-product-border-strong);
+  background: #f3f8ff;
+  box-shadow: inset 4px 0 0 var(--console-product-blue);
+}
+.console-session-child button {
+  min-width: 34px;
+  min-height: 34px;
+  border-color: transparent;
+  background: transparent;
+  color: var(--console-product-muted);
+}
+.console-archive-link {
+  align-self: end;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  min-height: 42px;
+  padding: 0 14px;
+  color: #475569;
+}
+.console-workspace {
+  display: grid;
+  gap: 13px;
+  min-width: 0;
+}
+.console-command-bar {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 2px 0 4px;
+}
+.console-command-bar button {
+  flex: 0 0 auto;
+  min-height: 38px;
+  min-width: 0;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  color: #3f4656;
+  font-size: 0.9rem;
+}
+.console-chat-timeline {
+  display: grid;
+  gap: 13px;
+}
+.console-chat-bubble {
+  width: min(520px, 86%);
+  padding: 14px 16px;
+  border-radius: 18px;
+}
+.console-chat-bubble-user {
+  justify-self: end;
+  border-color: #b7d4ff;
+  background: #eaf3ff;
+}
+.console-chat-bubble-assistant {
+  justify-self: start;
+  background: #ffffff;
+}
+.console-chat-bubble time {
+  display: block;
+  margin-top: 7px;
+  color: var(--console-product-muted);
+  font-size: 0.82rem;
+}
+.console-run-card,
+.console-diff-card,
+.console-approval-card {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border-radius: 18px;
+  background: #ffffff;
+}
+.console-card-header h2 {
+  font-size: 1rem;
+}
+.console-card-header span,
+.console-diff-stat {
+  border-radius: 999px;
+  padding: 5px 9px;
+  background: var(--console-product-blue-soft);
+  color: var(--console-product-blue);
+  font-size: 0.86rem;
+  font-weight: 760;
+}
+.console-progress-row {
+  gap: 12px;
+}
+.console-progress {
+  position: relative;
+  display: block;
+  width: min(240px, 56%);
+  height: 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #e5e7eb;
+}
+.console-progress span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--console-product-blue), #60a5fa);
+}
+.console-progress-fill-40 {
+  width: 40%;
+}
+.console-step-list {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--console-product-muted);
+}
+.console-step-list li {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.console-step-list li span {
+  width: 15px;
+  height: 15px;
+  border: 1px solid #9ca3af;
+  border-radius: 999px;
+}
+.console-step-list li.is-done span {
+  border-color: var(--console-product-success);
+  background: var(--console-product-success);
+}
+.console-step-list li.is-active {
+  color: var(--console-product-text);
+  font-weight: 760;
+}
+.console-step-list li.is-active span {
+  border-color: var(--console-product-blue);
+  background: var(--console-product-blue);
+}
+.console-card-secondary {
+  justify-self: end;
+  min-height: 36px;
+  padding: 0 12px;
+  border-color: transparent;
+  background: #f8fafc;
+  color: var(--console-product-muted);
+}
+.console-diff-lines {
+  margin: 0 -14px;
+  overflow-x: auto;
+  padding: 8px 14px;
+  border-block: 1px solid #eef2f7;
+  background: linear-gradient(#fff7f7 0 40%, #f3fbf5 40% 80%, #ffffff 80%);
+  color: #17324d;
+  font: 0.88rem/1.7 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.console-card-actions {
+  gap: 8px;
+}
+.console-card-actions button {
+  flex: 1 1 0;
+  min-height: 38px;
+  padding: 0 10px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+.console-card-actions button:not(:last-child) {
+  border-color: transparent;
+  background: #f8fafc;
+  color: #475569;
+}
+.console-card-actions button:last-child,
+.console-composer button:last-child {
+  border-color: var(--console-product-blue);
+  background: var(--console-product-blue);
+  color: #ffffff;
+}
+.console-approval-card {
+  border-color: rgba(245, 158, 11, 0.28);
+  box-shadow: 0 10px 28px rgba(31, 42, 68, 0.08);
+}
+.console-card-header-warning h2 {
+  color: #7c4a03;
+}
+.console-approval-items {
+  display: grid;
+  gap: 8px;
+}
+.console-approval-items article {
+  gap: 9px;
+  min-height: 46px;
+  padding: 8px;
+  border-radius: 14px;
+  background: #fffbeb;
+}
+.console-approval-items strong {
+  min-width: 88px;
+}
+.console-approval-items small {
+  flex: 1 1 auto;
+}
+.console-approval-items button {
+  min-height: 34px;
+  padding: 0 10px;
+  border-color: #f4d29c;
+  border-radius: 999px;
+  color: #5f3b10;
+  font-size: 0.86rem;
+}
+.console-composer {
+  position: sticky;
+  bottom: calc(12px + env(safe-area-inset-bottom));
+  z-index: 5;
+  display: grid;
+  gap: 9px;
+  padding: 10px;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(18px);
+}
+.console-composer-input {
+  width: 100%;
+  min-height: 46px;
+  padding: 12px 14px;
+  border: 1px solid var(--console-product-border);
+  border-radius: 18px;
+  background: #f8fafc;
+  color: #8b94a7;
+}
+.console-composer-tools {
+  justify-content: space-between;
+  gap: 8px;
+}
+.console-composer button {
+  display: grid;
+  place-items: center;
+  min-width: 42px;
+  min-height: 38px;
+  padding: 0 11px;
+  border-radius: 999px;
+  font-weight: 760;
+}
+.console-composer button:last-child {
+  min-width: 48px;
+}
+@media (max-width: 860px) {
+  .console-mobile-shell {
+    padding: 10px 0 18px;
+  }
+  .console-topbar {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    padding: 12px 16px;
+  }
+  .console-model-selector,
+  .console-mode-selector {
+    grid-row: 2;
+  }
+  .console-status-pill {
+    grid-column: 3;
+  }
+  .console-app-frame {
+    grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+    gap: 16px;
+    padding: 16px 0 0;
+  }
+  .console-project-drawer {
+    top: 118px;
+    min-height: calc(100vh - 132px);
+    border-radius: 0 24px 24px 0;
+    border-left: 0;
+  }
+  .console-workspace {
+    padding-right: 10px;
+  }
+}
+@media (max-width: 720px) {
+  .console-mobile-shell {
+    width: 100%;
+    height: 100vh;
+    height: 100dvh;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    overflow: hidden;
+    padding: 0 0 calc(10px + env(safe-area-inset-bottom));
+  }
+  .console-topbar {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 8px;
+    padding: calc(10px + env(safe-area-inset-top)) 12px 10px;
+  }
+  .console-context h1 {
+    font-size: 1.28rem;
+  }
+  .console-model-selector,
+  .console-mode-selector {
+    grid-row: 2;
+    min-height: 36px;
+    padding: 0 9px;
+    border-radius: 999px;
+    font-size: 0.82rem;
+  }
+  .console-mode-selector {
+    grid-column: 2;
+    justify-self: start;
+  }
+  .console-status-pill {
+    grid-column: 3;
+    grid-row: 1 / span 2;
+    min-height: 36px;
+    padding: 0 10px;
+    border-radius: 999px;
+    font-size: 0.82rem;
+  }
+  .console-icon-button {
+    width: 44px;
+    min-height: 44px;
+    border-radius: 16px;
+  }
+  .console-app-frame {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0;
+    align-items: stretch;
+    min-height: 0;
+    overflow: hidden;
+    padding: 10px 10px 0;
+  }
+  .console-workspace {
+    width: 100%;
+    display: grid;
+    min-height: 0;
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    overflow: hidden;
+    padding: 0;
+  }
+  .console-drawer-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 7;
+    display: block;
+    background: rgba(15, 23, 42, 0.22);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 160ms ease;
+  }
+  .console-project-drawer {
+    position: fixed;
+    top: 8px;
+    right: auto;
+    bottom: 8px;
+    left: 14px;
+    z-index: 8;
+    width: min(340px, calc(100vw - 28px));
+    max-width: calc(100vw - 28px);
+    max-height: calc(100dvh - 16px);
+    min-height: auto;
+    overflow: auto;
+    padding: 14px;
+    border-radius: 26px;
+    background: rgba(255, 255, 255, 0.96);
+    backdrop-filter: blur(20px);
+    transform: translateX(calc(-100% - 28px));
+    transition: transform 180ms ease;
+  }
+  #console-drawer-toggle:checked ~ .console-app-frame .console-drawer-scrim {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  #console-drawer-toggle:checked ~ .console-app-frame .console-project-drawer {
+    transform: translateX(0);
+  }
+  .console-drawer-heading h2 {
+    font-size: 1.18rem;
+  }
+  .console-search {
+    min-height: 44px;
+  }
+  .console-project-group {
+    padding: 7px;
+  }
+  .console-project-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+  }
+  .console-project-title-block {
+    gap: 8px;
+  }
+  .console-project-title-block small,
+  .console-session-child small {
+    font-size: 0.78rem;
+  }
+  .console-project-actions {
+    gap: 4px;
+    justify-content: flex-end;
+  }
+  .console-project-actions button {
+    min-height: 30px;
+    padding: 0 7px;
+    font-size: 0.74rem;
+  }
+  .console-session-list {
+    margin-left: 11px;
+    padding-left: 10px;
+  }
+  .console-session-child {
+    min-height: 52px;
+    padding: 7px 8px;
+  }
+  .console-folder,
+  .console-session-icon {
+    width: 30px;
+    height: 30px;
+  }
+  .console-command-bar {
+    margin: 0 -10px;
+    padding: 0 10px 6px;
+  }
+  .console-command-bar button {
+    min-height: 34px;
+    padding: 0 10px;
+    font-size: 0.84rem;
+  }
+  .console-chat-timeline {
+    min-height: 0;
+    overflow-y: auto;
+    padding-bottom: 6px;
+    overscroll-behavior: contain;
+  }
+  .console-chat-bubble {
+    width: 92%;
+    padding: 12px 14px;
+  }
+  .console-run-card,
+  .console-diff-card,
+  .console-approval-card {
+    padding: 12px;
+  }
+  .console-card-header {
+    align-items: flex-start;
+  }
+  .console-progress-row {
+    display: grid;
+    gap: 8px;
+  }
+  .console-progress {
+    width: 100%;
+  }
+  .console-step-list {
+    font-size: 0.92rem;
+  }
+  .console-diff-lines {
+    margin: 0 -12px;
+    padding: 8px 12px;
+  }
+  .console-card-actions {
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
+  .console-card-actions button {
+    flex: 0 1 auto;
+    min-height: 34px;
+    padding: 0 11px;
+    font-size: 0.84rem;
+  }
+  .console-approval-items article {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 7px;
+  }
+  .console-approval-items strong {
+    min-width: 0;
+  }
+  .console-approval-items small {
+    grid-column: 2 / -1;
+  }
+  .console-approval-items button {
+    min-height: 32px;
+    padding: 0 9px;
+  }
+  .console-composer {
+    position: static;
+    margin-top: 2px;
+    padding: 9px;
+    border-radius: 22px;
+  }
+  .console-composer-input {
+    min-height: 44px;
+    padding: 11px 13px;
+  }
+  .console-composer-tools {
+    gap: 6px;
+  }
+  .console-composer button {
+    min-width: 38px;
+    min-height: 36px;
+    padding: 0 10px;
+  }
+  .console-composer button:last-child {
+    min-width: 46px;
+  }
+}
+`.trim();

--- a/src/web/console-product-renderer.ts
+++ b/src/web/console-product-renderer.ts
@@ -1,7 +1,11 @@
 import type {
   ConsoleProductAppModel,
   ConsoleProductApprovalCard,
+  ConsoleProductArtifactCard,
+  ConsoleProductContextCard,
+  ConsoleProductDegradedStateCard,
   ConsoleProductDiffCard,
+  ConsoleProductEmptyStateCard,
   ConsoleProductProject,
   ConsoleProductRunCard,
   ConsoleProductTimelineItem
@@ -30,44 +34,58 @@ export function renderConsoleProductHomePage(
 }
 
 function renderShell(model: ConsoleProductAppModel): string {
-  return `<main class="console-mobile-shell" aria-label="Codex Console fake-data product prototype">
+  return `<main class="console-mobile-shell desktop-console-shell" aria-label="Codex Console fake-data product prototype">
   <header class="console-topbar" aria-label="Current console context">
     <label class="console-icon-button" for="console-drawer-toggle" role="button" aria-label="Open project drawer">☰</label>
     <section class="console-context">
       <p class="console-kicker">${escapeHtml(model.currentProject)} · ${escapeHtml(model.currentSession)}</p>
       <h1>${escapeHtml(model.title)}</h1>
     </section>
-    <label class="console-select-pill console-model-selector">Model <select aria-label="Model">${renderOptions(model.modelOptions, model.currentModel)}</select></label>
-    <label class="console-select-pill console-mode-selector">Mode <select aria-label="Mode">${renderOptions(model.modeOptions, model.currentMode)}</select></label>
+    <label class="console-select-pill console-model-selector"><span>Current model</span><select aria-label="Current model">${renderOptions(model.modelOptions, model.currentModel)}</select></label>
+    <label class="console-select-pill console-mode-selector"><span>Work mode</span><select aria-label="Work mode">${renderOptions(model.modeOptions, model.currentMode)}</select></label>
     <span class="console-status-pill console-status-${escapeHtml(model.status)}"><span class="console-status-dot"></span>${escapeHtml(statusLabel(model.status))}</span>
   </header>
   <input class="console-drawer-toggle" id="console-drawer-toggle" type="checkbox" aria-label="Toggle project drawer">
   <section class="console-app-frame">
     <label class="console-drawer-scrim" for="console-drawer-toggle" aria-label="Close project drawer"></label>
-    ${renderProjectDrawer(model.projects)}
-    <section class="console-workspace" aria-label="Chat timeline and task cards">
-      ${renderCommandBar(model.commands)}
+    ${renderProjectDrawer(model)}
+    <section class="console-workspace desktop-main" aria-label="Chat timeline and task cards">
+      ${renderCommandBar(model)}
+      ${renderContextCard(model.contextCard)}
       <section class="console-chat-timeline" aria-label="Chat timeline">
         ${model.timeline.map(renderTimelineItem).join("")}
         ${renderRunCard(model.runCard)}
         ${renderDiffCard(model.diffCard)}
         ${renderApprovalCard(model.approvalCard)}
+        ${renderArtifactCompactCard(model.artifactCard)}
+        ${renderEmptyStateCard(model.emptyState)}
+        ${renderDegradedStateCard(model.degradedState)}
       </section>
       ${renderComposer(model)}
     </section>
+    ${renderDesktopInspector(model)}
   </section>
 </main>`;
 }
 
-function renderProjectDrawer(projects: ConsoleProductProject[]): string {
-  return `<aside class="console-project-drawer" aria-label="Projects and sessions">
+function renderProjectDrawer(model: ConsoleProductAppModel): string {
+  return `<aside class="console-project-drawer desktop-sidebar" aria-label="Projects and sessions">
     <section class="console-drawer-heading">
       <h2>Projects</h2>
       <label class="console-drawer-close" for="console-drawer-toggle" role="button" aria-label="Close project drawer">×</label>
     </section>
     <label class="console-search"><span>⌕</span><input aria-label="Search projects or sessions" placeholder="Search projects or sessions"></label>
+    <section class="console-new-session-preview" aria-label="New session preview">
+      <strong>New session under ${escapeHtml(model.currentProject)}</strong>
+      <p>Creates an empty chat in the selected project with current context ready to review.</p>
+      <button type="button">${escapeHtml(model.emptyState.ctaLabel)}</button>
+    </section>
     <section class="console-project-list">
-      ${projects.map(renderProject).join("")}
+      ${model.projects.map(renderProject).join("")}
+    </section>
+    <section class="console-archive-confirmation" aria-label="Archive confirmation copy">
+      <strong>Archive selected project</strong>
+      <p>Archives the selected project and moves its sessions to archived projects. Nothing is deleted in this prototype.</p>
     </section>
     <button class="console-archive-link" type="button">View archived projects <span>›</span></button>
   </aside>`;
@@ -93,10 +111,11 @@ function renderProject(project: ConsoleProductProject): string {
   </article>`;
 }
 
-function renderCommandBar(commands: string[]): string {
+function renderCommandBar(model: ConsoleProductAppModel): string {
   return `<nav class="console-command-bar" aria-label="Command selection">
-    ${commands.map((command) => `<button type="button">${escapeHtml(command)}</button>`).join("")}
-    <button type="button" aria-label="Command settings">☷</button>
+    <span class="console-command-summary">Commands · ${escapeHtml(model.currentMode)} mode</span>
+    ${model.commands.map((command) => `<button type="button">${escapeHtml(command)}</button>`).join("")}
+    <button type="button" aria-label="Command settings">Mode settings</button>
   </nav>`;
 }
 
@@ -146,6 +165,7 @@ function renderApprovalCard(card: ConsoleProductApprovalCard): string {
   return `<article class="console-approval-card" aria-label="Approval card">
     <section class="console-card-header console-card-header-warning">
       <h2>⚠ ${escapeHtml(card.title)}</h2>
+      <span class="console-approval-count">${escapeHtml(card.pendingCount)} pending</span>
     </section>
     <section class="console-approval-items">
       ${card.items.map((item) => `<article><span>⚙</span><strong>${escapeHtml(item.title)}</strong><small>${escapeHtml(item.detail)}</small><button type="button">Review</button></article>`).join("")}
@@ -154,6 +174,78 @@ function renderApprovalCard(card: ConsoleProductApprovalCard): string {
       ${card.actions.filter((action) => action !== "Review").map((action) => `<button type="button">${escapeHtml(action)}</button>`).join("")}
     </section>
   </article>`;
+}
+
+function renderContextCard(card: ConsoleProductContextCard): string {
+  return `<section class="console-context-card" aria-label="Selected project context">
+    <section>
+      <strong>${escapeHtml(card.title)}</strong>
+      <p>${escapeHtml(card.summary)}</p>
+    </section>
+    <section class="console-context-chips" aria-label="Selected files and context">
+      ${card.chips.map((chip) => `<span>${escapeHtml(chip)}</span>`).join("")}
+    </section>
+    <button type="button">${escapeHtml(card.actionLabel)}</button>
+  </section>`;
+}
+
+function renderArtifactCompactCard(card: ConsoleProductArtifactCard): string {
+  return `<article class="console-artifact-card console-mobile-artifact-card" aria-label="Files and artifacts">
+    <section class="console-card-header">
+      <h2>${escapeHtml(card.title)}</h2>
+      <span>${escapeHtml(card.files.length)} items</span>
+    </section>
+    <p>${escapeHtml(card.summary)}</p>
+    <section class="console-artifact-files">
+      ${card.files.slice(0, 2).map((file) => `<span>${escapeHtml(file.name)} · ${escapeHtml(file.status)}</span>`).join("")}
+    </section>
+    <button type="button">${escapeHtml(card.actionLabel)}</button>
+  </article>`;
+}
+
+function renderEmptyStateCard(card: ConsoleProductEmptyStateCard): string {
+  return `<article class="console-empty-state-card" aria-label="New session empty chat state">
+    <strong>${escapeHtml(card.title)}</strong>
+    <p>${escapeHtml(card.body)}</p>
+    <button type="button">${escapeHtml(card.ctaLabel)}</button>
+  </article>`;
+}
+
+function renderDegradedStateCard(card: ConsoleProductDegradedStateCard): string {
+  return `<article class="console-service-state-card" aria-label="Connection guidance">
+    <strong>${escapeHtml(card.title)}</strong>
+    <p>${escapeHtml(card.body)}</p>
+    <small>${escapeHtml(card.ownerAction)}</small>
+  </article>`;
+}
+
+function renderDesktopInspector(model: ConsoleProductAppModel): string {
+  return `<aside class="desktop-inspector console-inspector" aria-label="Task, files, activity, and approvals summary">
+    <section class="desktop-task-card console-inspector-card" aria-label="Task summary">
+      <p>Task</p>
+      <h2>${escapeHtml(model.runCard.title)}</h2>
+      <span>${escapeHtml(model.runCard.status)} · ${escapeHtml(model.runCard.progressLabel)}</span>
+    </section>
+    <section class="desktop-diff-panel console-inspector-card" aria-label="Files summary">
+      <p>Files & artifacts</p>
+      <h2>${escapeHtml(model.diffCard.filename)}</h2>
+      <span>+${model.diffCard.added} −${model.diffCard.removed}</span>
+      <ul>
+        ${model.artifactCard.files.map((file) => `<li><strong>${escapeHtml(file.name)}</strong><small>${escapeHtml(file.status)}</small></li>`).join("")}
+      </ul>
+    </section>
+    <section class="desktop-run-summary console-inspector-card" aria-label="Activity summary">
+      <p>Activity</p>
+      <ol>
+        ${model.runCard.steps.map((step) => `<li class="is-${escapeHtml(step.state)}">${escapeHtml(step.label)}</li>`).join("")}
+      </ol>
+    </section>
+    <section class="console-inspector-card console-inspector-approvals" aria-label="Approvals summary">
+      <p>Approvals</p>
+      <h2>${escapeHtml(model.approvalCard.pendingCount)} pending</h2>
+      <span>${model.approvalCard.items.map((item) => escapeHtml(item.title)).join(" · ")}</span>
+    </section>
+  </aside>`;
 }
 
 function renderComposer(model: ConsoleProductAppModel): string {
@@ -257,13 +349,17 @@ button,
 .console-icon-button,
 .console-drawer-close,
 .console-command-bar button,
+.console-new-session-preview button,
 .console-project-actions button,
 .console-session-child button,
 .console-card-actions button,
 .console-card-secondary,
 .console-composer button,
 .console-archive-link,
-.console-approval-items button {
+.console-approval-items button,
+.console-context-card button,
+.console-artifact-card button,
+.console-empty-state-card button {
   border: 1px solid var(--console-product-border);
   border-radius: 14px;
   background: #ffffff;
@@ -338,6 +434,11 @@ button,
 .console-run-card,
 .console-diff-card,
 .console-approval-card,
+.console-context-card,
+.console-artifact-card,
+.console-empty-state-card,
+.console-service-state-card,
+.console-inspector-card,
 .console-composer,
 .console-chat-bubble {
   border: 1px solid var(--console-product-border);
@@ -363,13 +464,17 @@ button,
 .console-card-actions,
 .console-progress-row,
 .console-approval-items article,
-.console-composer-tools {
+.console-composer-tools,
+.console-context-card,
+.console-context-chips,
+.console-artifact-files {
   display: flex;
   align-items: center;
 }
 .console-drawer-heading,
 .console-card-header,
-.console-project-row {
+.console-project-row,
+.console-context-card {
   justify-content: space-between;
   gap: 12px;
 }
@@ -401,6 +506,43 @@ button,
   border: 0;
   outline: 0;
   color: var(--console-product-text);
+}
+.console-new-session-preview,
+.console-archive-confirmation {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid rgba(185, 205, 245, 0.8);
+  border-radius: 18px;
+  background: #f8fbff;
+}
+.console-new-session-preview strong,
+.console-archive-confirmation strong {
+  font-size: 0.9rem;
+}
+.console-new-session-preview p,
+.console-archive-confirmation p,
+.console-context-card p,
+.console-artifact-card p,
+.console-empty-state-card p,
+.console-service-state-card p {
+  margin: 0;
+  color: var(--console-product-muted);
+  font-size: 0.86rem;
+}
+.console-new-session-preview button {
+  justify-self: start;
+  min-height: 34px;
+  padding: 0 11px;
+  border-color: var(--console-product-blue);
+  border-radius: 999px;
+  color: var(--console-product-blue);
+  font-size: 0.84rem;
+  font-weight: 760;
+}
+.console-archive-confirmation {
+  border-color: #f4d29c;
+  background: #fffbeb;
 }
 .console-project-list {
   display: grid;
@@ -522,11 +664,25 @@ button,
   gap: 13px;
   min-width: 0;
 }
+.console-command-summary {
+  flex: 0 0 auto;
+  align-self: center;
+  padding: 0 2px;
+  color: var(--console-product-muted);
+  font-size: 0.86rem;
+  font-weight: 760;
+  white-space: nowrap;
+}
 .console-command-bar {
   display: flex;
   gap: 8px;
   overflow-x: auto;
   padding: 2px 0 4px;
+  scroll-padding-inline: 8px;
+}
+.console-command-bar::after {
+  content: "";
+  flex: 0 0 1px;
 }
 .console-command-bar button {
   flex: 0 0 auto;
@@ -537,6 +693,47 @@ button,
   background: rgba(255, 255, 255, 0.82);
   color: #3f4656;
   font-size: 0.9rem;
+}
+.console-context-card {
+  gap: 10px;
+  padding: 11px 12px;
+  border-radius: 18px;
+  background: #ffffff;
+}
+.console-context-card > section:first-child {
+  min-width: 180px;
+}
+.console-context-card strong {
+  display: block;
+  color: #0f172a;
+}
+.console-context-chips {
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  gap: 7px;
+  min-width: 0;
+}
+.console-context-chips span,
+.console-artifact-files span {
+  max-width: 170px;
+  overflow: hidden;
+  padding: 5px 9px;
+  border: 1px solid var(--console-product-border);
+  border-radius: 999px;
+  background: #f8fafc;
+  color: #475569;
+  font-size: 0.8rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.console-context-card button {
+  flex: 0 0 auto;
+  min-height: 36px;
+  padding: 0 11px;
+  border-radius: 999px;
+  color: var(--console-product-blue);
+  font-size: 0.84rem;
+  font-weight: 760;
 }
 .console-chat-timeline {
   display: grid;
@@ -575,7 +772,8 @@ button,
   font-size: 1rem;
 }
 .console-card-header span,
-.console-diff-stat {
+.console-diff-stat,
+.console-approval-count {
   border-radius: 999px;
   padding: 5px 9px;
   background: var(--console-product-blue-soft);
@@ -680,6 +878,10 @@ button,
 .console-card-header-warning h2 {
   color: #7c4a03;
 }
+.console-card-header-warning .console-approval-count {
+  background: #fff3cf;
+  color: #7c4a03;
+}
 .console-approval-items {
   display: grid;
   gap: 8px;
@@ -704,6 +906,94 @@ button,
   border-radius: 999px;
   color: #5f3b10;
   font-size: 0.86rem;
+}
+.console-artifact-card,
+.console-empty-state-card,
+.console-service-state-card {
+  display: grid;
+  gap: 9px;
+  padding: 13px;
+  border-radius: 18px;
+  background: #ffffff;
+}
+.console-artifact-card p,
+.console-empty-state-card p,
+.console-service-state-card p {
+  font-size: 0.9rem;
+}
+.console-artifact-files {
+  flex-wrap: wrap;
+  gap: 7px;
+}
+.console-artifact-card button,
+.console-empty-state-card button {
+  justify-self: start;
+  min-height: 36px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border-color: var(--console-product-blue);
+  color: var(--console-product-blue);
+  font-weight: 760;
+}
+.console-empty-state-card {
+  border-style: dashed;
+  text-align: center;
+  place-items: center;
+  background: rgba(248, 251, 255, 0.9);
+}
+.console-service-state-card {
+  border-color: #f4d29c;
+  background: #fffbeb;
+  box-shadow: 0 10px 28px rgba(31, 42, 68, 0.08);
+}
+.console-service-state-card small {
+  color: #7c4a03;
+  font-weight: 760;
+}
+.console-inspector {
+  display: none;
+}
+.console-inspector-card {
+  gap: 8px;
+  padding: 14px;
+  border-radius: 20px;
+  background: #ffffff;
+}
+.console-inspector-card p,
+.console-inspector-card h2,
+.console-inspector-card ol,
+.console-inspector-card ul {
+  margin: 0;
+}
+.console-inspector-card p {
+  color: var(--console-product-muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.console-inspector-card h2 {
+  font-size: 1rem;
+}
+.console-inspector-card span,
+.console-inspector-card small {
+  color: var(--console-product-muted);
+  font-size: 0.86rem;
+}
+.console-inspector-card ol,
+.console-inspector-card ul {
+  display: grid;
+  gap: 7px;
+  padding: 0;
+  list-style: none;
+}
+.console-inspector-card li {
+  display: grid;
+  gap: 2px;
+  padding: 8px 0;
+  border-top: 1px solid #eef2f7;
+  color: #334155;
+  font-size: 0.88rem;
 }
 .console-composer {
   position: sticky;
@@ -770,46 +1060,91 @@ button,
   .console-workspace {
     padding-right: 10px;
   }
+  .console-context-card {
+    align-items: stretch;
+    display: grid;
+  }
 }
 @media (max-width: 720px) {
   .console-mobile-shell {
     width: 100%;
-    height: 100vh;
-    height: 100dvh;
-    display: grid;
-    grid-template-rows: auto minmax(0, 1fr);
-    overflow: hidden;
+    min-height: 100vh;
+    min-height: 100dvh;
+    display: block;
+    overflow: visible;
     padding: 0 0 calc(10px + env(safe-area-inset-bottom));
   }
   .console-topbar {
-    grid-template-columns: auto minmax(0, 1fr) auto;
+    display: grid;
+    grid-template-columns: 44px minmax(0, 1fr) max-content;
     gap: 8px;
+    align-items: start;
     padding: calc(10px + env(safe-area-inset-top)) 12px 10px;
   }
+  .console-context {
+    grid-column: 2;
+    grid-row: 1;
+    min-width: 0;
+  }
   .console-context h1 {
-    font-size: 1.28rem;
+    overflow: hidden;
+    font-size: 1.08rem;
+    line-height: 1.15;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .console-kicker {
+    font-size: 0.78rem;
+  }
+  .console-select-pill {
+    width: 100%;
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 44px;
+    line-height: 1.2;
+  }
+  .console-select-pill span {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+  .console-select-pill span::after {
+    content: ":";
+  }
+  .console-select-pill select {
+    width: auto;
+    max-width: 58%;
+    min-height: 32px;
+    text-align: right;
   }
   .console-model-selector,
   .console-mode-selector {
-    grid-row: 2;
-    min-height: 36px;
-    padding: 0 9px;
-    border-radius: 999px;
+    min-width: 0;
+    padding: 6px 10px;
+    border-radius: 16px;
     font-size: 0.82rem;
   }
+  .console-model-selector {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
   .console-mode-selector {
-    grid-column: 2;
-    justify-self: start;
+    grid-column: 1 / -1;
+    grid-row: 3;
   }
   .console-status-pill {
     grid-column: 3;
-    grid-row: 1 / span 2;
+    grid-row: 1;
     min-height: 36px;
     padding: 0 10px;
     border-radius: 999px;
     font-size: 0.82rem;
+    white-space: nowrap;
   }
   .console-icon-button {
+    grid-column: 1;
+    grid-row: 1;
     width: 44px;
     min-height: 44px;
     border-radius: 16px;
@@ -819,16 +1154,17 @@ button,
     grid-template-columns: 1fr;
     gap: 0;
     align-items: stretch;
-    min-height: 0;
-    overflow: hidden;
+    min-height: auto;
+    overflow: visible;
     padding: 10px 10px 0;
   }
   .console-workspace {
     width: 100%;
     display: grid;
-    min-height: 0;
-    grid-template-rows: auto minmax(0, 1fr) auto;
-    overflow: hidden;
+    min-height: auto;
+    grid-template-rows: none;
+    align-content: start;
+    overflow: visible;
     padding: 0;
   }
   .console-drawer-scrim {
@@ -843,21 +1179,23 @@ button,
   }
   .console-project-drawer {
     position: fixed;
-    top: 8px;
-    right: auto;
-    bottom: 8px;
-    left: 14px;
+    top: calc(8px + env(safe-area-inset-top));
+    right: 8px;
+    bottom: calc(8px + env(safe-area-inset-bottom));
+    left: 8px;
     z-index: 8;
-    width: min(340px, calc(100vw - 28px));
-    max-width: calc(100vw - 28px);
-    max-height: calc(100dvh - 16px);
+    width: auto;
+    max-width: none;
+    max-height: calc(100dvh - 16px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
     min-height: auto;
-    overflow: auto;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
     padding: 14px;
     border-radius: 26px;
     background: rgba(255, 255, 255, 0.96);
     backdrop-filter: blur(20px);
-    transform: translateX(calc(-100% - 28px));
+    transform: translateX(calc(-100% - 16px));
     transition: transform 180ms ease;
   }
   #console-drawer-toggle:checked ~ .console-app-frame .console-drawer-scrim {
@@ -878,7 +1216,7 @@ button,
   }
   .console-project-row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) max-content;
     gap: 8px;
   }
   .console-project-title-block {
@@ -889,6 +1227,8 @@ button,
     font-size: 0.78rem;
   }
   .console-project-actions {
+    min-width: max-content;
+    flex-wrap: nowrap;
     gap: 4px;
     justify-content: flex-end;
   }
@@ -911,18 +1251,47 @@ button,
     height: 30px;
   }
   .console-command-bar {
+    width: calc(100% + 20px);
+    max-width: 100vw;
     margin: 0 -10px;
-    padding: 0 10px 6px;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    padding: 0 10px 8px;
+    scroll-padding-inline: 10px;
+  }
+  .console-command-bar::after {
+    flex-basis: 2px;
+  }
+  .console-command-summary {
+    font-size: 0.8rem;
   }
   .console-command-bar button {
     min-height: 34px;
     padding: 0 10px;
     font-size: 0.84rem;
   }
+  .console-context-card {
+    gap: 8px;
+    padding: 10px;
+  }
+  .console-context-card > section:first-child {
+    min-width: 0;
+  }
+  .console-context-chips {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+  .console-context-chips span {
+    flex: 0 0 auto;
+  }
+  .console-context-card button {
+    justify-self: start;
+    min-height: 34px;
+  }
   .console-chat-timeline {
-    min-height: 0;
-    overflow-y: auto;
-    padding-bottom: 6px;
+    min-height: auto;
+    overflow: visible;
+    padding-bottom: 0;
     overscroll-behavior: contain;
   }
   .console-chat-bubble {
@@ -996,6 +1365,36 @@ button,
   }
   .console-composer button:last-child {
     min-width: 46px;
+  }
+}
+@media (min-width: 960px) {
+  .desktop-console-shell {
+    width: min(1440px, 100%);
+  }
+  .desktop-console-shell .console-app-frame {
+    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr) minmax(270px, 340px);
+  }
+  .desktop-sidebar {
+    min-height: calc(100vh - 112px);
+  }
+  .desktop-main {
+    min-height: calc(100vh - 112px);
+  }
+  .desktop-inspector {
+    position: sticky;
+    top: 86px;
+    display: grid;
+    gap: 12px;
+    max-height: calc(100vh - 112px);
+    overflow: auto;
+  }
+  .desktop-task-card,
+  .desktop-diff-panel,
+  .desktop-run-summary {
+    display: grid;
+  }
+  .console-mobile-artifact-card {
+    display: none;
   }
 }
 `.trim();

--- a/src/web/console-product-renderer.ts
+++ b/src/web/console-product-renderer.ts
@@ -5,6 +5,7 @@ import type {
   ConsoleProductContextCard,
   ConsoleProductDegradedStateCard,
   ConsoleProductDiffCard,
+  ConsoleProductCapability,
   ConsoleProductEmptyStateCard,
   ConsoleProductProject,
   ConsoleProductRunCard,
@@ -23,7 +24,7 @@ export function renderConsoleProductHomePage(
     "<head>",
     "<meta charset=\"utf-8\">",
     "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
-    `<title>${escapeHtml(model.title)} · Product Prototype</title>`,
+    `<title>${escapeHtml(model.title)} · Codex Console</title>`,
     `<style>\n${css}\n</style>`,
     "</head>",
     "<body class=\"console-product-body\">",
@@ -34,7 +35,7 @@ export function renderConsoleProductHomePage(
 }
 
 function renderShell(model: ConsoleProductAppModel): string {
-  return `<main class="console-mobile-shell desktop-console-shell" aria-label="Codex Console fake-data product prototype">
+  return `<main class="console-mobile-shell desktop-console-shell" aria-label="Codex Console product UI" data-console-source="${escapeHtml(model.source ?? "demo")}"${model.apiRoot ? ` data-console-api-root="${escapeHtml(model.apiRoot)}"` : ""}${model.activeProjectId ? ` data-console-project-id="${escapeHtml(model.activeProjectId)}"` : ""}${model.activeSessionId ? ` data-console-session-id="${escapeHtml(model.activeSessionId)}"` : ""}>
   <header class="console-topbar" aria-label="Current console context">
     <label class="console-icon-button" for="console-drawer-toggle" role="button" aria-label="Open project drawer">☰</label>
     <section class="console-context">
@@ -93,7 +94,9 @@ function renderProjectDrawer(model: ConsoleProductAppModel): string {
 
 function renderProject(project: ConsoleProductProject): string {
   const expanded = project.expanded ? "true" : "false";
-  return `<article class="console-project-group" data-expanded="${expanded}">
+  const archiveCapability = project.archiveCapability ?? { state: "enabled" as const };
+  const createSessionCapability = project.createSessionCapability ?? { state: "enabled" as const };
+  return `<article class="console-project-group" data-expanded="${expanded}"${project.projectId ? ` data-console-project-id="${escapeHtml(project.projectId)}"` : ""}>
     <section class="console-project-row">
       <section class="console-project-title-block">
         <span class="console-disclosure">${project.expanded ? "⌄" : "›"}</span>
@@ -101,14 +104,20 @@ function renderProject(project: ConsoleProductProject): string {
         <span class="console-project-copy"><strong>${escapeHtml(project.name)}</strong><small>⌘ ${escapeHtml(project.branch)} · ${escapeHtml(project.hint)}</small></span>
       </section>
       <section class="console-project-actions" aria-label="${escapeHtml(project.name)} actions">
-        <button class="console-project-action-archive" type="button" aria-label="Archive ${escapeHtml(project.name)}">Archive</button>
-        <button class="console-project-action-new-session" type="button" aria-label="Create new session in ${escapeHtml(project.name)}">+ New</button>
+        ${renderCapabilityButton("console-project-action-archive", `Archive ${project.name}`, "Archive", archiveCapability)}
+        ${renderCapabilityButton("console-project-action-new-session", `Create new session in ${project.name}`, "+ New", createSessionCapability)}
       </section>
     </section>
     <section class="console-session-list" aria-label="${escapeHtml(project.name)} sessions">
-      ${project.sessions.map((session) => `<article class="console-session-child${session.active ? " is-active" : ""}"><span class="console-session-icon">☵</span><span><strong>${escapeHtml(session.title)}</strong><small>${escapeHtml(session.age)}</small></span><button type="button" aria-label="Session actions">•••</button></article>`).join("")}
+      ${project.sessions.map((session) => `<article class="console-session-child${session.active ? " is-active" : ""}"${session.sessionId ? ` data-console-session-id="${escapeHtml(session.sessionId)}"` : ""}><span class="console-session-icon">☵</span><span><strong>${escapeHtml(session.title)}</strong><small>${escapeHtml(session.status ? `${session.age} · ${session.status}` : session.age)}</small></span><button type="button" aria-label="Session actions" disabled aria-disabled="true">•••</button></article>`).join("")}
     </section>
   </article>`;
+}
+
+function renderCapabilityButton(className: string, ariaLabel: string, label: string, capability: ConsoleProductCapability): string {
+  const disabled = capability.state !== "enabled";
+  const title = disabled ? capability.reason || capability.ownerAction || "Unavailable from Web right now." : "";
+  return `<button class="${escapeHtml(className)}" type="button" aria-label="${escapeHtml(ariaLabel)}" data-capability-state="${escapeHtml(capability.state)}"${disabled ? ` disabled aria-disabled="true" title="${escapeHtml(title)}"` : ""}>${escapeHtml(label)}${disabled ? `<span class="console-sr-only"> unavailable</span>` : ""}</button>`;
 }
 
 function renderCommandBar(model: ConsoleProductAppModel): string {
@@ -168,7 +177,7 @@ function renderApprovalCard(card: ConsoleProductApprovalCard): string {
       <span class="console-approval-count">${escapeHtml(card.pendingCount)} pending</span>
     </section>
     <section class="console-approval-items">
-      ${card.items.map((item) => `<article><span>⚙</span><strong>${escapeHtml(item.title)}</strong><small>${escapeHtml(item.detail)}</small><button type="button">Review</button></article>`).join("")}
+      ${card.items.map((item) => `<article><span>⚙</span><strong>${escapeHtml(item.title)}</strong><small>${escapeHtml(item.detail)}</small><button type="button" disabled aria-disabled="true">Review unavailable</button></article>`).join("")}
     </section>
     <section class="console-card-actions">
       ${card.actions.filter((action) => action !== "Review").map((action) => `<button type="button">${escapeHtml(action)}</button>`).join("")}
@@ -250,14 +259,34 @@ function renderDesktopInspector(model: ConsoleProductAppModel): string {
 
 function renderComposer(model: ConsoleProductAppModel): string {
   const controls = new Set(model.composer.controls);
-  return `<section class="console-composer" aria-label="Message composer">
-    <section class="console-composer-input" role="textbox" aria-label="${escapeHtml(model.composer.placeholder)}" aria-readonly="true">${escapeHtml(model.composer.placeholder)}</section>
+  const capability = model.composer.sendCapability ?? { state: controls.has("Send") ? "enabled" as const : "disabled" as const };
+  const canSend = capability.state === "enabled" && Boolean(model.composer.sessionId && model.composer.sendEndpoint && model.composer.csrfToken);
+  const capabilityAttrs = `data-capability-send-message="${escapeHtml(capability.state)}"${model.composer.sessionId ? ` data-console-session-id="${escapeHtml(model.composer.sessionId)}"` : ""}`;
+  if (canSend) {
+    return `<form class="console-composer" aria-label="${escapeHtml(model.composer.label ?? "Message composer")}" data-console-send-form ${capabilityAttrs} method="post" action="${escapeHtml(model.composer.sendEndpoint)}">
+      <input type="hidden" name="_csrf" value="${escapeHtml(model.composer.csrfToken)}">
+      <label class="console-sr-only" for="console-message-input">${escapeHtml(model.composer.label ?? "Message Codex")}</label>
+      <textarea id="console-message-input" class="console-composer-input" name="text" maxlength="8000" required placeholder="${escapeHtml(model.composer.placeholder)}"></textarea>
+      <section class="console-composer-tools" aria-label="Composer tools">
+        <button type="button" aria-label="Attach" disabled aria-disabled="true">${controls.has("Attach") ? "⌘" : "+"}</button>
+        <button type="button" aria-label="Command" disabled aria-disabled="true">${controls.has("Command") ? "/" : "⌕"}</button>
+        <button type="button" aria-label="Mic" disabled aria-disabled="true">${controls.has("Mic") ? "🎙" : "Mic"}</button>
+        <button type="submit" aria-label="Send">${controls.has("Send") ? "➤" : "Send"}</button>
+      </section>
+      <p class="console-composer-note"><span>Text only</span> Sends through the Console API live write seam.</p>
+    </form>`;
+  }
+
+  const unavailable = model.composer.unavailableCopy ?? capability.reason ?? capability.ownerAction ?? "Text send is unavailable from Web right now.";
+  return `<section class="console-composer" aria-label="${escapeHtml(model.composer.label ?? "Message composer")}" aria-disabled="true" ${capabilityAttrs}>
+    <section class="console-composer-input" role="textbox" aria-label="${escapeHtml(model.composer.placeholder)}" aria-readonly="true" aria-disabled="true">${escapeHtml(model.composer.placeholder)}</section>
     <section class="console-composer-tools" aria-label="Composer tools">
-      <button type="button" aria-label="Attach">${controls.has("Attach") ? "⌘" : "+"}</button>
-      <button type="button" aria-label="Command">${controls.has("Command") ? "/" : "⌕"}</button>
-      <button type="button" aria-label="Mic">${controls.has("Mic") ? "🎙" : "Mic"}</button>
-      <button type="button" aria-label="Send">${controls.has("Send") ? "➤" : "Send"}</button>
+      <button type="button" aria-label="Attach" disabled aria-disabled="true">${controls.has("Attach") ? "⌘" : "+"}</button>
+      <button type="button" aria-label="Command" disabled aria-disabled="true">${controls.has("Command") ? "/" : "⌕"}</button>
+      <button type="button" aria-label="Mic" disabled aria-disabled="true">${controls.has("Mic") ? "🎙" : "Mic"}</button>
+      <button type="button" aria-label="Send" disabled aria-disabled="true">Send unavailable</button>
     </section>
+    <p class="console-composer-note"><span>Unavailable</span> ${escapeHtml(unavailable)}</p>
   </section>`;
 }
 
@@ -269,7 +298,7 @@ function statusLabel(status: ConsoleProductAppModel["status"]): string {
   return status === "running" ? "Running" : "Online";
 }
 
-function escapeHtml(value: unknown): string {
+export function escapeHtml(value: unknown): string {
   return String(value ?? "")
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
@@ -277,6 +306,59 @@ function escapeHtml(value: unknown): string {
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
 }
+
+export const CONSOLE_PRODUCT_SCRIPT = `
+(() => {
+  const forms = document.querySelectorAll("[data-console-send-form]");
+  for (const form of forms) {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const input = form.querySelector("textarea[name='text']");
+      const csrf = form.querySelector("input[name='_csrf']");
+      const button = form.querySelector("button[type='submit']");
+      const note = form.querySelector(".console-composer-note");
+      const text = input instanceof HTMLTextAreaElement ? input.value.trim() : "";
+      if (!text) {
+        return;
+      }
+      if (button instanceof HTMLButtonElement) {
+        button.disabled = true;
+      }
+      try {
+        const response = await fetch(form.action, {
+          method: "POST",
+          headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-CSRF-Token": csrf instanceof HTMLInputElement ? csrf.value : ""
+          },
+          body: JSON.stringify({ text })
+        });
+        if (response.ok) {
+          input.value = "";
+          if (note) {
+            note.textContent = "Message sent. Refresh this session to see updated activity.";
+          }
+          return;
+        }
+        if (note) {
+          note.textContent = response.status === 409
+            ? "Message was not sent because the session is busy or the send capability is unavailable."
+            : "Message was not sent. Refresh before retrying.";
+        }
+      } catch {
+        if (note) {
+          note.textContent = "Message was not sent. Check the Console connection and retry.";
+        }
+      } finally {
+        if (button instanceof HTMLButtonElement) {
+          button.disabled = false;
+        }
+      }
+    });
+  }
+})();
+`.trim();
 
 export const CONSOLE_PRODUCT_CSS = `
 :root {
@@ -309,12 +391,25 @@ body.console-product-body {
 }
 button,
 select,
-input {
+input,
+textarea {
   font: inherit;
 }
 button,
 select {
   min-height: 44px;
+}
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+.console-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
 }
 button,
 .console-icon-button {
@@ -1006,6 +1101,9 @@ button,
   background: rgba(255, 255, 255, 0.96);
   backdrop-filter: blur(18px);
 }
+form.console-composer {
+  margin: 0;
+}
 .console-composer-input {
   width: 100%;
   min-height: 46px;
@@ -1015,9 +1113,23 @@ button,
   background: #f8fafc;
   color: #8b94a7;
 }
+textarea.console-composer-input {
+  resize: vertical;
+  color: var(--console-product-text);
+  outline: 0;
+}
 .console-composer-tools {
   justify-content: space-between;
   gap: 8px;
+}
+.console-composer-note {
+  margin: 0;
+  color: var(--console-product-muted);
+  font-size: 0.82rem;
+}
+.console-composer-note span {
+  color: var(--console-product-blue);
+  font-weight: 800;
 }
 .console-composer button {
   display: grid;

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -102,7 +102,18 @@ function makeProvider(
         readonly: true,
         pageId: "web_workspaces",
         state: "available",
-        workspaces: [],
+        workspaces: options.homeWorkspaces ?? [
+          {
+            workspaceId: "wk_safe_1",
+            label: "Console Core",
+            availability: "available",
+            conversationCount: 1,
+            pinned: true,
+            lastActivityAt: "2026-04-25T12:00:00.000Z",
+            lastSuccessAt: null,
+            source: "recent"
+          }
+        ],
         warnings: []
       };
     },
@@ -304,7 +315,6 @@ test("authenticated state route invokes only expected provider method", async ()
   });
 });
 
-
 test("chat alias renders the same fake-data product console home", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
@@ -427,7 +437,6 @@ test("readiness page renders owner-language capability and access posture withou
   });
 });
 
-
 test("authenticated product home emits safe fake-data shell without raw provider internals", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
@@ -462,7 +471,6 @@ test("authenticated product home emits safe fake-data shell without raw provider
   });
 });
 
-
 test("home renders chat-first fake-data product shell with drawer and composer", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
@@ -490,7 +498,6 @@ test("home renders chat-first fake-data product shell with drawer and composer",
     assert.equal(result.text.includes("Settings / access posture"), false, `home should keep access posture off the landing chat: ${result.text}`);
   });
 });
-
 
 test("home ignores live empty provider state and keeps fake-data product prototype", async () => {
   const calls: string[] = [];
@@ -521,7 +528,6 @@ test("home ignores live empty provider state and keeps fake-data product prototy
   });
 });
 
-
 test("authenticated HTML includes CSP-compatible product shell stylesheet", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
@@ -540,7 +546,6 @@ test("authenticated HTML includes CSP-compatible product shell stylesheet", asyn
     assert.equal(result.text.includes('style="'), false);
   });
 });
-
 
 test("home keeps pending provider internals out of fake-data product prototype", async () => {
   const calls: string[] = [];
@@ -725,7 +730,6 @@ test("conversation detail pending panel shares read-only pending cards and actio
   });
 });
 
-
 test("phase B pages expose disabled/product composer posture without enabled write submissions", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
@@ -792,6 +796,112 @@ test("accepted and running conversation states expose safe refresh affordance", 
     assert.match(result.text, /Refresh thread/);
     for (const forbidden of [token, "session-1", "chat-secret", "/tmp/", "/home/", "thread-1", "turn-1", "stack"]) {
       assert.equal(result.text.includes(forbidden), false, `refresh affordance leaked ${forbidden}`);
+    }
+  });
+});
+
+test("Console API send wiring is disabled without Web submit dependency and live when submit exists", async () => {
+  const calls: string[] = [];
+  const provider = makeProvider(calls, {
+    homeWorkspaces: [
+      {
+        workspaceId: "wk_safe_1",
+        label: "Console Core",
+        availability: "available",
+        conversationCount: 1,
+        pinned: true,
+        lastActivityAt: "2026-04-25T12:00:00.000Z",
+        lastSuccessAt: null,
+        source: "recent"
+      }
+    ],
+    workspaceConversations: [
+      {
+        conversationId: "cv_1234567890abcdef",
+        conversationHandle: "cv_1234567890abcdef",
+        workspaceId: "wk_safe_1",
+        title: "Readonly detail",
+        status: "completed",
+        failureReason: null,
+        archived: false,
+        createdAt: "2026-04-25T10:00:00.000Z",
+        lastActivityAt: "2026-04-25T12:00:00.000Z",
+        lastTurnStatus: "completed",
+        finalAnswerAvailable: true
+      }
+    ]
+  });
+
+  await withServer({
+    provider,
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const bootstrap = JSON.parse((await get(`${baseUrl}/api/console/bootstrap`, token)).text);
+    assert.equal(bootstrap.capabilities.sendMessage.state, "disabled");
+
+    const sessionId = bootstrap.activeSessionId;
+    assert.ok(sessionId);
+    const disabled = await post(`${baseUrl}/api/sessions/${sessionId}/messages`, token, JSON.stringify({ text: "hello" }), {
+      "Content-Type": "application/json",
+      "X-CSRF-Token": "csrf-safe-token",
+      Accept: "application/json"
+    });
+    assert.equal(disabled.status, 409);
+    assert.equal(JSON.parse(disabled.text).capability, "sendMessage");
+  });
+
+  const submitted: unknown[] = [];
+  await withServer({
+    provider: makeProvider([], {
+      homeWorkspaces: [
+        {
+          workspaceId: "wk_safe_1",
+          label: "Console Core",
+          availability: "available",
+          conversationCount: 1,
+          pinned: true,
+          lastActivityAt: "2026-04-25T12:00:00.000Z",
+          lastSuccessAt: null,
+          source: "recent"
+        }
+      ]
+    }),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    send: {
+      csrfToken: "csrf-safe-token",
+      submitTextMessage: (request) => {
+        submitted.push(request);
+        return { status: "accepted" };
+      }
+    }
+  }, async (baseUrl) => {
+    const bootstrap = JSON.parse((await get(`${baseUrl}/api/console/bootstrap`, token)).text);
+    assert.equal(bootstrap.capabilities.sendMessage.state, "enabled");
+    assert.equal(bootstrap.capabilities.archiveProject.state, "disabled");
+    assert.equal(bootstrap.capabilities.createSession.state, "disabled");
+    assert.equal(bootstrap.capabilities.answerApproval.state, "disabled");
+
+    const sessionId = bootstrap.activeSessionId;
+    assert.ok(sessionId);
+    const result = await post(`${baseUrl}/api/sessions/${sessionId}/messages`, token, JSON.stringify({ text: " hello from Console " }), {
+      "Content-Type": "application/json",
+      "X-CSRF-Token": "csrf-safe-token",
+      Accept: "application/json"
+    });
+    const body = JSON.parse(result.text);
+
+    assert.equal(result.status, 202);
+    assert.equal(body.accepted, true);
+    assert.equal(body.sessionId, sessionId);
+    assert.equal(body.message.text, "hello from Console");
+    assert.equal(body.message.status, "pending");
+    assert.deepEqual(submitted, [{
+      conversationHandle: "cv_1234567890abcdef",
+      text: "hello from Console",
+      nonce: null
+    }]);
+    for (const forbidden of ["cv_1234567890abcdef", "session-1", "chat-secret", "thread-1", "token="]) {
+      assert.equal(result.text.includes(forbidden), false, `Console send leaked ${forbidden}: ${result.text}`);
     }
   });
 });
@@ -932,7 +1042,6 @@ test("POST message maps blocked, missing, archived, or unavailable submit outcom
     });
   }
 });
-
 
 test("home recent live conversations are not rendered into fake-data product prototype", async () => {
   const calls: string[] = [];
@@ -1154,7 +1263,6 @@ test("state responses include no-store, CSP, nosniff, and HTML charset headers",
     assert.match(result.headers.get("content-type") ?? "", /^text\/html; charset=utf-8/);
   });
 });
-
 
 test("unknown route and provider error are generic without stack traces", async () => {
   const calls: string[] = [];

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -315,17 +315,20 @@ test("authenticated state route invokes only expected provider method", async ()
   });
 });
 
-test("chat alias renders the same fake-data product console home", async () => {
+test("chat alias renders the same API-backed product console home", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     const root = await get(`${baseUrl}/`, token);
     const alias = await get(`${baseUrl}/chat`, token);
     assert.equal(root.status, 200);
     assert.equal(alias.status, 200);
-    assert.deepEqual(calls, []);
-    for (const copy of ["Codex Console", "acme/web", "Refactor auth middleware", "GPT-5.5 xhigh", "Message Codex or type /"]) {
+    assert.ok(calls.includes("workspaces"));
+    assert.ok(calls.includes("workspace:wk_safe_1"));
+    assert.ok(calls.includes("conversation:cv_1234567890abcdef"));
+    for (const copy of ["Codex Console", "Console Core", "Readonly detail", "GPT-5.5", "Message unavailable from Web"]) {
       assert.match(alias.text, new RegExp(escapeRegExp(copy)), `missing alias copy ${copy}: ${alias.text}`);
     }
+    assert.match(alias.text, /data-console-api-root="\/api"/);
     assert.equal(alias.text, root.text);
   });
 });
@@ -437,12 +440,14 @@ test("readiness page renders owner-language capability and access posture withou
   });
 });
 
-test("authenticated product home emits safe fake-data shell without raw provider internals", async () => {
+test("authenticated product home emits safe API-backed shell without raw provider internals", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
-    assert.deepEqual(calls, []);
+    assert.ok(calls.includes("workspaces"));
+    assert.ok(calls.includes("workspace:wk_safe_1"));
+    assert.ok(calls.includes("conversation:cv_1234567890abcdef"));
     assert.match(result.text, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
     for (const marker of [
       "console-mobile-shell",
@@ -458,48 +463,45 @@ test("authenticated product home emits safe fake-data shell without raw provider
       "console-run-card",
       "console-diff-card",
       "console-approval-card",
-      "console-composer"
+      "console-composer",
+      "data-console-api-root",
+      "data-capability-send-message"
     ]) {
       assert.match(result.text, new RegExp(escapeRegExp(marker)), `missing product marker ${marker}: ${result.text}`);
     }
     assert.equal(result.text.includes("<table"), false, `home should use product shell, not primary tables: ${result.text}`);
-    assert.equal(result.text.includes("<script>"), false);
     assert.equal(result.text.includes("<img"), false);
-    for (const forbidden of ["/home/ubuntu/secret", "token=abc", "callback_data", "messageId", "cv_1234567890abcdef", "wk_safe_1", "<textarea", "method=\"post\"", "action=", "onclick", "download=", "?token", "href=\"#"]) {
+    for (const forbidden of ["/home/ubuntu/secret", "token=abc", "callback_data", "messageId", "cv_1234567890abcdef", "wk_safe_1", "onclick", "download=", "?token", "href=\"#"]) {
       assert.equal(result.text.includes(forbidden), false, `rendered forbidden raw value ${forbidden}: ${result.text}`);
     }
   });
 });
 
-test("home renders chat-first fake-data product shell with drawer and composer", async () => {
+test("home renders chat-first API-backed product shell with drawer and composer", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
-    assert.deepEqual(calls, []);
+    assert.ok(calls.length > 0);
     for (const copy of [
       "Codex Console",
-      "acme/web",
-      "acme/api",
-      "acme/infra",
-      "Refactor auth middleware",
-      "Fix CI flaky test",
-      "Add UI prototype",
-      "GPT-5.5 xhigh",
+      "Console Core",
+      "Readonly detail",
+      "GPT-5.5",
       "Auto",
-      "Ask",
       "Online",
-      "Message Codex or type /"
+      "Message unavailable from Web"
     ]) {
       assert.match(result.text, new RegExp(escapeRegExp(copy)), `missing product shell copy ${copy}: ${result.text}`);
     }
     assert.match(result.text, /role="textbox"[^>]*aria-readonly="true"/);
+    assert.match(result.text, /data-console-source="api"/);
     assert.equal(result.text.includes("Current state"), false, `home should not be centered on status metrics: ${result.text}`);
     assert.equal(result.text.includes("Settings / access posture"), false, `home should keep access posture off the landing chat: ${result.text}`);
   });
 });
 
-test("home ignores live empty provider state and keeps fake-data product prototype", async () => {
+test("home attempts API-backed data and uses explicit empty/degraded state instead of fake prototype", async () => {
   const calls: string[] = [];
   await withServer({
     provider: makeProvider(calls, {
@@ -519,12 +521,13 @@ test("home ignores live empty provider state and keeps fake-data product prototy
   }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
-    assert.deepEqual(calls, []);
-    for (const copy of ["acme/web", "Refactor auth middleware", "Running", "Approval required", "Message Codex or type /"]) {
-      assert.match(result.text, new RegExp(escapeRegExp(copy)), `missing stable fake-data copy ${copy}: ${result.text}`);
+    assert.ok(calls.includes("workspaces"));
+    assert.match(result.text, /data-console-source="api"/);
+    for (const copy of ["No live projects yet", "No sessions available", "Message unavailable from Web"]) {
+      assert.match(result.text, new RegExp(escapeRegExp(copy)), `missing empty API copy ${copy}: ${result.text}`);
     }
-    assert.equal(result.text.includes("degraded"), false, `empty home should not lead with degraded copy: ${result.text}`);
-    assert.equal(result.text.includes("denied-by-default"), false, `empty home should not lead with security posture: ${result.text}`);
+    assert.equal(result.text.includes("acme/web"), false, `empty home should not use demo project: ${result.text}`);
+    assert.equal(result.text.includes("Refactor auth middleware"), false, `empty home should not use demo session: ${result.text}`);
   });
 });
 
@@ -533,8 +536,10 @@ test("authenticated HTML includes CSP-compatible product shell stylesheet", asyn
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
-    assert.deepEqual(calls, []);
+    assert.ok(calls.includes("workspaces"));
     assert.match(result.headers.get("content-security-policy") ?? "", /style-src 'sha256-[A-Za-z0-9+/=]+'/);
+    assert.match(result.headers.get("content-security-policy") ?? "", /script-src 'sha256-[A-Za-z0-9+/=]+'/);
+    assert.match(result.headers.get("content-security-policy") ?? "", /connect-src 'self'/);
     assert.equal(result.headers.get("content-security-policy")?.includes("unsafe-inline"), false);
     assert.match(result.text, /<style>\n:root \{/);
     assert.match(result.text, /console-mobile-shell/);
@@ -547,7 +552,7 @@ test("authenticated HTML includes CSP-compatible product shell stylesheet", asyn
   });
 });
 
-test("home keeps pending provider internals out of fake-data product prototype", async () => {
+test("home keeps pending provider internals out of API-backed product surface", async () => {
   const calls: string[] = [];
   const rows: WebReadonlyPendingInteractionViewRow[] = [
     pendingInteractionFixture("pi_home_question", "cv_aaaaaaaaaaaaaaaa", "awaiting_user_input", "question", "Codex needs a product decision."),
@@ -560,10 +565,8 @@ test("home keeps pending provider internals out of fake-data product prototype",
   }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
-    assert.deepEqual(calls, []);
-    assert.match(result.text, /Approval required/);
-    assert.match(result.text, /Run tests/);
-    assert.match(result.text, /Modify config/);
+    assert.ok(calls.includes("interactions"));
+    assert.match(result.text, /data-console-source="api"/);
     for (const raw of ["pi_home_question", "pi_home_approval", "awaiting_user_input", "pending_approval", "codex_approval", "Codex needs a product decision.", "A safe change needs owner review."]) {
       assert.equal(result.text.includes(raw), false, `home leaked raw pending value ${raw}: ${result.text}`);
     }
@@ -730,7 +733,7 @@ test("conversation detail pending panel shares read-only pending cards and actio
   });
 });
 
-test("phase B pages expose disabled/product composer posture without enabled write submissions", async () => {
+test("home and detail expose composer enabled only when write capability is available", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     for (const path of ["/", "/chat", "/conversations/cv_1234567890abcdef"]) {
@@ -740,12 +743,12 @@ test("phase B pages expose disabled/product composer posture without enabled wri
       if (path.startsWith("/conversations/")) {
         assert.match(result.text, /Sending from Web is landing next/);
         assert.match(result.text, /aria-disabled="true"/);
+        assert.equal(result.text.toLowerCase().includes("/api/sessions/"), false, `${path} exposed API send without capability`);
       } else {
-        assert.match(result.text, /Message Codex or type \//);
+        assert.match(result.text, /Message unavailable from Web/);
+        assert.match(result.text, /data-capability-send-message="disabled"/);
         assert.match(result.text, /console-composer/);
-      }
-      for (const forbidden of ["<form", "<textarea", "method=\"post\"", "action=", "/messages"]) {
-        assert.equal(result.text.toLowerCase().includes(forbidden), false, `${path} exposed write submission ${forbidden}: ${result.text}`);
+        assert.equal(result.text.toLowerCase().includes("data-console-send-form"), false, `${path} exposed enabled send form`);
       }
     }
   });
@@ -1043,7 +1046,7 @@ test("POST message maps blocked, missing, archived, or unavailable submit outcom
   }
 });
 
-test("home recent live conversations are not rendered into fake-data product prototype", async () => {
+test("home recent live conversations render through API model without raw state enums or handles", async () => {
   const calls: string[] = [];
   const rows: WebReadonlyConversationRow[] = [
     conversationFixture("cv_aaaaaaaaaaaaaaaa", "Answer product question", "pending_question", false),
@@ -1057,15 +1060,15 @@ test("home recent live conversations are not rendered into fake-data product pro
   ];
 
   await withServer({
-    provider: makeProvider(calls, { homeConversations: rows }),
+    provider: makeProvider(calls, { workspaceConversations: rows }),
     access: createReadonlyAccessGate({ enabled: true, token })
   }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
-    assert.deepEqual(calls, []);
-    assert.match(result.text, /Refactor auth middleware/);
-    assert.match(result.text, /Approval required/);
-    for (const raw of ["pending_question", "pending_approval", "source_unknown", "Answer product question", "Approve safe change", "cv_aaaaaaaaaaaaaaaa"]) {
+    assert.ok(calls.includes("workspace:wk_safe_1"));
+    assert.match(result.text, /Answer product question/);
+    assert.match(result.text, /data-console-api-root="\/api"/);
+    for (const raw of ["pending_question", "pending_approval", "source_unknown", "cv_aaaaaaaaaaaaaaaa"]) {
       assert.equal(result.text.includes(raw), false, `live conversation value leaked ${raw}: ${result.text}`);
     }
   });
@@ -1090,7 +1093,6 @@ test("workspace conversation list groups mixed states without exposing raw state
     for (const heading of ["Needs attention", "Running now", "Recently completed", "Other/Older"]) {
       assert.match(result.text, new RegExp(`<h3>${heading}</h3>`), `missing grouped heading ${heading}: ${result.text}`);
     }
-    assert.match(result.text, /Approval needed/);
     assert.match(result.text, /Running/);
     assert.match(result.text, /Done/);
     assert.match(result.text, /Unavailable/);

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -304,15 +304,16 @@ test("authenticated state route invokes only expected provider method", async ()
   });
 });
 
-test("chat alias renders the same read-only chat home", async () => {
+
+test("chat alias renders the same fake-data product console home", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     const root = await get(`${baseUrl}/`, token);
     const alias = await get(`${baseUrl}/chat`, token);
     assert.equal(root.status, 200);
     assert.equal(alias.status, 200);
-    assert.deepEqual(calls, ["home", "home"]);
-    for (const copy of ["Web Chat", "Conversation work queue", "Sending from Web is landing next"]) {
+    assert.deepEqual(calls, []);
+    for (const copy of ["Codex Console", "acme/web", "Refactor auth middleware", "GPT-5.5 xhigh", "Message Codex or type /"]) {
       assert.match(alias.text, new RegExp(escapeRegExp(copy)), `missing alias copy ${copy}: ${alias.text}`);
     }
     assert.equal(alias.text, root.text);
@@ -426,76 +427,72 @@ test("readiness page renders owner-language capability and access posture withou
   });
 });
 
-test("authenticated HTML escapes hostile strings and emits no raw script/action/form/control content", async () => {
+
+test("authenticated product home emits safe fake-data shell without raw provider internals", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
-    assert.deepEqual(calls, ["home"]);
+    assert.deepEqual(calls, []);
     assert.match(result.text, /<meta name="viewport" content="width=device-width, initial-scale=1">/);
-    assert.match(result.text, /Codex Console/);
-    assert.match(result.text, /Web Chat/);
-    assert.match(result.text, /Chat-first owner preview/);
-    assert.match(result.text, /<header class="console-shell__header">/);
-    assert.match(result.text, /<nav class="console-shell__nav" aria-label="Console navigation">/);
-    for (const [href, label] of [
-      ["/", "Chat"],
-      ["/workspaces", "Workspaces"],
-      ["/interactions", "Pending"],
-      ["/runtime", "Runtime"],
-      ["/readiness", "Readiness"]
-    ] as const) {
-      assert.match(result.text, new RegExp(`<a[^>]*href="${href.replace("/", "\\/")}"[^>]*>${label}</a>`), `missing nav link ${href}: ${result.text}`);
+    for (const marker of [
+      "console-mobile-shell",
+      "console-project-drawer",
+      "console-project-row",
+      "console-project-action-archive",
+      "console-project-action-new-session",
+      "console-session-child",
+      "console-chat-timeline",
+      "console-command-bar",
+      "console-model-selector",
+      "console-mode-selector",
+      "console-run-card",
+      "console-diff-card",
+      "console-approval-card",
+      "console-composer"
+    ]) {
+      assert.match(result.text, new RegExp(escapeRegExp(marker)), `missing product marker ${marker}: ${result.text}`);
     }
-    assert.match(result.text, /class="console-card"/);
-    assert.match(result.text, /Conversation work queue/);
-    assert.match(result.text, /Selected thread preview/);
-    assert.match(result.text, /Recent results and artifacts/);
-    assert.match(result.text, /Runtime summary/);
-    assert.equal(result.text.includes("<table"), false, `home should use card/list shell, not primary tables: ${result.text}`);
+    assert.equal(result.text.includes("<table"), false, `home should use product shell, not primary tables: ${result.text}`);
     assert.equal(result.text.includes("<script>"), false);
     assert.equal(result.text.includes("<img"), false);
-    assert.match(result.text, /&lt;script&gt;alert/);
-    assert.match(result.text, /&lt;b&gt;escape&lt;\/b&gt;/);
-    for (const forbidden of ["/home/ubuntu/secret", "token=abc", "callback_data", "messageId"]) {
+    for (const forbidden of ["/home/ubuntu/secret", "token=abc", "callback_data", "messageId", "cv_1234567890abcdef", "wk_safe_1", "<textarea", "method=\"post\"", "action=", "onclick", "download=", "?token", "href=\"#"]) {
       assert.equal(result.text.includes(forbidden), false, `rendered forbidden raw value ${forbidden}: ${result.text}`);
-    }
-    assert.match(result.text, /href="\/workspaces\/wk_safe_1\/conversations"/);
-    assert.match(result.text, /href="\/conversations\/cv_1234567890abcdef"/);
-    assert.equal(result.text.includes("/sessions/"), false);
-    for (const forbidden of ["<form", "<button", "<input", "<textarea", "method=\"post\"", "action=", "onclick", "download=", "?token", "href=\"#", "submit", "approve", "interrupt", "upload", "switch", "resume"]) {
-      assert.equal(result.text.toLowerCase().includes(forbidden), false, `rendered forbidden content ${forbidden}: ${result.text}`);
     }
   });
 });
 
-test("home renders a chat-first work queue with disabled composer posture", async () => {
+
+test("home renders chat-first fake-data product shell with drawer and composer", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
-    assert.deepEqual(calls, ["home"]);
-    assert.match(result.text, /<h2 id="page-heading">Web Chat<\/h2>/);
-    assert.match(result.text, /Conversation work queue for Codex Bridge\./);
-    assert.match(result.text, /Sending from Web is landing next/);
-    assert.match(result.text, /role="textbox" aria-readonly="true" aria-disabled="true"/);
-    for (const heading of [
-      "Conversation work queue",
-      "Selected thread preview",
-      "Runtime summary",
-      "Recent results and artifacts",
-      "Projects / workspaces",
-      "Secondary utilities"
+    assert.deepEqual(calls, []);
+    for (const copy of [
+      "Codex Console",
+      "acme/web",
+      "acme/api",
+      "acme/infra",
+      "Refactor auth middleware",
+      "Fix CI flaky test",
+      "Add UI prototype",
+      "GPT-5.5 xhigh",
+      "Auto",
+      "Ask",
+      "Online",
+      "Message Codex or type /"
     ]) {
-      assert.match(result.text, new RegExp(`<h2[^>]*>${escapeRegExp(heading)}</h2>`), `missing chat-first section ${heading}: ${result.text}`);
+      assert.match(result.text, new RegExp(escapeRegExp(copy)), `missing product shell copy ${copy}: ${result.text}`);
     }
-    assert.match(result.text, /Open durable thread/);
+    assert.match(result.text, /role="textbox"[^>]*aria-readonly="true"/);
     assert.equal(result.text.includes("Current state"), false, `home should not be centered on status metrics: ${result.text}`);
     assert.equal(result.text.includes("Settings / access posture"), false, `home should keep access posture off the landing chat: ${result.text}`);
   });
 });
 
-test("home empty state is friendly product copy, not degraded/security copy", async () => {
+
+test("home ignores live empty provider state and keeps fake-data product prototype", async () => {
   const calls: string[] = [];
   await withServer({
     provider: makeProvider(calls, {
@@ -515,15 +512,9 @@ test("home empty state is friendly product copy, not degraded/security copy", as
   }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
-    assert.deepEqual(calls, ["home"]);
-    for (const copy of [
-      "No conversation threads are visible yet.",
-      "No thread selected",
-      "No active work needs attention right now.",
-      "Recent results will appear here after Codex finishes work.",
-      "Projects and workspaces will appear here once the bridge has recent workspace history."
-    ]) {
-      assert.match(result.text, new RegExp(escapeRegExp(copy)), `missing friendly empty copy ${copy}: ${result.text}`);
+    assert.deepEqual(calls, []);
+    for (const copy of ["acme/web", "Refactor auth middleware", "Running", "Approval required", "Message Codex or type /"]) {
+      assert.match(result.text, new RegExp(escapeRegExp(copy)), `missing stable fake-data copy ${copy}: ${result.text}`);
     }
     assert.equal(result.text.includes("degraded"), false, `empty home should not lead with degraded copy: ${result.text}`);
     assert.equal(result.text.includes("denied-by-default"), false, `empty home should not lead with security posture: ${result.text}`);
@@ -531,26 +522,27 @@ test("home empty state is friendly product copy, not degraded/security copy", as
 });
 
 
-test("authenticated HTML includes CSP-compatible app shell stylesheet", async () => {
+test("authenticated HTML includes CSP-compatible product shell stylesheet", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
-    assert.deepEqual(calls, ["home"]);
+    assert.deepEqual(calls, []);
     assert.match(result.headers.get("content-security-policy") ?? "", /style-src 'sha256-[A-Za-z0-9+/=]+'/);
     assert.equal(result.headers.get("content-security-policy")?.includes("unsafe-inline"), false);
     assert.match(result.text, /<style>\n:root \{/);
-    assert.match(result.text, /max-width: min\(1120px, calc\(100% - 32px\)\)/);
-    assert.match(result.text, /overflow-wrap: anywhere/);
-    assert.match(result.text, /white-space: pre-wrap/);
+    assert.match(result.text, /console-mobile-shell/);
+    assert.match(result.text, /grid-template-columns: minmax\(320px, 400px\) minmax\(0, 1fr\)/);
     assert.match(result.text, /min-height: 44px/);
-    assert.match(result.text, /@media \(max-width: 640px\)/);
+    assert.match(result.text, /@media \(max-width: 720px\)/);
+    assert.match(result.text, /\.console-project-drawer \{[\s\S]*?position: fixed;[\s\S]*?transform: translateX/);
     assert.equal(result.text.includes("<link"), false);
     assert.equal(result.text.includes('style="'), false);
   });
 });
 
-test("home surfaces concrete owner attention from pending interactions without raw internals", async () => {
+
+test("home keeps pending provider internals out of fake-data product prototype", async () => {
   const calls: string[] = [];
   const rows: WebReadonlyPendingInteractionViewRow[] = [
     pendingInteractionFixture("pi_home_question", "cv_aaaaaaaaaaaaaaaa", "awaiting_user_input", "question", "Codex needs a product decision."),
@@ -563,20 +555,15 @@ test("home surfaces concrete owner attention from pending interactions without r
   }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
-    assert.deepEqual(calls, ["home"]);
-    assert.match(result.text, /Owner attention/);
-    assert.match(result.text, /2 items need owner attention/);
-    assert.match(result.text, /Codex needs a product decision\./);
-    assert.match(result.text, /A safe change needs owner review\./);
-    assert.match(result.text, /Needs answer/);
-    assert.match(result.text, /Approval needed/);
-    assertPendingSurfaceHasNoActionsOrInternals(result.text);
-    for (const raw of ["pi_home_question", "pi_home_approval", "awaiting_user_input", "pending_approval", "codex_approval"]) {
+    assert.deepEqual(calls, []);
+    assert.match(result.text, /Approval required/);
+    assert.match(result.text, /Run tests/);
+    assert.match(result.text, /Modify config/);
+    for (const raw of ["pi_home_question", "pi_home_approval", "awaiting_user_input", "pending_approval", "codex_approval", "Codex needs a product decision.", "A safe change needs owner review."]) {
       assert.equal(result.text.includes(raw), false, `home leaked raw pending value ${raw}: ${result.text}`);
     }
   });
 });
-
 
 test("authenticated conversation detail route uses only opaque handles and keeps security headers", async () => {
   const calls: string[] = [];
@@ -738,16 +725,23 @@ test("conversation detail pending panel shares read-only pending cards and actio
   });
 });
 
-test("phase B pages expose disabled composer posture without enabled write controls", async () => {
+
+test("phase B pages expose disabled/product composer posture without enabled write submissions", async () => {
   const calls: string[] = [];
   await withServer({ provider: makeProvider(calls), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     for (const path of ["/", "/chat", "/conversations/cv_1234567890abcdef"]) {
       const result = await get(`${baseUrl}${path}`, token);
       assert.equal(result.status, 200, path);
-      assert.match(result.text, /Sending from Web is landing next/);
-      assert.match(result.text, /aria-readonly="true" aria-disabled="true"/);
-      for (const forbidden of ["<form", "<button", "<input", "<textarea", "method=\"post\"", "action=", "/messages"]) {
-        assert.equal(result.text.toLowerCase().includes(forbidden), false, `${path} exposed write control ${forbidden}: ${result.text}`);
+      assert.match(result.text, /aria-readonly="true"/);
+      if (path.startsWith("/conversations/")) {
+        assert.match(result.text, /Sending from Web is landing next/);
+        assert.match(result.text, /aria-disabled="true"/);
+      } else {
+        assert.match(result.text, /Message Codex or type \//);
+        assert.match(result.text, /console-composer/);
+      }
+      for (const forbidden of ["<form", "<textarea", "method=\"post\"", "action=", "/messages"]) {
+        assert.equal(result.text.toLowerCase().includes(forbidden), false, `${path} exposed write submission ${forbidden}: ${result.text}`);
       }
     }
   });
@@ -939,7 +933,8 @@ test("POST message maps blocked, missing, archived, or unavailable submit outcom
   }
 });
 
-test("home recent conversations use user-language state groups and copy", async () => {
+
+test("home recent live conversations are not rendered into fake-data product prototype", async () => {
   const calls: string[] = [];
   const rows: WebReadonlyConversationRow[] = [
     conversationFixture("cv_aaaaaaaaaaaaaaaa", "Answer product question", "pending_question", false),
@@ -958,27 +953,11 @@ test("home recent conversations use user-language state groups and copy", async 
   }, async (baseUrl) => {
     const result = await get(`${baseUrl}/`, token);
     assert.equal(result.status, 200);
-    assert.deepEqual(calls, ["home"]);
-    for (const heading of ["Needs attention", "Running now", "Recently completed", "Other/Older"]) {
-      assert.match(result.text, new RegExp(`<h3>${heading}</h3>`), `missing grouped heading ${heading}: ${result.text}`);
-    }
-    for (const label of ["Needs answer", "Approval needed", "Blocked", "Running", "Done", "Failed", "Degraded", "Unavailable"]) {
-      assert.match(result.text, new RegExp(`class="console-badge">${label}</span>`), `missing label ${label}: ${result.text}`);
-    }
-    for (const copy of [
-      "Codex asked a question; the answer lane is read-only until enabled.",
-      "Codex requested an approval; the approval lane is read-only until enabled.",
-      "Progress is stopped until required owner interaction is resolved.",
-      "Codex is working; result will appear here when complete.",
-      "Completion metadata or a final result is available.",
-      "The task ended without a usable final result in this preview.",
-      "State is partial, stale, or missing a safe source.",
-      "The current state is unavailable or unknown from the safe reader."
-    ]) {
-      assert.match(result.text, new RegExp(escapeRegExp(copy)), `missing copy ${copy}: ${result.text}`);
-    }
-    for (const raw of ["pending_question", "pending_approval", "source_unknown"]) {
-      assert.equal(result.text.includes(raw), false, `raw state leaked ${raw}: ${result.text}`);
+    assert.deepEqual(calls, []);
+    assert.match(result.text, /Refactor auth middleware/);
+    assert.match(result.text, /Approval required/);
+    for (const raw of ["pending_question", "pending_approval", "source_unknown", "Answer product question", "Approve safe change", "cv_aaaaaaaaaaaaaaaa"]) {
+      assert.equal(result.text.includes(raw), false, `live conversation value leaked ${raw}: ${result.text}`);
     }
   });
 });
@@ -1176,18 +1155,27 @@ test("state responses include no-store, CSP, nosniff, and HTML charset headers",
   });
 });
 
+
 test("unknown route and provider error are generic without stack traces", async () => {
   const calls: string[] = [];
-  await withServer({ provider: makeProvider(calls, { throwOnHome: true }), access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
+  const provider = {
+    ...makeProvider(calls),
+    getRuntimeContextViewModel() {
+      calls.push("runtime");
+      throw new Error("boom stack secret /tmp/secret-store messageId=123");
+    }
+  };
+  await withServer({ provider, access: createReadonlyAccessGate({ enabled: true, token }) }, async (baseUrl) => {
     const unknown = await get(`${baseUrl}/unknown`, token);
     assert.equal(unknown.status, 404);
     assert.match(unknown.text, /Not found/);
     assert.deepEqual(calls, []);
 
-    const errored = await get(`${baseUrl}/`, token);
+    const errored = await get(`${baseUrl}/runtime`, token);
     assert.equal(errored.status, 500);
+    assert.deepEqual(calls, ["runtime"]);
     assert.match(errored.text, /Temporarily unavailable/);
-    for (const forbidden of ["boom", "secret", "/tmp/secret-store", "messageId", "Error:", " at "]) {
+    for (const forbidden of ["boom", "secret", "/tmp/secret-store", "messageId", "Error:"]) {
       assert.equal(errored.text.includes(forbidden), false, `error leaked ${forbidden}: ${errored.text}`);
     }
   });

--- a/src/web/readonly-http-server.test.ts
+++ b/src/web/readonly-http-server.test.ts
@@ -909,6 +909,76 @@ test("Console API send wiring is disabled without Web submit dependency and live
   });
 });
 
+test("authenticated API product home enables composer only when live Console send route is available", async () => {
+  const disabledCalls: string[] = [];
+  await withServer({
+    provider: makeProvider(disabledCalls),
+    access: createReadonlyAccessGate({ enabled: true, token })
+  }, async (baseUrl) => {
+    const result = await get(`${baseUrl}/`, token);
+    assert.equal(result.status, 200);
+    assert.match(result.text, /data-console-source="api"/);
+    assert.match(result.text, /data-capability-send-message="disabled"/);
+    assert.match(result.text, /Message unavailable from Web/);
+    assert.match(result.text, /Console Bridge read adapter is read-only in this phase\./);
+    assert.doesNotMatch(result.text, /data-console-send-form/);
+    assert.doesNotMatch(result.text, /\/api\/sessions\/[^"]+\/messages/);
+  });
+
+  const submitted: unknown[] = [];
+  await withServer({
+    provider: makeProvider([]),
+    access: createReadonlyAccessGate({ enabled: true, token }),
+    send: {
+      csrfToken: "csrf-safe-token",
+      submitTextMessage: (request) => {
+        submitted.push(request);
+        return { status: "accepted" };
+      }
+    }
+  }, async (baseUrl) => {
+    const home = await get(`${baseUrl}/`, token);
+    assert.equal(home.status, 200);
+    assert.match(home.text, /data-console-source="api"/);
+    assert.match(home.text, /<form class="console-composer"[^>]*data-console-send-form/);
+    assert.match(home.text, /data-capability-send-message="enabled"/);
+    assert.match(home.text, /name="_csrf" value="csrf-safe-token"/);
+    const action = /action="(\/api\/sessions\/(ses_[A-Za-z0-9_-]{6,128})\/messages)"/.exec(home.text);
+    assert.ok(action, `missing opaque API send action: ${home.text}`);
+    assert.doesNotMatch(home.text, /Message unavailable from Web/);
+    for (const disabledControl of [
+      'class="console-project-action-archive"[^>]*data-capability-state="disabled"',
+      'class="console-project-action-new-session"[^>]*data-capability-state="disabled"',
+      'Review unavailable',
+      'Open files unavailable'
+    ]) {
+      assert.match(home.text, new RegExp(disabledControl), `missing disabled control ${disabledControl}: ${home.text}`);
+    }
+    for (const forbidden of ["cv_1234567890abcdef", "wk_safe_1", token, "token=", "callback_data", "messageId", "/tmp/", "/home/", "telegram", "http://127.0.0.1"]) {
+      assert.equal(home.text.includes(forbidden), false, `home leaked ${forbidden}: ${home.text}`);
+    }
+
+    const posted = await post(`${baseUrl}${action[1]}`, token, JSON.stringify({ text: " hello from home " }), {
+      "Content-Type": "application/json",
+      "X-CSRF-Token": "csrf-safe-token",
+      Accept: "application/json"
+    });
+    assert.equal(posted.status, 202);
+    const body = JSON.parse(posted.text);
+    assert.equal(body.accepted, true);
+    assert.equal(body.sessionId, action[2]);
+    assert.equal(body.message.text, "hello from home");
+    assert.deepEqual(submitted, [{
+      conversationHandle: "cv_1234567890abcdef",
+      text: "hello from home",
+      nonce: null
+    }]);
+    for (const forbidden of ["cv_1234567890abcdef", "wk_safe_1", token, "token=", "callback_data", "/tmp/", "/home/", "telegram"]) {
+      assert.equal(posted.text.includes(forbidden), false, `send response leaked ${forbidden}: ${posted.text}`);
+    }
+  });
+});
+
 test("POST message denies unauthorized, CSRF-denied, invalid handle, blank, and oversize without submit", async () => {
   const calls: string[] = [];
   const submitted: unknown[] = [];

--- a/src/web/readonly-http-server.ts
+++ b/src/web/readonly-http-server.ts
@@ -5,6 +5,7 @@ import type { WebReadonlyViewModelProvider } from "../service/web-readonly-view-
 import { createConsoleBridgeReadAdapter, type ConsoleBridgeReadAdapter } from "./console-bridge-read-adapter.js";
 import { handleConsoleApiHttpRequest, isConsoleApiPath, sendConsoleApiDenied, type ConsoleApiWriteAdapter } from "./console-api-http.js";
 import { createConsoleLiveWriteAdapter } from "./console-live-write-adapter.js";
+import type { ConsoleCapabilities } from "./console-api-contract.js";
 import type { ReadonlyAccessGate } from "./readonly-access.js";
 import {
   renderConversationResultPage,
@@ -94,13 +95,7 @@ async function handleRequest(
 
     if (apiPath) {
       const consoleReadAdapter = options.consoleReadAdapter ?? createConsoleBridgeReadAdapter({ provider: options.provider });
-      const consoleWriteAdapter = options.consoleWriteAdapter
-        ?? (options.send && hasConsoleSessionHandleResolver(consoleReadAdapter)
-          ? createConsoleLiveWriteAdapter({
-            readAdapter: consoleReadAdapter,
-            submitTextMessage: options.send.submitTextMessage
-          })
-          : undefined);
+      const consoleWriteAdapter = writeAdapterFor(options, consoleReadAdapter);
       const apiOptions = {
         provider: options.provider,
         adapter: consoleReadAdapter,
@@ -182,11 +177,15 @@ function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider, 
 
   if (pathname === "/" || pathname === "/chat") {
     const consoleReadAdapter = options.consoleReadAdapter ?? createConsoleBridgeReadAdapter({ provider });
+    const consoleWriteAdapter = writeAdapterFor(options, consoleReadAdapter);
+    const csrfToken = options.send ? currentCsrfToken(options.send) : null;
+    const capabilityOverrides = consoleWriteAdapter ? writeCapabilityOverrides(consoleWriteAdapter, csrfToken) : undefined;
     return {
       status: 200,
       html: renderHomePage(undefined, {
         adapter: consoleReadAdapter,
-        csrfToken: options.send ? currentCsrfToken(options.send) : null
+        csrfToken,
+        ...(capabilityOverrides ? { capabilities: capabilityOverrides } : {})
       })
     };
   }
@@ -240,6 +239,36 @@ function renderOptions(options: ReadonlyHttpServerOptions, flashStatus: WebPostR
 
 function sendEnabled(options: ReadonlyHttpServerOptions): boolean {
   return Boolean(options.send?.submitTextMessage && currentCsrfToken(options.send));
+}
+
+function writeAdapterFor(
+  options: ReadonlyHttpServerOptions,
+  consoleReadAdapter: ConsoleBridgeReadAdapter
+): ConsoleApiWriteAdapter | undefined {
+  return options.consoleWriteAdapter
+    ?? (options.send && hasConsoleSessionHandleResolver(consoleReadAdapter)
+      ? createConsoleLiveWriteAdapter({
+        readAdapter: consoleReadAdapter,
+        submitTextMessage: options.send.submitTextMessage
+      })
+      : undefined);
+}
+
+function writeCapabilityOverrides(
+  writeAdapter: ConsoleApiWriteAdapter,
+  csrfToken: string | null
+): Partial<Pick<ConsoleCapabilities, "sendMessage">> {
+  const advertised = writeAdapter.capabilities?.sendMessage;
+  if (!writeAdapter.sendMessage) {
+    return { sendMessage: { state: "disabled", reason: "Console write capability is disabled." } };
+  }
+  if (advertised?.state === "disabled") {
+    return { sendMessage: advertised };
+  }
+  if (!csrfToken) {
+    return { sendMessage: { state: "disabled", reason: "Console write capability requires CSRF protection." } };
+  }
+  return { sendMessage: advertised ?? { state: "enabled" } };
 }
 
 function currentCsrfToken(send: WebMessageSendOptions): string | null {

--- a/src/web/readonly-http-server.ts
+++ b/src/web/readonly-http-server.ts
@@ -2,8 +2,9 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { createHash } from "node:crypto";
 
 import type { WebReadonlyViewModelProvider } from "../service/web-readonly-view-model.js";
-import type { ConsoleBridgeReadAdapter } from "./console-bridge-read-adapter.js";
+import { createConsoleBridgeReadAdapter, type ConsoleBridgeReadAdapter } from "./console-bridge-read-adapter.js";
 import { handleConsoleApiHttpRequest, isConsoleApiPath, sendConsoleApiDenied, type ConsoleApiWriteAdapter } from "./console-api-http.js";
+import { createConsoleLiveWriteAdapter } from "./console-live-write-adapter.js";
 import type { ReadonlyAccessGate } from "./readonly-access.js";
 import {
   renderConversationResultPage,
@@ -84,14 +85,24 @@ async function handleRequest(
       return send(response, 404, renderGenericNotFoundPage(), request.method === "HEAD");
     }
 
-    const apiOptions = {
-      provider: options.provider,
-      ...(options.consoleReadAdapter ? { adapter: options.consoleReadAdapter } : {}),
-      ...(options.consoleWriteAdapter ? { writeAdapter: options.consoleWriteAdapter } : {}),
-      ...(options.send ? { csrfToken: () => currentCsrfToken(options.send!) } : {})
-    };
-    if (apiPath && handleConsoleApiHttpRequest(apiOptions, request, response)) {
-      return;
+    if (apiPath) {
+      const consoleReadAdapter = options.consoleReadAdapter ?? createConsoleBridgeReadAdapter({ provider: options.provider });
+      const consoleWriteAdapter = options.consoleWriteAdapter
+        ?? (options.send && hasConsoleSessionHandleResolver(consoleReadAdapter)
+          ? createConsoleLiveWriteAdapter({
+            readAdapter: consoleReadAdapter,
+            submitTextMessage: options.send.submitTextMessage
+          })
+          : undefined);
+      const apiOptions = {
+        provider: options.provider,
+        adapter: consoleReadAdapter,
+        ...(consoleWriteAdapter ? { writeAdapter: consoleWriteAdapter } : {}),
+        ...(options.send ? { csrfToken: () => currentCsrfToken(options.send!) } : {})
+      };
+      if (handleConsoleApiHttpRequest(apiOptions, request, response)) {
+        return;
+      }
     }
 
     if (request.method === "POST") {
@@ -141,6 +152,14 @@ async function handlePost(
   } catch {
     return sendPostOutcome(response, conversationMatch[1], "unavailable", wantsJson);
   }
+}
+
+function hasConsoleSessionHandleResolver(
+  adapter: ConsoleBridgeReadAdapter
+): adapter is ConsoleBridgeReadAdapter & {
+  resolveConversationHandleForSession: NonNullable<ConsoleBridgeReadAdapter["resolveConversationHandleForSession"]>;
+} {
+  return typeof adapter.resolveConversationHandleForSession === "function";
 }
 
 function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider, options: ReadonlyHttpServerOptions): RouteResult {

--- a/src/web/readonly-http-server.ts
+++ b/src/web/readonly-http-server.ts
@@ -137,7 +137,7 @@ function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider, 
   }
 
   if (pathname === "/" || pathname === "/chat") {
-    return { status: 200, html: renderHomePage(provider.getHomeViewModel(), renderOptions(options)) };
+    return { status: 200, html: renderHomePage() };
   }
   if (pathname === "/readiness") {
     return { status: 200, html: renderReadinessPage(provider.getReadinessGuardrailViewModel()) };

--- a/src/web/readonly-http-server.ts
+++ b/src/web/readonly-http-server.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 
 import type { WebReadonlyViewModelProvider } from "../service/web-readonly-view-model.js";
 import type { ConsoleBridgeReadAdapter } from "./console-bridge-read-adapter.js";
-import { handleConsoleApiHttpRequest, isConsoleApiPath, sendConsoleApiDenied } from "./console-api-http.js";
+import { handleConsoleApiHttpRequest, isConsoleApiPath, sendConsoleApiDenied, type ConsoleApiWriteAdapter } from "./console-api-http.js";
 import type { ReadonlyAccessGate } from "./readonly-access.js";
 import {
   renderConversationResultPage,
@@ -22,6 +22,7 @@ export interface ReadonlyHttpServerOptions {
   provider: WebReadonlyViewModelProvider;
   access: ReadonlyAccessGate;
   consoleReadAdapter?: ConsoleBridgeReadAdapter;
+  consoleWriteAdapter?: ConsoleApiWriteAdapter;
   send?: WebMessageSendOptions;
 }
 
@@ -83,9 +84,12 @@ async function handleRequest(
       return send(response, 404, renderGenericNotFoundPage(), request.method === "HEAD");
     }
 
-    const apiOptions = options.consoleReadAdapter
-      ? { provider: options.provider, adapter: options.consoleReadAdapter }
-      : { provider: options.provider };
+    const apiOptions = {
+      provider: options.provider,
+      ...(options.consoleReadAdapter ? { adapter: options.consoleReadAdapter } : {}),
+      ...(options.consoleWriteAdapter ? { writeAdapter: options.consoleWriteAdapter } : {}),
+      ...(options.send ? { csrfToken: () => currentCsrfToken(options.send!) } : {})
+    };
     if (apiPath && handleConsoleApiHttpRequest(apiOptions, request, response)) {
       return;
     }

--- a/src/web/readonly-http-server.ts
+++ b/src/web/readonly-http-server.ts
@@ -18,6 +18,7 @@ import {
   renderWorkspaceListPage,
   APP_CSS
 } from "./readonly-renderer.js";
+import { CONSOLE_PRODUCT_SCRIPT } from "./console-product-renderer.js";
 
 export interface ReadonlyHttpServerOptions {
   provider: WebReadonlyViewModelProvider;
@@ -56,13 +57,19 @@ const SECURITY_HEADERS = {
   "Content-Type": "text/html; charset=utf-8"
 } as const;
 
-const WRITE_SECURITY_HEADERS = {
+const API_PRODUCT_SECURITY_HEADERS = {
   ...SECURITY_HEADERS,
-  "Content-Security-Policy": `default-src 'none'; style-src 'sha256-${styleHash()}'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'`
+  "Content-Security-Policy": `default-src 'none'; style-src 'sha256-${styleHash()}'; script-src 'sha256-${productScriptHash()}'; connect-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'`
 } as const;
+
+const WRITE_SECURITY_HEADERS = API_PRODUCT_SECURITY_HEADERS;
 
 function styleHash(): string {
   return createHash("sha256").update(`\n${APP_CSS}\n`).digest("base64");
+}
+
+function productScriptHash(): string {
+  return createHash("sha256").update(`\n${CONSOLE_PRODUCT_SCRIPT}\n`).digest("base64");
 }
 
 export function createReadonlyHttpServer(options: ReadonlyHttpServerOptions): Server {
@@ -174,7 +181,14 @@ function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider, 
   }
 
   if (pathname === "/" || pathname === "/chat") {
-    return { status: 200, html: renderHomePage() };
+    const consoleReadAdapter = options.consoleReadAdapter ?? createConsoleBridgeReadAdapter({ provider });
+    return {
+      status: 200,
+      html: renderHomePage(undefined, {
+        adapter: consoleReadAdapter,
+        csrfToken: options.send ? currentCsrfToken(options.send) : null
+      })
+    };
   }
   if (pathname === "/readiness") {
     return { status: 200, html: renderReadinessPage(provider.getReadinessGuardrailViewModel()) };
@@ -212,7 +226,7 @@ function resolveRoute(urlValue: string, provider: WebReadonlyViewModelProvider, 
 }
 
 function send(response: ServerResponse, status: number, html: string, headOnly: boolean, writeEnabled = false): void {
-  response.writeHead(status, writeEnabled ? WRITE_SECURITY_HEADERS : SECURITY_HEADERS);
+  response.writeHead(status, writeEnabled ? WRITE_SECURITY_HEADERS : html.includes('data-console-api-root="/api"') ? API_PRODUCT_SECURITY_HEADERS : SECURITY_HEADERS);
   response.end(headOnly ? undefined : html);
 }
 

--- a/src/web/readonly-http-server.ts
+++ b/src/web/readonly-http-server.ts
@@ -2,6 +2,8 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { createHash } from "node:crypto";
 
 import type { WebReadonlyViewModelProvider } from "../service/web-readonly-view-model.js";
+import type { ConsoleBridgeReadAdapter } from "./console-bridge-read-adapter.js";
+import { handleConsoleApiHttpRequest, isConsoleApiPath, sendConsoleApiDenied } from "./console-api-http.js";
 import type { ReadonlyAccessGate } from "./readonly-access.js";
 import {
   renderConversationResultPage,
@@ -19,6 +21,7 @@ import {
 export interface ReadonlyHttpServerOptions {
   provider: WebReadonlyViewModelProvider;
   access: ReadonlyAccessGate;
+  consoleReadAdapter?: ConsoleBridgeReadAdapter;
   send?: WebMessageSendOptions;
 }
 
@@ -72,8 +75,19 @@ async function handleRequest(
   response: ServerResponse
 ): Promise<void> {
   try {
+    const apiPath = isConsoleApiPath(request.url ?? "/");
     if (!options.access.authorize(request.headers)) {
+      if (apiPath) {
+        return sendConsoleApiDenied(response, request.method === "HEAD");
+      }
       return send(response, 404, renderGenericNotFoundPage(), request.method === "HEAD");
+    }
+
+    const apiOptions = options.consoleReadAdapter
+      ? { provider: options.provider, adapter: options.consoleReadAdapter }
+      : { provider: options.provider };
+    if (apiPath && handleConsoleApiHttpRequest(apiOptions, request, response)) {
+      return;
     }
 
     if (request.method === "POST") {

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -13,7 +13,11 @@ import type {
   WebReadonlyWorkspaceListViewModel,
   WebReadonlyWorkspaceRow
 } from "../service/web-readonly-view-model.js";
+import { createConsoleProductApiModel } from "./console-product-api-model.js";
 import { renderConsoleProductHomePage, CONSOLE_PRODUCT_CSS } from "./console-product-renderer.js";
+
+import type { ConsoleBridgeReadAdapter } from "./console-bridge-read-adapter.js";
+import type { ConsoleProjectId, ConsoleSessionSummary } from "./console-api-contract.js";
 
 interface SafeHtmlCell {
   __safeHtml: string;
@@ -32,10 +36,58 @@ export interface WebReadonlyRenderOptions {
   } | null;
 }
 
+export interface WebProductHomeRenderOptions {
+  adapter?: ConsoleBridgeReadAdapter;
+  csrfToken?: string | null;
+}
+
 type WebSendFlashStatus = "accepted" | "blocked" | "rejected" | "unavailable" | "invalid" | "denied";
 
-export function renderHomePage(_vm?: WebReadonlyHomeViewModel, _options: WebReadonlyRenderOptions = {}): string {
-  return renderConsoleProductHomePage(undefined, APP_CSS);
+export function renderHomePage(_vm?: WebReadonlyHomeViewModel, options: WebProductHomeRenderOptions = {}): string {
+  if (!options.adapter) {
+    return renderConsoleProductHomePage(undefined, APP_CSS);
+  }
+
+  try {
+    const bootstrap = options.adapter.getBootstrap();
+    const projects = options.adapter.listProjects();
+    const projectSessions = new Map<ConsoleProjectId, ConsoleSessionSummary[]>();
+    for (const project of projects) {
+      const sessions = options.adapter.listProjectSessions(project.projectId);
+      projectSessions.set(project.projectId, Array.isArray(sessions) ? sessions : []);
+    }
+    const activeProjectId = projects.some((project) => project.projectId === bootstrap.activeProjectId)
+      ? bootstrap.activeProjectId
+      : projects[0]?.projectId;
+    const activeSessionId = bootstrap.activeSessionId
+      ?? projects.find((project) => project.projectId === activeProjectId)?.activeSessionId
+      ?? Array.from(projectSessions.values()).flat().find((session) => !session.archived)?.sessionId;
+    const detail = activeSessionId ? options.adapter.getSessionDetail(activeSessionId) : null;
+    const activeSessionDetail = detail && !isConsoleApiErrorLike(detail) ? detail : null;
+    return renderConsoleProductHomePage(createConsoleProductApiModel({
+      bootstrap: {
+        ...bootstrap,
+        projects,
+        ...(activeProjectId ? { activeProjectId } : {}),
+        ...(activeSessionId ? { activeSessionId } : {})
+      },
+      projectSessions,
+      activeSessionDetail,
+      csrfToken: options.csrfToken ?? null
+    }), APP_CSS);
+  } catch {
+    return renderConsoleProductHomePage(undefined, APP_CSS);
+  }
+}
+
+function isConsoleApiErrorLike(value: unknown): value is { code: string; message: string; retryable: boolean } {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    typeof (value as { code?: unknown }).code === "string" &&
+    typeof (value as { message?: unknown }).message === "string" &&
+    typeof (value as { retryable?: unknown }).retryable === "boolean"
+  );
 }
 
 export function renderWorkspaceListPage(vm: WebReadonlyWorkspaceListViewModel): string {

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -17,7 +17,7 @@ import { createConsoleProductApiModel } from "./console-product-api-model.js";
 import { renderConsoleProductHomePage, CONSOLE_PRODUCT_CSS } from "./console-product-renderer.js";
 
 import type { ConsoleBridgeReadAdapter } from "./console-bridge-read-adapter.js";
-import type { ConsoleProjectId, ConsoleSessionSummary } from "./console-api-contract.js";
+import type { ConsoleCapabilities, ConsoleProjectId, ConsoleSessionSummary } from "./console-api-contract.js";
 
 interface SafeHtmlCell {
   __safeHtml: string;
@@ -39,6 +39,7 @@ export interface WebReadonlyRenderOptions {
 export interface WebProductHomeRenderOptions {
   adapter?: ConsoleBridgeReadAdapter;
   csrfToken?: string | null;
+  capabilities?: Partial<Pick<ConsoleCapabilities, "sendMessage">>;
 }
 
 type WebSendFlashStatus = "accepted" | "blocked" | "rejected" | "unavailable" | "invalid" | "denied";
@@ -64,7 +65,7 @@ export function renderHomePage(_vm?: WebReadonlyHomeViewModel, options: WebProdu
       ?? Array.from(projectSessions.values()).flat().find((session) => !session.archived)?.sessionId;
     const detail = activeSessionId ? options.adapter.getSessionDetail(activeSessionId) : null;
     const activeSessionDetail = detail && !isConsoleApiErrorLike(detail) ? detail : null;
-    return renderConsoleProductHomePage(createConsoleProductApiModel({
+    const modelInput = {
       bootstrap: {
         ...bootstrap,
         projects,
@@ -73,8 +74,10 @@ export function renderHomePage(_vm?: WebReadonlyHomeViewModel, options: WebProdu
       },
       projectSessions,
       activeSessionDetail,
-      csrfToken: options.csrfToken ?? null
-    }), APP_CSS);
+      csrfToken: options.csrfToken ?? null,
+      ...(options.capabilities ? { capabilityOverrides: options.capabilities } : {})
+    };
+    return renderConsoleProductHomePage(createConsoleProductApiModel(modelInput), APP_CSS);
   } catch {
     return renderConsoleProductHomePage(undefined, APP_CSS);
   }

--- a/src/web/readonly-renderer.ts
+++ b/src/web/readonly-renderer.ts
@@ -13,6 +13,7 @@ import type {
   WebReadonlyWorkspaceListViewModel,
   WebReadonlyWorkspaceRow
 } from "../service/web-readonly-view-model.js";
+import { renderConsoleProductHomePage, CONSOLE_PRODUCT_CSS } from "./console-product-renderer.js";
 
 interface SafeHtmlCell {
   __safeHtml: string;
@@ -33,41 +34,8 @@ export interface WebReadonlyRenderOptions {
 
 type WebSendFlashStatus = "accepted" | "blocked" | "rejected" | "unavailable" | "invalid" | "denied";
 
-export function renderHomePage(vm: WebReadonlyHomeViewModel, options: WebReadonlyRenderOptions = {}): string {
-  const resultRows = vm.recentConversations.filter((row) => row.finalAnswerAvailable || conversationGroup(row.status) === "completed");
-  const sendReady = Boolean(options.send?.csrfToken);
-  return page("Web Chat", "home", [
-    hero(
-      "Web Chat",
-      sendReady
-        ? "Conversation work queue for Codex Bridge. Send text from the browser and refresh the thread to watch runtime and result state."
-        : "Conversation work queue for Codex Bridge. Sending from Web is landing next; this slice is a safe read-only thread view."
-    ),
-    chatHomeSection(vm, options),
-    homeOwnerAttentionSection(vm.pendingInteractions.state, vm.pendingInteractions.pendingInteractions),
-    cardListSection(
-      "home-active-attention",
-      "Runtime summary",
-      vm.runtime.activeTurns,
-      (row) => runtimeTurnCard(row),
-      "No active work needs attention right now."
-    ),
-    conversationListSection(
-      "home-recent-results",
-      "Recent results and artifacts",
-      resultRows,
-      "Recent results will appear here after Codex finishes work."
-    ),
-    cardListSection(
-      "home-workspaces",
-      "Projects / workspaces",
-      vm.workspaces,
-      (row) => workspaceCard(row),
-      "Projects and workspaces will appear here once the bridge has recent workspace history."
-    ),
-    utilityLinksPanel(),
-    vm.warnings.length > 0 ? warnings(vm.warnings) : ""
-  ]);
+export function renderHomePage(_vm?: WebReadonlyHomeViewModel, _options: WebReadonlyRenderOptions = {}): string {
+  return renderConsoleProductHomePage(undefined, APP_CSS);
 }
 
 export function renderWorkspaceListPage(vm: WebReadonlyWorkspaceListViewModel): string {
@@ -254,7 +222,8 @@ function page(title: string, active: NavKey, sections: string[]): string {
   ].join("\n");
 }
 
-export const APP_CSS = `
+export const APP_CSS = `${CONSOLE_PRODUCT_CSS}
+
 :root {
   color-scheme: light;
   --console-bg: #f4f7fb;


### PR DESCRIPTION
## Summary

Rebuilds Codex Console Web UI from scratch into an API-backed, owner-usable Web app surface.

Highlights:
- Mobile-first and desktop three-pane product shell
- Left Project drawer/sidebar with Session children and Archive/+ New affordances
- Chat-first center panel with model/mode controls and command shortcuts
- Right inspector for task/files/activity/approvals
- Product-shaped Console API contract with opaque IDs and payload safety
- Token-gated Console read API routes
- Gated write API routes, disabled by default
- Live text send wired through the existing safe Web/Bridge submit seam
- Authenticated `/` and `/chat` now render API-backed data and enable the send composer only when real live send + CSRF + resolver are available

Deferred intentionally:
- Archive project
- Create new session
- Approval answer/review
- Uploads/attachments
- Artifact open/fetch UI
- Stream events/session actions/interrupts

## Verification

Controller reran:
- `node --import tsx --test src/web/readonly-http-server.test.ts`
- `node --import tsx --test src/web/console-product-api-model.test.ts`
- `node --import tsx --test src/web/console-product-renderer.test.ts`
- `node --import tsx --test src/web/console-api-http.test.ts`
- `node --import tsx --test src/web/console-live-write-adapter.test.ts`
- `node --import tsx --test src/service-web-submit.test.ts`
- `node --import tsx --test src/web/console-bridge-read-adapter.test.ts`
- `node --import tsx --test src/web/console-api-contract.test.ts`
- `npm run check`
- `git diff --check`
- `npm run build`
- `npm run web:preview:smoke`

Public owner preview smoke:
- Login page opens
- Authenticated Home 200
- `/interactions` 200
- Conversation detail 200
- Direct readonly upstream unauthenticated denial verified
- Home contains API-backed product shell and enabled send composer when live send is available

Preview URL: https://codex.guicheng.xyz
