### PR TITLE
Send final answers as native Telegram rich messages

### DIFF
--- a/docs/product/runtime-and-delivery.md
+++ b/docs/product/runtime-and-delivery.md
@@ -131,8 +131,10 @@ Rules:
 
 Final-answer handling:
 - send the final assistant answer as a separate Telegram message after the turn finishes
-- render the final assistant answer with Telegram formatting rather than exposing raw Markdown markers
-- if the answer is long enough to harm chat readability, send a collapsed preview with an inline `展开全文` button
+- prefer Telegram's native rich-message Markdown route for final answers and plan results that fit the 32,768-character rich-message limit
+- pass Markdown tables through unchanged so supported Telegram clients render them as native rich tables
+- if native rich-message delivery is unavailable, rejected, or over the rich-message limit, fall back to the existing Telegram-safe HTML renderer
+- when the HTML fallback is long enough to harm chat readability, send a collapsed preview with an inline `展开全文` button
 - keep long final answers on a single bridge-owned message by editing that message for `展开全文`, `收起`, and page navigation
 - persist collapsed previews plus rendered pages locally so final-answer buttons still work after bridge restart
 - if an expanded final answer still exceeds Telegram single-message size, page through the rendered HTML instead of sending a cascade of long continuation messages

--- a/src/packs/contract.ts
+++ b/src/packs/contract.ts
@@ -45,6 +45,15 @@ export interface EgressSendMessageOptions {
   parseMode?: "HTML" | null;
 }
 
+export interface EgressRichMessage {
+  markdown?: string;
+  html?: string;
+  blocks?: unknown[];
+  media?: unknown[];
+  isRtl?: boolean;
+  skipEntityDetection?: boolean;
+}
+
 export interface EgressSendPhotoOptions {
   caption?: string;
   parseMode?: "HTML";
@@ -60,6 +69,11 @@ export interface PlatformEgressAdapter {
   readonly kind: "bot_api" | "open_api";
 
   sendMessage(chatId: string, text: string, options?: EgressSendMessageOptions): Promise<EgressMessageSendResult>;
+  sendRichMessage?(
+    chatId: string,
+    richMessage: EgressRichMessage,
+    options?: Pick<EgressSendMessageOptions, "replyMarkup">
+  ): Promise<EgressMessageSendResult>;
   sendPhoto(chatId: string, photoPath: string, options?: EgressSendPhotoOptions): Promise<EgressMessageSendResult>;
   sendDocument(chatId: string, filePath: string, options?: EgressSendDocumentOptions): Promise<EgressMessageSendResult>;
   editMessageText(chatId: string, messageId: number, text: string, options?: EgressSendMessageOptions): Promise<EgressEditResult>;

--- a/src/service.ts
+++ b/src/service.ts
@@ -529,6 +529,8 @@ export class BridgeService {
       })),
       safeSendHtmlMessageResult: async (chatId, html, replyMarkup) =>
         this.safeSendHtmlMessageResult(chatId, html, replyMarkup),
+      safeSendRichMarkdownMessageResult: async (chatId, markdown, replyMarkup) =>
+        this.safeSendRichMarkdownMessageResult(chatId, markdown, replyMarkup),
       handleGlobalRuntimeNotice: async (notification) => this.runtimeNoticeBroadcaster.broadcast(notification),
       handleThreadArchiveNotification: async (classified) => this.threadArchiveReconciler.handleNotification(classified)
     });
@@ -3686,6 +3688,14 @@ export class BridgeService {
     replyMarkup?: TelegramInlineKeyboardMarkup
   ): Promise<EgressMessageSendResult | null> {
     return this.getSafeMessenger()?.sendHtmlMessageResult(chatId, html, replyMarkup) ?? null;
+  }
+
+  private async safeSendRichMarkdownMessageResult(
+    chatId: string,
+    markdown: string,
+    replyMarkup?: TelegramInlineKeyboardMarkup
+  ): Promise<EgressMessageSendResult | null> {
+    return this.getSafeMessenger()?.sendRichMarkdownMessageResult(chatId, markdown, replyMarkup) ?? null;
   }
 
   private async safeSendPhoto(

--- a/src/service/safe-messenger.ts
+++ b/src/service/safe-messenger.ts
@@ -155,6 +155,51 @@ export class SafeMessenger {
     });
   }
 
+  async sendRichMarkdownMessageResult(
+    chatId: string,
+    markdown: string,
+    replyMarkup?: unknown
+  ): Promise<EgressMessageSendResult | null> {
+    if (typeof this.egress.sendRichMessage !== "function") {
+      return null;
+    }
+
+    let lastError: unknown = null;
+    for (let attempt = 0; attempt <= TELEGRAM_SEND_RETRY_DELAYS_MS.length; attempt += 1) {
+      try {
+        const sent = await this.egress.sendRichMessage(
+          chatId,
+          { markdown },
+          replyMarkup !== undefined ? { replyMarkup } : undefined
+        );
+        await this.logger.info("rich markdown message sent", {
+          chatId,
+          messageId: sent.messageId,
+          replyMarkup: replyMarkup !== undefined ? "present" : null,
+          preview: summarizeTextPreview(markdown),
+          attempts: attempt + 1
+        });
+        return sent;
+      } catch (error) {
+        lastError = error;
+        const retryDelayMs = getTelegramSendRetryDelayMs(error, attempt);
+        if (retryDelayMs === null) {
+          break;
+        }
+        await this.logger.warn("rich markdown delivery retry scheduled", {
+          chatId,
+          attempt: attempt + 1,
+          retryDelayMs,
+          error: `${error}`
+        });
+        await this.sleep(retryDelayMs);
+      }
+    }
+
+    await this.logger.error("rich markdown delivery failed", { chatId, error: `${lastError}` });
+    return null;
+  }
+
   async editMessageText(
     chatId: string,
     messageId: number,

--- a/src/service/turn-coordinator.test.ts
+++ b/src/service/turn-coordinator.test.ts
@@ -74,6 +74,13 @@ async function createCoordinatorContext(options: {
       inline_keyboard: Array<Array<{ text: string; callback_data: string }>>;
     }
   ) => Promise<EgressMessageSendResult | null>;
+  safeSendRichMarkdownMessageResult?: (
+    chatId: string,
+    markdown: string,
+    replyMarkup?: {
+      inline_keyboard: Array<Array<{ text: string; callback_data: string }>>;
+    }
+  ) => Promise<EgressMessageSendResult | null>;
   sendControlSurfaceFile?: (
     chatId: string,
     filePath: string,
@@ -131,6 +138,13 @@ async function createCoordinatorContext(options: {
   const sentHtmlMessages: Array<{
     chatId: string;
     html: string;
+    replyMarkup?: {
+      inline_keyboard: Array<Array<{ text: string; callback_data: string }>>;
+    };
+  }> = [];
+  const sentRichMessages: Array<{
+    chatId: string;
+    markdown: string;
     replyMarkup?: {
       inline_keyboard: Array<Array<{ text: string; callback_data: string }>>;
     };
@@ -267,6 +281,17 @@ async function createCoordinatorContext(options: {
       sentHtmlMessages.push(replyMarkup ? { chatId, html, replyMarkup } : { chatId, html });
       return { messageId: nextMessageId++ };
     },
+    ...(options.safeSendRichMarkdownMessageResult
+      ? {
+          safeSendRichMarkdownMessageResult: async (chatId, markdown, replyMarkup) => {
+            const sent = await options.safeSendRichMarkdownMessageResult?.(chatId, markdown, replyMarkup) ?? null;
+            if (sent) {
+              sentRichMessages.push(replyMarkup ? { chatId, markdown, replyMarkup } : { chatId, markdown });
+            }
+            return sent;
+          }
+        }
+      : {}),
     handleGlobalRuntimeNotice: async () => {},
     handleThreadArchiveNotification: async () => {}
   });
@@ -280,6 +305,7 @@ async function createCoordinatorContext(options: {
     sentDocuments,
     sentImages,
     sentHtmlMessages,
+    sentRichMessages,
     interactionResolutions,
     acceptedTurnStartReanchors,
     currentSessionCardSyncs,
@@ -821,6 +847,89 @@ test("TurnCoordinator completes a normal turn and delivers the recovered final a
     assert.deepEqual(finalizedHandoffs, [{ chatId: "chat-1", sessionId: session.sessionId }]);
     assert.equal(store.getSessionById(session.sessionId)?.status, "idle");
     assert.equal(store.getSessionById(session.sessionId)?.lastTurnId, "turn-1");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("TurnCoordinator prefers native rich Markdown for final answers", async () => {
+  const markdown = "| Worker | State |\n| --- | --- |\n| Delivery | Ready |";
+  const { coordinator, store, sentHtmlMessages, sentRichMessages, cleanup } = await createCoordinatorContext({
+    appServer: {
+      resumeThread: async () => ({
+        thread: {
+          id: "thread-rich",
+          turns: [{
+            id: "turn-rich",
+            items: [{ type: "agentMessage", phase: "final_answer", text: markdown }]
+          }]
+        }
+      })
+    },
+    safeSendRichMarkdownMessageResult: async () => ({ messageId: 91 })
+  });
+
+  try {
+    const session = store.createSession({
+      chatId: "chat-1",
+      projectName: "Project One",
+      projectPath: "/tmp/project-one"
+    });
+
+    await coordinator.beginActiveTurn("chat-1", session, "thread-rich", "turn-rich", "inProgress");
+    await coordinator.handleAppServerNotification("turn/completed", {
+      threadId: "thread-rich",
+      turnId: "turn-rich",
+      status: "completed"
+    });
+
+    assert.deepEqual(sentRichMessages, [{ chatId: "chat-1", markdown }]);
+    assert.equal(sentHtmlMessages.length, 0);
+    assert.equal(store.listFinalAnswerViews("chat-1")[0]?.deliveryMessageId, 91);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("TurnCoordinator falls back to HTML when native rich Markdown delivery fails", async () => {
+  const { coordinator, store, sentHtmlMessages, sentRichMessages, cleanup } = await createCoordinatorContext({
+    appServer: {
+      resumeThread: async () => ({
+        thread: {
+          id: "thread-rich-fallback",
+          turns: [{
+            id: "turn-rich-fallback",
+            items: [{ type: "agentMessage", phase: "final_answer", text: "Fallback answer" }]
+          }]
+        }
+      })
+    },
+    safeSendRichMarkdownMessageResult: async () => null
+  });
+
+  try {
+    const session = store.createSession({
+      chatId: "chat-1",
+      projectName: "Project One",
+      projectPath: "/tmp/project-one"
+    });
+
+    await coordinator.beginActiveTurn(
+      "chat-1",
+      session,
+      "thread-rich-fallback",
+      "turn-rich-fallback",
+      "inProgress"
+    );
+    await coordinator.handleAppServerNotification("turn/completed", {
+      threadId: "thread-rich-fallback",
+      turnId: "turn-rich-fallback",
+      status: "completed"
+    });
+
+    assert.equal(sentRichMessages.length, 0);
+    assert.equal(sentHtmlMessages.length, 1);
+    assert.match(sentHtmlMessages[0]?.html ?? "", /Fallback answer/u);
   } finally {
     await cleanup();
   }
@@ -1688,6 +1797,50 @@ test("TurnCoordinator completes plan-mode turns by sending a plan result with im
     assert.equal(views[0]?.deliveryState, "visible");
     assert.deepEqual(reanchorReasons, []);
     assert.deepEqual(finalizedHandoffs, [{ chatId: "chat-1", sessionId: session.sessionId }]);
+  } finally {
+    await cleanup();
+  }
+});
+
+test("TurnCoordinator sends plan results as native rich Markdown with implementation actions", async () => {
+  const planMarkdown = "## Plan\n\n| Step | State |\n| --- | --- |\n| Ship | Ready |";
+  const { coordinator, store, sentHtmlMessages, sentRichMessages, cleanup } = await createCoordinatorContext({
+    appServer: {
+      resumeThread: async () => ({
+        thread: {
+          id: "thread-rich-plan",
+          turns: [{ id: "turn-rich-plan", items: [{ type: "plan", text: planMarkdown }] }]
+        }
+      })
+    },
+    safeSendRichMarkdownMessageResult: async () => ({ messageId: 92 })
+  });
+
+  try {
+    const session = store.createSession({
+      chatId: "chat-1",
+      projectName: "Project One",
+      projectPath: "/tmp/project-one",
+      planMode: true
+    });
+
+    await coordinator.beginActiveTurn(
+      "chat-1",
+      session,
+      "thread-rich-plan",
+      "turn-rich-plan",
+      "inProgress"
+    );
+    await coordinator.handleAppServerNotification("turn/completed", {
+      threadId: "thread-rich-plan",
+      turnId: "turn-rich-plan",
+      status: "completed"
+    });
+
+    assert.equal(sentHtmlMessages.length, 0);
+    assert.equal(sentRichMessages[0]?.markdown, planMarkdown);
+    assert.equal(sentRichMessages[0]?.replyMarkup?.inline_keyboard[0]?.[0]?.text, "实施这个计划");
+    assert.equal(store.listFinalAnswerViews("chat-1")[0]?.deliveryMessageId, 92);
   } finally {
     await cleanup();
   }

--- a/src/service/turn-coordinator.ts
+++ b/src/service/turn-coordinator.ts
@@ -220,6 +220,13 @@ interface TurnCoordinatorDeps {
       inline_keyboard: Array<Array<{ text: string; callback_data: string }>>;
     }
   ) => Promise<EgressMessageSendResult | null>;
+  safeSendRichMarkdownMessageResult?: (
+    chatId: string,
+    markdown: string,
+    replyMarkup?: {
+      inline_keyboard: Array<Array<{ text: string; callback_data: string }>>;
+    }
+  ) => Promise<EgressMessageSendResult | null>;
   handleGlobalRuntimeNotice: (notification: GlobalRuntimeNotice) => Promise<void>;
   handleThreadArchiveNotification: (classified: ThreadArchiveNotification) => Promise<void>;
 }
@@ -1153,6 +1160,21 @@ export class TurnCoordinator {
 
     const directDelivery = createTerminalResultDeliveryView(saved, rendered.truncated);
     const directMarkup = this.buildTerminalResultReplyMarkup(saved, directDelivery.controls);
+    if ([...text].length <= 32_768 && this.deps.safeSendRichMarkdownMessageResult) {
+      const richSent = await this.deps.safeSendRichMarkdownMessageResult(activeTurn.chatId, text);
+      if (richSent) {
+        store.setTerminalResultMessageId(saved.answerId, richSent.messageId);
+        store.setTerminalResultDeliveryState(saved.answerId, "visible");
+        return {
+          answerId: saved.answerId,
+          kind: "final_answer",
+          visible: true,
+          resultVisible: true,
+          deferredNoticeVisible: false
+        };
+      }
+    }
+
     const sent = await executeTelegramHtmlSurfaceOperation({
       intent: "terminal_result",
       chatId: activeTurn.chatId,
@@ -1214,11 +1236,29 @@ export class TurnCoordinator {
     });
 
     const directDelivery = createTerminalResultDeliveryView(saved, rendered.truncated);
+    const directMarkup = this.buildTerminalResultReplyMarkup(saved, directDelivery.controls);
+    if ([...planMarkdown].length <= 32_768 && this.deps.safeSendRichMarkdownMessageResult) {
+      const richSent = await this.deps.safeSendRichMarkdownMessageResult(activeTurn.chatId, planMarkdown, {
+        inline_keyboard: buildPlanResultActionRows(saved.answerId)
+      });
+      if (richSent) {
+        store.setTerminalResultMessageId(saved.answerId, richSent.messageId);
+        store.setTerminalResultDeliveryState(saved.answerId, "visible");
+        return {
+          answerId: saved.answerId,
+          kind: "plan_result",
+          visible: true,
+          resultVisible: true,
+          deferredNoticeVisible: false
+        };
+      }
+    }
+
     const sent = await executeTelegramHtmlSurfaceOperation({
       intent: "terminal_result",
       chatId: activeTurn.chatId,
       html: directDelivery.html,
-      replyMarkup: this.buildTerminalResultReplyMarkup(saved, directDelivery.controls),
+      replyMarkup: directMarkup,
       deferredIntent: "terminal_result_deferred_notice",
       requirements: {
         requiresCallbacks: true,

--- a/src/telegram/api.test.ts
+++ b/src/telegram/api.test.ts
@@ -138,6 +138,59 @@ test("TelegramApi sends pin and unpin requests with the expected payload", async
   }
 });
 
+test("TelegramApi sends native rich Markdown with reply markup", async () => {
+  const requests: Array<{ method: string; body: Record<string, unknown> }> = [];
+  const server = createServer(async (req, res) => {
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of req) {
+      chunks.push(chunk);
+    }
+
+    requests.push({
+      method: req.url?.split("/").pop() ?? "",
+      body: JSON.parse(Buffer.concat(chunks).toString("utf8"))
+    });
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({
+      ok: true,
+      result: { message_id: 42, date: 0, chat: { id: 1, type: "private" } }
+    }));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  try {
+    const api = new TelegramApi("test-token", `http://127.0.0.1:${address.port}`);
+    const result = await api.sendRichMessage("chat-1", {
+      markdown: "| Name | State |\n| --- | --- |\n| Worker | Ready |"
+    }, {
+      replyMarkup: {
+        inline_keyboard: [[{ text: "Continue", callback_data: "continue" }]]
+      }
+    });
+
+    assert.equal(result.message_id, 42);
+    assert.deepEqual(requests, [{
+      method: "sendRichMessage",
+      body: {
+        chat_id: "chat-1",
+        rich_message: {
+          markdown: "| Name | State |\n| --- | --- |\n| Worker | Ready |"
+        },
+        reply_markup: {
+          inline_keyboard: [[{ text: "Continue", callback_data: "continue" }]]
+        }
+      }
+    }]);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
+  }
+});
+
 test("TelegramApi records successful fetch operations", async () => {
   const operations: unknown[] = [];
   const originalFetch = globalThis.fetch;

--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -85,6 +85,15 @@ export interface TelegramInlineKeyboardMarkup {
   inline_keyboard: TelegramInlineKeyboardButton[][];
 }
 
+export interface TelegramInputRichMessage {
+  blocks?: unknown[];
+  html?: string;
+  markdown?: string;
+  media?: unknown[];
+  is_rtl?: boolean;
+  skip_entity_detection?: boolean;
+}
+
 export interface TelegramBotCommand {
   command: string;
   description: string;
@@ -168,6 +177,20 @@ export class TelegramApi {
       text,
       reply_markup: options?.replyMarkup,
       parse_mode: options?.parseMode
+    }, 20_000);
+  }
+
+  async sendRichMessage(
+    chatId: string,
+    richMessage: TelegramInputRichMessage,
+    options?: {
+      replyMarkup?: TelegramInlineKeyboardMarkup;
+    }
+  ): Promise<TelegramMessage> {
+    return await this.call<TelegramMessage>("sendRichMessage", {
+      chat_id: chatId,
+      rich_message: richMessage,
+      reply_markup: options?.replyMarkup
     }, 20_000);
   }
 

--- a/src/telegram/egress-adapter.ts
+++ b/src/telegram/egress-adapter.ts
@@ -2,12 +2,13 @@ import type {
   EgressDeleteResult,
   EgressEditResult,
   EgressMessageSendResult,
+  EgressRichMessage,
   EgressSendDocumentOptions,
   EgressSendMessageOptions,
   EgressSendPhotoOptions,
   PlatformEgressAdapter
 } from "../packs/contract.js";
-import type { TelegramApi } from "./api.js";
+import type { TelegramApi, TelegramInlineKeyboardMarkup } from "./api.js";
 
 export class TelegramEgressAdapter implements PlatformEgressAdapter {
   readonly kind = "bot_api" as const;
@@ -27,6 +28,26 @@ export class TelegramEgressAdapter implements PlatformEgressAdapter {
       opts.replyMarkup = options.replyMarkup;
     }
     const sent = await this.api.sendMessage(chatId, text, Object.keys(opts).length > 0 ? opts : undefined);
+    return { messageId: sent.message_id };
+  }
+
+  async sendRichMessage(
+    chatId: string,
+    richMessage: EgressRichMessage,
+    options?: Pick<EgressSendMessageOptions, "replyMarkup">
+  ): Promise<EgressMessageSendResult> {
+    const sent = await this.api.sendRichMessage(chatId, {
+      ...(richMessage.blocks !== undefined ? { blocks: richMessage.blocks } : {}),
+      ...(richMessage.html !== undefined ? { html: richMessage.html } : {}),
+      ...(richMessage.markdown !== undefined ? { markdown: richMessage.markdown } : {}),
+      ...(richMessage.media !== undefined ? { media: richMessage.media } : {}),
+      ...(richMessage.isRtl !== undefined ? { is_rtl: richMessage.isRtl } : {}),
+      ...(richMessage.skipEntityDetection !== undefined
+        ? { skip_entity_detection: richMessage.skipEntityDetection }
+        : {})
+    }, options?.replyMarkup !== undefined
+      ? { replyMarkup: options.replyMarkup as TelegramInlineKeyboardMarkup }
+      : undefined);
     return { messageId: sent.message_id };
   }
 


### PR DESCRIPTION
## Summary

- add typed Bot API support for `sendRichMessage`
- prefer native rich Markdown for final answers and plan results within Telegram's 32,768-character limit
- pass Markdown tables through unchanged so Telegram can render them as native rich tables
- retain the existing Telegram-safe HTML and collapsible delivery path as the fallback when rich delivery is unavailable, rejected, or over the limit
- preserve plan-result action buttons on rich messages
- document the updated delivery contract

Example content now sent through the native rich-message route:

| Worker | State |
| --- | --- |
| Delivery | Ready |
| Workflows | Ready |

Telegram Bot API reference: https://core.telegram.org/bots/api#rich-message-formatting-options

## Testing

- [x] `npm run check`
- [x] `npm run test` — 718 passed, 0 failed
- [x] `npm run build`
- [x] `git diff --check`

## Docs

- [ ] no doc update needed
- [ ] README updated
- [x] product/architecture/operations docs updated

## Notes For Reviewers

The native route is optional at the platform-egress boundary, so non-Telegram packs retain their current behavior. Any rich-message API failure returns to the existing HTML renderer instead of dropping the final answer. The implementation changes source files only; generated `dist` artifacts are produced by the normal build.
